### PR TITLE
Recognize json as plain text (if no other handlers are present).

### DIFF
--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -173,7 +173,10 @@ class PlainTextConverter(DocumentConverter):
         # Only accept text files
         if content_type is None:
             return None
-        elif "text/" not in content_type.lower():
+        elif all(
+            not content_type.lower().startswith(type_prefix)
+            for type_prefix in ["text/", "application/json"]
+        ):
             return None
 
         text_content = str(from_path(local_path).best())

--- a/tests/test_files/test.json
+++ b/tests/test_files/test.json
@@ -1,0 +1,10 @@
+{
+    "key1": "string_value",
+    "key2": 1234,
+    "key3": [
+        "list_value1",
+        "list_value2"
+    ],
+    "5b64c88c-b3c3-4510-bcb8-da0b200602d8": "uuid_key",
+    "uuid_value": "9700dc99-6685-40b4-9a3a-5e406dcb37f3"
+}

--- a/tests/test_markitdown.py
+++ b/tests/test_markitdown.py
@@ -145,6 +145,11 @@ LLM_TEST_STRINGS = [
     "5bda1dd6",
 ]
 
+JSON_TEST_STRINGS = [
+    "5b64c88c-b3c3-4510-bcb8-da0b200602d8",
+    "9700dc99-6685-40b4-9a3a-5e406dcb37f3",
+]
+
 
 # --- Helper Functions ---
 def validate_strings(result, expected_strings, exclude_strings=None):
@@ -256,6 +261,10 @@ def test_markitdown_local() -> None:
     # Test MSG (Outlook email) processing
     result = markitdown.convert(os.path.join(TEST_FILES_DIR, "test_outlook_msg.msg"))
     validate_strings(result, MSG_TEST_STRINGS)
+
+    # Test JSON processing
+    result = markitdown.convert(os.path.join(TEST_FILES_DIR, "test.json"))
+    validate_strings(result, JSON_TEST_STRINGS)
 
     # Test input with leading blank characters
     input_data = b"   \n\n\n<html><body><h1>Test</h1></body></html>"


### PR DESCRIPTION
This PR fixes #34 by adding the `application/json` mimetype to the PlainTextConverter.

Arguably many other types should be added... and perhaps we should accept anything that looks like UTF-8 or similar.

**Note**: We may want to render json more directly in the future (#251, #219, etc), but for now, this is a good stopgap that corrects a behavior that was intended, but broken. We can add more sophisticated converters by simply placing them in higher priority when registering them. PlainTextConverter should always be the last resort and a good fallback when no other converters are available.

