### PR TITLE
Proper handling when trying to read a non-existing file

### DIFF
--- a/src/markitdown/__init__.py
+++ b/src/markitdown/__init__.py
@@ -2,10 +2,16 @@
 #
 # SPDX-License-Identifier: MIT
 
-from ._markitdown import MarkItDown, FileConversionException, UnsupportedFormatException
+from ._markitdown import (
+    MarkItDown,
+    FileConversionException,
+    UnsupportedFormatException,
+    FileDoesNotExistException,
+)
 
 __all__ = [
     "MarkItDown",
     "FileConversionException",
+    "FileDoesNotExistException",
     "UnsupportedFormatException",
 ]

--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -845,6 +845,10 @@ class UnsupportedFormatException(BaseException):
     pass
 
 
+class FileDoesNotExistException(BaseException):
+    pass
+
+
 class MarkItDown:
     """(In preview) An extremely simple text-based document reader, suitable for LLM use.
     This reader will convert common file-types or webpages to Markdown."""
@@ -910,6 +914,9 @@ class MarkItDown:
         # Prepare a list of extensions to try (in order of priority)
         ext = kwargs.get("file_extension")
         extensions = [ext] if ext is not None else []
+
+        if not os.path.exists(path):
+            raise FileDoesNotExistException(f"File {path} does not exist")
 
         # Get extension alternatives from the path and puremagic
         base, ext = os.path.splitext(path)

--- a/tests/test_markitdown.py
+++ b/tests/test_markitdown.py
@@ -6,7 +6,7 @@ import shutil
 import pytest
 import requests
 
-from markitdown import MarkItDown
+from markitdown import MarkItDown, FileDoesNotExistException
 
 skip_remote = (
     True if os.environ.get("GITHUB_ACTIONS") else False
@@ -143,6 +143,9 @@ def test_markitdown_local() -> None:
     for test_string in BLOG_TEST_STRINGS:
         text_content = result.text_content.replace("\\", "")
         assert test_string in text_content
+
+    with pytest.raises(FileDoesNotExistException):
+        markitdown.convert(os.path.join(TEST_FILES_DIR, "missing_file.pdf"))
 
     # Test Wikipedia processing
     result = markitdown.convert(


### PR DESCRIPTION
In relation to https://github.com/microsoft/markitdown/issues/40 , instead of UnboundLocalError, indicate that you are trying to access a non-existing file.