### PR TITLE
Skip generating md links in 'pre' blocks

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -33,6 +33,10 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
         if not text:
             return ""
+
+        if el.find_parent("pre") is not None:
+            return text
+
         href = el.get("href")
         title = el.get("title")
 


### PR DESCRIPTION
Markdown does not support links in pre-formatted code blocks. 

With the current release, `markitdown` mangles code chunks by generating links.

For example: `markitdown https://r4ds.hadley.nz/base-r` [](https://r4ds.hadley.nz/base-r) will generate code chunks that look like this:


````r
```
# Left
[hist](https://rdrr.io/r/graphics/hist.html)(diamonds$carat)

# Right
[plot](https://rdrr.io/r/graphics/plot.default.html)(diamonds$carat, diamonds$price)
```
````

With this patch, the same code chunk is now correctly generated
````r
```
# Left
hist(diamonds$carat)

# Right
plot(diamonds$carat, diamonds$price)
```
````