### PR TITLE
feat: add version option to markitdown CLI

### DIFF
--- a/src/markitdown/__main__.py
+++ b/src/markitdown/__main__.py
@@ -1,36 +1,47 @@
 # SPDX-FileCopyrightText: 2024-present Adam Fourney <adamfo@microsoft.com>
 #
 # SPDX-License-Identifier: MIT
-import sys
 import argparse
+import sys
 from textwrap import dedent
+
+from .__about__ import __version__
 from ._markitdown import MarkItDown
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Convert various file formats to markdown.",
+        prog="markitdown",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         usage=dedent(
             """
-            SYNTAX: 
-                
+            SYNTAX:
+
                 markitdown <OPTIONAL: FILENAME>
                 If FILENAME is empty, markitdown reads from stdin.
-            
+
             EXAMPLE:
-                
+
                 markitdown example.pdf
-                
+
                 OR
-            
+
                 cat example.pdf | markitdown
-            
-                OR 
-            
+
+                OR
+
                 markitdown < example.pdf
             """
         ).strip(),
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="show the version number and exit",
     )
 
     parser.add_argument("filename", nargs="?")


### PR DESCRIPTION
Add a `--version` option to the markitdown command-line interface  that displays the current version number.

```sh
(markitdown) root@2df60f111fa4:/workspaces/markitdown# python -m markitdown -v
markitdown 0.0.1a3
```