### PR TITLE
Fix UnboundLocalError in MarkItDown._convert

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -312,6 +312,7 @@ class MarkItDown:
     def _convert(
         self, local_path: str, extensions: List[Union[str, None]], **kwargs
     ) -> DocumentConverterResult:
+        res: Union[None, DocumentConverterResult] = None
         error_trace = ""
 
         # Create a copy of the page_converters list, sorted by priority.


### PR DESCRIPTION
Fixes https://github.com/microsoft/markitdown/issues/40, https://github.com/microsoft/markitdown/issues/81.
If the first converter raises an exception, then the `res` variable is not initialized and we get an `UnboundLocalError` when checking `if res is not None`.