### PR TITLE
fix(transcription): TRANSCRIPTION_CAPABLE should be iniztialized

### DIFF
--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -33,6 +33,7 @@ from bs4 import BeautifulSoup
 from charset_normalizer import from_path
 
 # Optional Transcription support
+IS_AUDIO_TRANSCRIPTION_CAPABLE = False
 try:
     # Using warnings' catch_warnings to catch
     # pydub's warning of ffmpeg or avconv missing


### PR DESCRIPTION
Running `Markitdonw` on audio files without having `pydub` and `speech_recognition` installed would result in a NameError: name 'IS_AUDIO_TRANSCRIPTION_CAPABLE' is not defined.

This PR resolves that issue.

#74 