### PR TITLE
chore: configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Set up Dependabot to check and update GitHub Actions. Some current GitHub Actions are deprecated.
I noticed other Microsoft projects also use Dependabot, so I think it’s a good for us to use it too.

https://github.com/microsoft/PowerToys/blob/main/.github/dependabot.yml