### PR TITLE
CLI: add LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Or from the CLI:
 
 ```bash
 pip install markitdown
-markitdown --llm-client OpenAI --llm-model gpt-4o example.jpg
+markitdown --llm-model gpt-4o example.jpg
 ```
 
 ### Docker

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ result = md.convert("example.jpg")
 print(result.text_content)
 ```
 
+Or from the CLI:
+
+```bash
+pip install markitdown
+markitdown --llm-client OpenAI --llm-model gpt-4o example.jpg
+```
+
 ### Docker
 
 ```sh

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -88,11 +88,11 @@ def main(args=None):
             )
         elif args.filename is None:
             raise ValueError("Filename is required when using Document Intelligence.")
-        markitdown = MarkItDown(
-            enable_plugins=args.use_plugins, docintel_endpoint=args.endpoint
-        )
-    else:
-        markitdown = MarkItDown(enable_plugins=args.use_plugins)
+
+    markitdown = MarkItDown(
+        enable_plugins=args.use_plugins,
+        docintel_endpoint=args.endpoint if args.use_docintel else None,
+    )
 
     if args.filename:
         result = markitdown.convert(args.filename)

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -56,9 +56,10 @@ parser.add_argument(
     action="store_true",
     help="list installed 3rd-party plugins (loaded with `--use-plugin`)",
 )
-parser.add_argument("--llm-client", choices={"OpenAI"}, help="default None")
-parser.add_argument("--llm-client-url", help="base URL for --llm-client")
-parser.add_argument("--llm-model", help="required for --llm-client")
+parser.add_argument("--llm-model", metavar="MODEL", help="e.g. gpt-4o")
+parser.add_argument(
+    "--llm-client-url", metavar="URL", help="base URL for OpenAI LLM client"
+)
 parser.add_argument(
     "filename", metavar="FILENAME", nargs="?", help="if unspecified, defaults to stdin"
 )
@@ -92,8 +93,9 @@ def main(args=None):
         elif args.filename is None:
             raise ValueError("Filename is required when using Document Intelligence.")
 
-    if args.llm_client == "OpenAI":
+    if args.llm_model:
         from openai import OpenAI
+
         llm_client = OpenAI(base_url=args.llm_client_url)
     else:
         llm_client = None

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -61,6 +61,14 @@ parser.add_argument(
     "--llm-client-url", metavar="URL", help="base URL for OpenAI LLM client"
 )
 parser.add_argument(
+    "-H",
+    "--llm-client-header",
+    metavar="HEADER",
+    nargs="*",
+    default=[],
+    help="may be specified multiple times",
+)
+parser.add_argument(
     "filename", metavar="FILENAME", nargs="?", help="if unspecified, defaults to stdin"
 )
 
@@ -96,7 +104,11 @@ def main(args=None):
     if args.llm_model:
         from openai import OpenAI
 
-        llm_client = OpenAI(base_url=args.llm_client_url)
+        headers = {}
+        for header in args.llm_client_header:
+            key, value = header.split(":", 1)
+            headers[key] = value.lstrip()
+        llm_client = OpenAI(base_url=args.llm_client_url, default_headers=headers)
     else:
         llm_client = None
 

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -37,28 +37,26 @@ parser.add_argument(
     "-d",
     "--use-docintel",
     action="store_true",
-    help="Use Document Intelligence to extract text instead of offline conversion. Requires a valid Document Intelligence Endpoint.",
+    help="use online Document Intelligence to extract text (requires a valid `--endpoint`)",
 )
 parser.add_argument(
     "-e",
     "--endpoint",
     type=str,
-    help="Document Intelligence Endpoint. Required if using Document Intelligence.",
+    help="required for `--use-docintel`",
 )
 parser.add_argument(
     "-p",
     "--use-plugins",
     action="store_true",
-    help="Use 3rd-party plugins to convert files. Use --list-plugins to see installed plugins.",
+    help="use 3rd-party plugins to convert files (see `--list-plugins`)",
 )
 parser.add_argument(
     "--list-plugins",
     action="store_true",
-    help="List installed 3rd-party plugins. Plugins are loaded when using the -p or --use-plugin option.",
+    help="list installed 3rd-party plugins (loaded with `--use-plugin`)",
 )
