### PR TITLE
fix: support -o param to avoid encoding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To install MarkItDown, use pip: `pip install markitdown`. Alternatively, you can
 markitdown path-to-file.pdf > document.md
 ```
 
+Or use `-o` to specify the output file:
+
+```bash
+markitdown path-to-file.pdf -o document.md
+```
+
 You can also pipe content:
 
 ```bash

--- a/src/markitdown/__main__.py
+++ b/src/markitdown/__main__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 import sys
 import argparse
-from ._markitdown import MarkItDown
+from ._markitdown import MarkItDown, DocumentConverterResult
 
 
 def main():
@@ -27,19 +27,37 @@ EXAMPLE:
     OR 
 
     markitdown < example.pdf
+    
+    OR
+    
+    markitdown example.pdf -o example.md
 """.strip(),
     )
 
     parser.add_argument("filename", nargs="?")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file name. If not provided, output is written to stdout.",
+    )
     args = parser.parse_args()
 
     if args.filename is None:
         markitdown = MarkItDown()
         result = markitdown.convert_stream(sys.stdin.buffer)
-        print(result.text_content)
+        _handle_output(args, result)
     else:
         markitdown = MarkItDown()
         result = markitdown.convert(args.filename)
+        _handle_output(args, result)
+
+
+def _handle_output(args, result: DocumentConverterResult):
+    """Handle output to stdout or file"""
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(result.text_content)
+    else:
         print(result.text_content)
 
 


### PR DESCRIPTION
Noticed that some encoding issues used `>` to output files, which may cause terminal to misinterpret characters when Python interpreter's encoding type is not equal to terminal's encoding type. The changes added a `-o` param to let Python saves the output file directly, which can avoid the problem. Related issues: #111 #78 #138 #151

![image](https://github.com/user-attachments/assets/f3bb8f04-edd7-464c-88bc-be4e3876d4e3)
![image](https://github.com/user-attachments/assets/c94a21d3-ae83-444f-8f34-8615eecc8201)

And I tested the pdf file mentioned in #78, it works.
![image](https://github.com/user-attachments/assets/62c2e035-3ca7-458b-9aac-3f1d74808be1)
