### PR TITLE
JsonConverter for Converting JSON Files into Structured Markdown Files

### DIFF
--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -1204,6 +1204,42 @@ class ZipConverter(DocumentConverter):
                 text_content=f"[ERROR] Failed to process zip file {local_path}: {str(e)}",
             )
 
+class JsonConverter(DocumentConverter):
+    """
+    Converts Jsons to Markdown. The output preserves the structure of the JSON file as closely as possible, while using Markdown syntax for readability.
+    """
+
+    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+        # Bail if not a Json
+        extension = kwargs.get("file_extension", "")
+        if extension.lower() != ".json":
+            return None
+
+        list_heading = kwargs.get("list_heading", "Elem")
+        with open(local_path, "r") as f:
+            json_data = json.load(f)
+
+        md_content = ""
+
+        if isinstance(json_data, dict):
+            md_content += json.dumps(json_data, indent=4, ensure_ascii=False) + "\n"
+        elif isinstance(json_data, list):
+            for idx, item in enumerate(json_data, start=1):
+                md_content += f"# {list_heading} {idx}\n"
+                if isinstance(item, (dict, list)):
+                    md_content += json.dumps(item, indent=4, ensure_ascii=False) + "\n\n"
+                else:
+                    md_content += f"{item}\n\n"
+        else:
+            md_content += f"{json_data}\n"
+
+        # removing tailing \n
+        md_content = md_content.strip()
+
+        return DocumentConverterResult(
+            title=None,
+            text_content=md_content,
+        )
 
 class FileConversionException(BaseException):
     pass
@@ -1276,6 +1312,7 @@ class MarkItDown:
         self.register_page_converter(WikipediaConverter())
         self.register_page_converter(YouTubeConverter())
         self.register_page_converter(BingSerpConverter())
+        self.register_page_converter(JsonConverter())
         self.register_page_converter(DocxConverter())
         self.register_page_converter(XlsxConverter())
         self.register_page_converter(PptxConverter())


### PR DESCRIPTION
This PR implements a JsonConverter class that converts JSON files into Markdown files while preserving the dictionary structure of the data to the greatest extent possible during the conversion process.

- For JSON files with dict like:

![image](https://github.com/user-attachments/assets/6d567b5b-1e0e-44fc-82d7-f9b8a488519a)

The conversion result will be:
![image](https://github.com/user-attachments/assets/119f39f7-f891-4d11-827c-6313845dace9)

- For JSON files containing a list of dicts, such as the SFT fine-tuning data for LLMs:
![image](https://github.com/user-attachments/assets/fa48cd19-28e4-4893-a7f8-e3f69e75ba40)

The conversion result will display each element of the list in sequence. Additionally, users can customize the value of the list heading (default is Elem):
![image](https://github.com/user-attachments/assets/39772dc0-ebeb-40ef-bcd1-fe872d34956e)

This conversion approach preserves the dictionary structure to the greatest extent possible, allowing converted .md files to be more intuitively readable and visually clear for users. Furthermore, when performing retrieval-augmented generation (RAG), LLMs are highly familiar with dict structure and can process them effectively.