### PR TITLE
chore: enable test multi-python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,22 +4,19 @@ on: [pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.10
-            3.11
-            3.12
-      - name: Set up pip cache
-        if: runner.os == 'Linux'
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: ${{ runner.os }}-pip-
+          python-version: ${{ matrix.python-version }}
+
       - name: Install Hatch
         run: pipx install hatch
+
       - name: Run tests
         run: hatch test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,6 @@ exclude_lines = [
 
 [tool.hatch.build.targets.sdist]
 only-include = ["src/markitdown"]
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.13", "3.12", "3.11", "3.10"]


### PR DESCRIPTION
### Current Behavior:
The test suite currently runs only on a single Python version.

### Proposed Changes:
- Update the GitHub Actions workflow to test multiple Python versions using matrix strategy.
- Add Python 3.13 to the workflow matrix.
- Add Python test matrix to pypyproject
- Remove the actions/cache@v3 step as setup-python already uses toolkit/cache internally. [[1]](https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies)

<details>

<summary>Evidence</summary>


[Before](https://github.com/microsoft/markitdown/actions/runs/12406010086/job/34642150347)

```sh
Run hatch test
Creating environment: hatch-test.py3.10
Installing project in development mode
Checking dependencies
Syncing dependencies
============================= test session starts ==============================
platform linux -- Python 3.10.[12](https://github.com/microsoft/markitdown/actions/runs/12406010086/job/34642150347#step:6:13), pytest-8.3.4, pluggy-1.5.0
rootdir: /home/runner/work/markitdown/markitdown
configfile: pyproject.toml
plugins: rerunfailures-[14](https://github.com/microsoft/markitdown/actions/runs/12406010086/job/34642150347#step:6:15).0, xdist-3.6.1, mock-3.14.0, anyio-4.7.0
collected 5 items

tests/test_markitdown.py s.s.s                                           [100%]

========================= 2 passed, 3 skipped in 4.58s =========================
```

[After](https://github.com/l-lumin/markitdown/actions/runs/12410944415)
![{83784D46-3A03-4BF3-AA3D-EFB1C4EC021B}](https://github.com/user-attachments/assets/f30be7c7-5b08-4281-8378-d8c0717ff0da)

```sh
Run hatch test
Creating environment: hatch-test.py3.10
Installing project in development mode
Checking dependencies
Syncing dependencies
============================= test session starts ==============================
platform linux -- Python 3.10.[12](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647604825#step:5:13), pytest-8.3.4, pluggy-1.5.0
rootdir: /home/runner/work/markitdown/markitdown
configfile: pyproject.toml
plugins: rerunfailures-[14](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647604825#step:5:15).0, xdist-3.6.1, mock-3.14.0, anyio-4.7.0
collected 5 items

tests/test_markitdown.py s.s.s                                           [100%]

========================= 2 passed, 3 skipped in 4.50s =========================
```
```sh
Run hatch test
Creating environment: hatch-test.py3.10
Installing project in development mode
Checking dependencies
Syncing dependencies
============================= test session starts ==============================
platform linux -- Python 3.10.[12](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647605206#step:5:13), pytest-8.3.4, pluggy-1.5.0
rootdir: /home/runner/work/markitdown/markitdown
configfile: pyproject.toml
plugins: rerunfailures-[14](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647605206#step:5:15).0, xdist-3.6.1, mock-3.14.0, anyio-4.7.0
collected 5 items

tests/test_markitdown.py s.s.s                                           [100%]

========================= 2 passed, 3 skipped in 4.59s =========================
```
```sh
Run hatch test
Creating environment: hatch-test.py3.10
Installing project in development mode
Checking dependencies
Syncing dependencies
============================= test session starts ==============================
platform linux -- Python 3.10.[12](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647605533#step:5:13), pytest-8.3.4, pluggy-1.5.0
rootdir: /home/runner/work/markitdown/markitdown
configfile: pyproject.toml
plugins: rerunfailures-[14](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647605533#step:5:15).0, xdist-3.6.1, mock-3.14.0, anyio-4.7.0
collected 5 items

tests/test_markitdown.py s.s.s                                           [100%]

========================= 2 passed, 3 skipped in 4.62s =========================
```
```sh
Run hatch test
Creating environment: hatch-test.py3.10
Installing project in development mode
Checking dependencies
Syncing dependencies
============================= test session starts ==============================
platform linux -- Python 3.10.[12](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647605883#step:5:13), pytest-8.3.4, pluggy-1.5.0
rootdir: /home/runner/work/markitdown/markitdown
configfile: pyproject.toml
plugins: rerunfailures-[14](https://github.com/l-lumin/markitdown/actions/runs/12410944415/job/34647605883#step:5:15).0, xdist-3.6.1, mock-3.14.0, anyio-4.7.0
collected 5 items

tests/test_markitdown.py s.s.s                                           [100%]

========================= 2 passed, 3 skipped in 4.50s =========================
```
</details>
