### PR TITLE
feat: enable Git support in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
 		// Sets the run context to one level up instead of the .devcontainer folder.
 		"context": "..",
 		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-		"dockerfile": "../Dockerfile"
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"INSTALL_GIT": "true"
+		}
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,15 @@ FROM python:3.13-slim-bullseye
 
 USER root
 
+ARG INSTALL_GIT=false
+RUN if [ "$INSTALL_GIT" = "true" ]; then \
+    apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 # Runtime dependency
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
- && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install markitdown
 


### PR DESCRIPTION
Added a process to install Git only when the devcontainer starts.
This should be helpful when the editor has source control features.
Avoided changes to the image and the addition of a separate Dockerfile.