### PR TITLE
Update CLI helpdoc formatting to allow indentation in code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/markitdown/__main__.py
+++ b/src/markitdown/__main__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 import sys
 import argparse
+from textwrap import dedent
 from ._markitdown import MarkItDown
 
 
@@ -10,24 +11,24 @@ def main():
     parser = argparse.ArgumentParser(
         description="Convert various file formats to markdown.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage="""
-SYNTAX: 
-    
-    markitdown <OPTIONAL: FILENAME>
-    If FILENAME is empty, markitdown reads from stdin.
-
-EXAMPLE:
-    
-    markitdown example.pdf
-    
-    OR
-
-    cat example.pdf | markitdown
-
-    OR 
-
-    markitdown < example.pdf
-""".strip(),
+        usage=dedent("""
+            SYNTAX: 
+                
+                markitdown <OPTIONAL: FILENAME>
+                If FILENAME is empty, markitdown reads from stdin.
+            
+            EXAMPLE:
+                
+                markitdown example.pdf
+                
+                OR
+            
+                cat example.pdf | markitdown
+            
+                OR 
+            
+                markitdown < example.pdf
+            """).strip(),
     )
 
     parser.add_argument("filename", nargs="?")

--- a/src/markitdown/__main__.py
+++ b/src/markitdown/__main__.py
@@ -11,7 +11,8 @@ def main():
     parser = argparse.ArgumentParser(
         description="Convert various file formats to markdown.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage=dedent("""
+        usage=dedent(
+            """
             SYNTAX: 
                 
                 markitdown <OPTIONAL: FILENAME>
@@ -28,7 +29,8 @@ def main():
                 OR 
             
                 markitdown < example.pdf
-            """).strip(),
+            """
+        ).strip(),
     )
 
     parser.add_argument("filename", nargs="?")


### PR DESCRIPTION
Use `textwrap.dedent()` to allow indented cli-helpdoc in `__main__.py` file. The indentation increases readability, while `textwrap.dedent` helps maintain the same functionality without breaking code.

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/9e16e2c9-e83f-4347-adc6-184022760e8c" />
