### PR TITLE
feat: add project description in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "markitdown"
 dynamic = ["version"]
-description = ''
+description = 'Utility tool for converting various files to Markdown'
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
Add a project description to the pyproject.toml file, as it is currently missing.

![{9AC31402-65A1-4985-9606-7EE0798BB703}](https://github.com/user-attachments/assets/ad4cccbf-62fa-424c-a1e4-f84c197f7b41)
