### PR TITLE
add necessary imports

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -4,6 +4,7 @@ from ._media_converter import MediaConverter
 import base64
 import mimetypes
 
+
 class ImageConverter(MediaConverter):
     """
     Converts images to markdown via extraction of metadata (if `exiftool` is installed), OCR (if `easyocr` is installed), and description via a multimodal LLM (if an llm_client is configured).

--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -1,7 +1,8 @@
 from typing import Union
 from ._base import DocumentConverter, DocumentConverterResult
 from ._media_converter import MediaConverter
-
+import base64
+import mimetypes
 
 class ImageConverter(MediaConverter):
     """


### PR DESCRIPTION
in _get_llm_description function, base64 and mimetypes used, but not imported.

```
client = OpenAI()
md = MarkItDown(llm_client=client, llm_model="gpt-4o")
result = md.convert("example.jpg")
>>> NameError: name 'mimetypes' is not defined
```

in packages/markitdown/src/markitdown/converters/_image_converter.py line #65;

```
    def _get_llm_description(self, local_path, extension, client, model, prompt=None):                                          if prompt is None or prompt.strip() == "":
            prompt = "Write a detailed caption for this image."

        data_uri = ""
        with open(local_path, "rb") as image_file:
>>>            content_type, encoding = mimetypes.guess_type("_dummy" + extension)
            if content_type is None:
                content_type = "image/jpeg"
>>>            image_base64 = base64.b64encode(image_file.read()).decode("utf-8")
            data_uri = f"data:{content_type};base64,{image_base64}"
```