-parser.add_argument(
-    "filename", nargs="?", help="if unspecified, defaults to stdin"
-)
+parser.add_argument("filename", nargs="?", help="if unspecified, defaults to stdin")
 
 
 def main(args=None):

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -30,7 +30,7 @@ parser.add_argument(
 parser.add_argument(
     "-o",
     "--output",
-    metavar="outfilename",
+    metavar="OUTFILENAME",
     help="if unspecified, defaults to stdout",
 )
 parser.add_argument(
@@ -56,7 +56,9 @@ parser.add_argument(
     action="store_true",
     help="list installed 3rd-party plugins (loaded with `--use-plugin`)",
 )
-parser.add_argument("filename", nargs="?", help="if unspecified, defaults to stdin")
+parser.add_argument(
+    "filename", metavar="FILENAME", nargs="?", help="if unspecified, defaults to stdin"
+)
 
 
 def main(args=None):

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -14,36 +14,14 @@ def main():
         description="Convert various file formats to markdown.",
         prog="markitdown",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage=dedent(
-            """
-            SYNTAX:
-
-                markitdown <OPTIONAL: FILENAME>
-                If FILENAME is empty, markitdown reads from stdin.
-
-            EXAMPLE:
-
-                markitdown example.pdf
-
-                OR
-
-                cat example.pdf | markitdown
-
-                OR
-
-                markitdown < example.pdf
-                
-                OR to save to a file use
-    
-                markitdown example.pdf -o example.md
-                
-                OR
-                
-                markitdown example.pdf > example.md
-            """
-        ).strip(),
+        epilog=dedent(
+            """\
+            examples:
+              markitdown example.pdf
+              markitdown -o example.md example.pdf
+              cat example.pdf | markitdown > example.md"""
+        ),
     )
-
     parser.add_argument(
         "-v",
         "--version",
@@ -51,41 +29,39 @@ def main():
         version=f"%(prog)s {__version__}",
         help="show the version number and exit",
     )
-
     parser.add_argument(
         "-o",
         "--output",
-        help="Output file name. If not provided, output is written to stdout.",
+        dest="filename",
+        help="if unspecified, defaults to stdout",
     )
-
     parser.add_argument(
         "-d",
         "--use-docintel",
         action="store_true",
         help="Use Document Intelligence to extract text instead of offline conversion. Requires a valid Document Intelligence Endpoint.",
     )
-
     parser.add_argument(
         "-e",
         "--endpoint",
         type=str,
         help="Document Intelligence Endpoint. Required if using Document Intelligence.",
     )
-
     parser.add_argument(
         "-p",
         "--use-plugins",
         action="store_true",
         help="Use 3rd-party plugins to convert files. Use --list-plugins to see installed plugins.",
     )
-
     parser.add_argument(
         "--list-plugins",
         action="store_true",
         help="List installed 3rd-party plugins. Plugins are loaded when using the -p or --use-plugin option.",
     )
+    parser.add_argument(
+        "filename", nargs="?", help="if unspecified, defaults to stdin"
+    )
 
-    parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
     if args.list_plugins:
@@ -123,14 +99,9 @@ def main():
     else:
         result = markitdown.convert(args.filename)
 
-    _handle_output(args, result)
-
-
-def _handle_output(args, result: DocumentConverterResult):
-    """Handle output to stdout or file"""
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:
-            f.write(result.text_content)
+            print(result.text_content, file=f)
     else:
         print(result.text_content)
 

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -56,6 +56,9 @@ parser.add_argument(
     action="store_true",
     help="list installed 3rd-party plugins (loaded with `--use-plugin`)",
 )
+parser.add_argument("--llm-client", choices={"OpenAI"}, help="default None")
+parser.add_argument("--llm-client-url", help="base URL for --llm-client")
+parser.add_argument("--llm-model", help="required for --llm-client")
 parser.add_argument(
     "filename", metavar="FILENAME", nargs="?", help="if unspecified, defaults to stdin"
 )
@@ -89,9 +92,17 @@ def main(args=None):
         elif args.filename is None:
             raise ValueError("Filename is required when using Document Intelligence.")
 
+    if args.llm_client == "OpenAI":
+        from openai import OpenAI
+        llm_client = OpenAI(base_url=args.llm_client_url)
+    else:
+        llm_client = None
+
     markitdown = MarkItDown(
         enable_plugins=args.use_plugins,
         docintel_endpoint=args.endpoint if args.use_docintel else None,
+        llm_client=llm_client,
+        llm_model=args.llm_model,
     )
 
     if args.filename:

--- a/packages/markitdown/tests/test_cli.py
+++ b/packages/markitdown/tests/test_cli.py
@@ -33,7 +33,7 @@ def test_invalid_flag(shared_tmp_dir) -> None:
     assert (
         "unrecognized arguments" in result.stderr
     ), f"Expected 'unrecognized arguments' to appear in STDERR"
-    assert "SYNTAX" in result.stderr, f"Expected 'SYNTAX' to appear in STDERR"
+    assert "usage" in result.stderr, f"Expected 'usage' to appear in STDERR"
 
 
 def test_output_to_stdout(shared_tmp_dir) -> None:


### PR DESCRIPTION
- [ ] please merge #84 first
- [x] add `--llm-model`
- [x] add `--llm-client-url`
- [x] add `--llm-client-header`

Tested successfully using <https://ollama.com/library/llava-phi3>:

```bash
OPENAI_API_KEY=ollama \
markitdown tests/test_files/test.jpg --llm-client-url=http://localhost:11434/v1 --llm-model=llava-phi3
```

Note that:

- `--llm-client-header` is needed for e.g. authori[sz]ation headers in-production
- I didn't add `--llm-client=OpenAI` because there are no other options yet
- I hope MS will merge this despite it being a free alternative to its paid LLMs ;)
