### PR TITLE
feat(ci): set concurrency for test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: tests
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This update ensures that workflows always run on the latest commit

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

note: did not add concurrency to the `pre-commit` workflow as it currently only uses Black. Since Hatch has Ruff built-in, we can merge the `pre-commit` workflow into the `test` workflow later for better efficiency

> Static analysis performed by the [fmt](https://hatch.pypa.io/latest/cli/reference/#hatch-fmt) command is ([by default](https://hatch.pypa.io/latest/config/internal/static-analysis/#customize-behavior)) backed entirely by [Ruff](https://github.com/astral-sh/ruff).
https://hatch.pypa.io/latest/config/internal/static-analysis/