### PR TITLE
feat(pptx): support image description with LLM for pptx files

### DIFF
--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -784,6 +784,35 @@ class PptxConverter(HtmlConverter):
     Converts PPTX files to Markdown. Supports heading, tables and images with alt text.
     """
 
+    def _get_llm_description(
+        self, llm_client, llm_model, image_blob, content_type, prompt=None
+    ):
+        if prompt is None or prompt.strip() == "":
+            prompt = "Write a detailed alt text for this image with less than 50 words."
+
+        image_base64 = base64.b64encode(image_blob).decode("utf-8")
+        data_uri = f"data:{content_type};base64,{image_base64}"
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": data_uri,
+                        },
+                    },
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ]
+
+        response = llm_client.chat.completions.create(
+            model=llm_model, messages=messages
+        )
+        return response.choices[0].message.content
+
     def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a PPTX
         extension = kwargs.get("file_extension", "")
@@ -804,17 +833,38 @@ class PptxConverter(HtmlConverter):
                 # Pictures
                 if self._is_picture(shape):
                     # https://github.com/scanny/python-pptx/pull/512#issuecomment-1713100069
-                    alt_text = ""
-                    try:
-                        alt_text = shape._element._nvXxPr.cNvPr.attrib.get("descr", "")
-                    except Exception:
-                        pass
+
+                    llm_description = None
+                    alt_text = None
+
+                    llm_client = kwargs.get("llm_client")
+                    llm_model = kwargs.get("llm_model")
+                    if llm_client is not None and llm_model is not None:
+                        try:
+                            llm_description = self._get_llm_description(
+                                llm_client,
+                                llm_model,
+                                shape.image.blob,
+                                shape.image.content_type,
+                            )
+                        except Exception:
+                            # Unable to describe with LLM
+                            pass
+
+                    if not llm_description:
+                        try:
+                            alt_text = shape._element._nvXxPr.cNvPr.attrib.get(
+                                "descr", ""
+                            )
+                        except Exception:
+                            # Unable to get alt text
+                            pass
 
                     # A placeholder name
                     filename = re.sub(r"\W", "", shape.name) + ".jpg"
                     md_content += (
                         "\n!["
-                        + (alt_text if alt_text else shape.name)
+                        + (llm_description or alt_text or shape.name)
                         + "]("
                         + filename
                         + ")\n"


### PR DESCRIPTION
This PR adds support for creating image descriptions with LLMs for images in pptx files.

The functionality is optional, and will be enabled with an `llm_model` and `llm_client` parameter configured. If those are not provided, markitdown will default to using the image `alt_text` for the description


## Example

### Input slide (with image on right-hand side)

<img width="1150" alt="Screenshot 2025-01-27 at 14 17 46" src="https://github.com/user-attachments/assets/b6c1e3ed-c53e-4c0f-8b90-1b0aef55116e" />

#### Output
```markdown
# 2cdda5c8-e50e-4db4-b5f0-9722a649f455
AutoGen is an open-source framework that allows developers to build LLM applications via multiple agents that can converse with each other to accomplish tasks. AutoGen agents are customizable, conversable, and can operate in various modes that employ combinations of LLMs, human inputs, and tools. Using AutoGen, developers can also flexibly define agent interaction behaviors. Both natural language and 04191ea8-5c73-4215-a1d3-1cfb43aaaf12 can be used to program flexible conversation patterns for different applications. AutoGen serves as a generic framework for building diverse applications of various complexities and LLM capacities. Empirical studies demonstrate the effectiveness of the framework in many example applications, with domains ranging from mathematics, coding, question answering, operations research, online decision-making, entertainment, etc.

![The image features a research paper titled "AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation." It includes diagrams illustrating agent customization, multi-agent conversations, and example agent chats, highlighting the framework's capabilities in developing LLM applications through flexible interaction patterns.](Picture4.jpg)
```

### Code example
```python
from markitdown import MarkItDown
from openai import OpenAI

client = OpenAI()

md = MarkItDown(llm_client=client, llm_model="gpt-4o-mini")
result = md.convert("tests/test_files/test.pptx")
print(result.text_content)
```

#### Output

Note the LLM-generated description for the image on Slide 2.
The original slides can be found [here](https://github.com/microsoft/markitdown/blob/bfde8574204d1111309fbbff0b4347a3bf518676/tests/test_files/test.pptx).

```markdown
<!-- Slide number: 1 -->
# AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation
Qingyun Wu , Gagan Bansal , Jieyu Zhang, Yiran Wu, Beibin Li, Erkang Zhu, Li Jiang, Xiaoyun Zhang, Shaokun Zhang, Jiale Liu, Ahmed Awadallah, Ryen W. White, Doug Burger, Chi Wang

<!-- Slide number: 2 -->
# 2cdda5c8-e50e-4db4-b5f0-9722a649f455
AutoGen is an open-source framework that allows developers to build LLM applications via multiple agents that can converse with each other to accomplish tasks. AutoGen agents are customizable, conversable, and can operate in various modes that employ combinations of LLMs, human inputs, and tools. Using AutoGen, developers can also flexibly define agent interaction behaviors. Both natural language and 04191ea8-5c73-4215-a1d3-1cfb43aaaf12 can be used to program flexible conversation patterns for different applications. AutoGen serves as a generic framework for building diverse applications of various complexities and LLM capacities. Empirical studies demonstrate the effectiveness of the framework in many example applications, with domains ranging from mathematics, coding, question answering, operations research, online decision-making, entertainment, etc.

![The image features a research paper titled "AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation." It includes diagrams illustrating agent customization, multi-agent conversations, and example agent chats, highlighting the framework's capabilities in developing LLM applications through flexible interaction patterns.](Picture4.jpg)

<!-- Slide number: 3 -->
# A table to test parsing:

| ColA | ColB | ColC | ColD | ColE | ColF |
| --- | --- | --- | --- | --- | --- |
| 1 | 2 | 3 | 4 | 5 | 6 |
| 7 | 8 | 9 | 1b92870d-e3b5-4e65-8153-919f4ff45592 | 11 | 12 |
| 13 | 14 | 15 | 16 | 17 | 18 |

<!-- Slide number: 4 -->
# A chart to test parsing:

### Chart: a3f6004b-6f4f-4ea8-bee3-3741f4dc385f

| Category | Series 1 |
|---|---|
| 2000 | 2000.0 |
| 2001 | 2001.0 |
| 2002 | 2002.0 |
| 2003 | 2003.0 |
```