### PR TITLE
update: change pdf text parser to pymupdf4llm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "pandas",
   "openpyxl",
   "pdfminer.six",
+  "pymupdf4llm",
   "puremagic",
   "pydub",
   "youtube-transcript-api",

--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -23,6 +23,7 @@ import markdownify
 import pandas as pd
 import pdfminer
 import pdfminer.high_level
+import pymupdf4llm
 import pptx
 
 # File-format detection
@@ -684,10 +685,12 @@ class PdfConverter(DocumentConverter):
         if extension.lower() != ".pdf":
             return None
 
-        return DocumentConverterResult(
-            title=None,
-            text_content=pdfminer.high_level.extract_text(local_path),
-        )
+        # return DocumentConverterResult(
+        #     title=None,
+        #     text_content=pdfminer.high_level.extract_text(local_path),
+        # )
+        text_content = pymupdf4llm.to_markdown(local_path, show_progress=False)
+        return DocumentConverterResult(title=None, text_content=text_content)
 
 
 class DocxConverter(HtmlConverter):


### PR DESCRIPTION
Using `pymupdf4llm` instead of `pdfminer` to parse pdf contents into markdown formats, as suggested by #131.

Pros and Cons:
- `pdfminer` extract texts only, generated files have no heading, titles, etc. `pymupdf4llm`, however, could perform a nice markdown featrues including different levels of heading, code blocks and images (could be saved to specific path, but not included in this commit)
- However,  `pymupdf4llm` may easily create lines of digits which belongs to plots, and create non-existing tables. This is a common problem to most PDF parsers, except those using ocr models (such as [markers](https://github.com/VikParuchuri/marker), [MinerU](https://github.com/opendatalab/MinerU)).
