### PR TITLE
File object support for Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,15 @@ MarkItDown also supports converting file objects directly:
 from markitdown import MarkItDown
 
 md = MarkItDown()
-path = "test.docx"
-with open(path, 'rb') as file:
+
+# Binary Mode
+with open("test.docx", 'rb') as file:
     result = md.convert(file, file_extension=".docx")
+    print(result.text_content)
+
+# Non-Binary Mode
+with open("sample.ipynb", 'rt', encoding="utf-8") as file:
+    result = md.convert(file, file_extension=".ipynb")
     print(result.text_content)
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ result = md.convert("test.pdf")
 print(result.text_content)
 ```
 
+MarkItDown also supports converting file objects directly:
+
+```python
+from markitdown import MarkItDown
+
+md = MarkItDown()
+path = "test.docx"
+with open(path, 'rb') as file:
+    result = md.convert(file, file_extension=".docx")
+    print(result.text_content)
+```
+
 To use Large Language Models for image descriptions, provide `llm_client` and `llm_model`:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ from markitdown import MarkItDown
 
 md = MarkItDown()
 
+# Providing the file extension when converting via file objects is recommended for most consistent results
 # Binary Mode
 with open("test.docx", 'rb') as file:
     result = md.convert(file, file_extension=".docx")

--- a/packages/markitdown/src/markitdown/__init__.py
+++ b/packages/markitdown/src/markitdown/__init__.py
@@ -10,7 +10,6 @@ from ._exceptions import (
     FileConversionException,
     UnsupportedFormatException,
 )
-from ._input import ConverterInput
 from .converters import DocumentConverter, DocumentConverterResult
 
 __all__ = [
@@ -22,5 +21,4 @@ __all__ = [
     "ConverterPrerequisiteException",
     "FileConversionException",
     "UnsupportedFormatException",
-    "ConverterInput",
 ]

--- a/packages/markitdown/src/markitdown/__init__.py
+++ b/packages/markitdown/src/markitdown/__init__.py
@@ -10,6 +10,7 @@ from ._exceptions import (
     FileConversionException,
     UnsupportedFormatException,
 )
+from ._input import ConverterInput
 from .converters import DocumentConverter, DocumentConverterResult
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     "ConverterPrerequisiteException",
     "FileConversionException",
     "UnsupportedFormatException",
+    "ConverterInput",
 ]

--- a/packages/markitdown/src/markitdown/_input.py
+++ b/packages/markitdown/src/markitdown/_input.py
@@ -1,0 +1,18 @@
+from typing import Any, Union
+
+class ConverterInput:
+    """
+    Wrapper for inputs to converter functions.
+    """
+    def __init__(
+        self,
+        input_type: str = "filepath",
+        filepath: Union[str, None] = None,
+        file_object: Union[Any, None] = None,
+    ):
+        if input_type not in ["filepath", "object"]:
+            raise ValueError(f"Invalid converter input type: {input_type}")
+        
+        self.input_type = input_type
+        self.filepath = filepath
+        self.file_object = file_object

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -182,7 +182,6 @@ class MarkItDown:
             - source: can be a string representing a path either as string pathlib path object or url, a requests.response object, or a file object (TextIO or BinaryIO)
             - extension: specifies the file extension to use when interpreting the file. If None, infer from source (path, uri, content-type, etc.)
         """
-
         # Local path or url
         if isinstance(source, str):
             if (
@@ -198,6 +197,9 @@ class MarkItDown:
             return self.convert_response(source, **kwargs)
         elif isinstance(source, Path):
             return self.convert_local(source, **kwargs)
+        # File object
+        elif isinstance(source, BufferedIOBase) or isinstance(source, TextIOBase):
+            return self.convert_file_object(source, **kwargs)
 
     def convert_local(
         self, path: Union[str, Path], **kwargs: Any
@@ -341,7 +343,6 @@ class MarkItDown:
         self, input: ConverterInput, extensions: List[Union[str, None]], **kwargs
     ) -> DocumentConverterResult:
         error_trace = ""
-
         # Create a copy of the page_converters list, sorted by priority.
         # We do this with each call to _convert because the priority of converters may change between calls.
         # The sort is guaranteed to be stable, so converters with the same priority will remain in the same order.
@@ -442,7 +443,7 @@ class MarkItDown:
             # Guess extensions for file objects
             elif isinstance(source, BufferedIOBase) or isinstance(source, TextIOBase):
                 guesses = puremagic.magic_stream(source)
-
+                
             extensions = list()
             for g in guesses:
                 ext = g.extension.strip()

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -175,7 +175,9 @@ class MarkItDown:
             warn("Plugins converters are already enabled.", RuntimeWarning)
 
     def convert(
-        self, source: Union[str, requests.Response, Path, BufferedIOBase, TextIOBase], **kwargs: Any
+        self,
+        source: Union[str, requests.Response, Path, BufferedIOBase, TextIOBase],
+        **kwargs: Any,
     ) -> DocumentConverterResult:  # TODO: deal with kwargs
         """
         Args:
@@ -222,10 +224,10 @@ class MarkItDown:
 
         # Convert
         return self._convert(input, extensions, **kwargs)
-    
+
     def convert_file_object(
         self, file_object: Union[BufferedIOBase, TextIOBase], **kwargs: Any
-    ) -> DocumentConverterResult: #TODO: deal with kwargs
+    ) -> DocumentConverterResult:  # TODO: deal with kwargs
         # Prepare a list of extensions to try (in order of priority)
         ext = kwargs.get("file_extension")
         extensions = [ext] if ext is not None else []
@@ -417,7 +419,7 @@ class MarkItDown:
         # Use puremagic to guess
         try:
             guesses = []
-            
+
             # Guess extensions for filepaths
             if isinstance(source, str):
                 guesses = puremagic.magic_file(source)

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -230,7 +230,7 @@ class MarkItDown:
         ext = kwargs.get("file_extension")
         extensions = [ext] if ext is not None else []
 
-        # TODO: Curently, there are some ongoing issues with puremagic's magic_stream function (incorrect guesses, unsupported file types, etc.)
+        # TODO: Curently, there are some ongoing issues with passing direct file objects to puremagic (incorrect guesses, unsupported file type errors, etc.)
         # Only use puremagic as a last resort if no extensions were provided
         if extensions == []:
             for g in self._guess_ext_magic(source=file_object):

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -175,7 +175,9 @@ class MarkItDown:
             warn("Plugins converters are already enabled.", RuntimeWarning)
 
     def convert(
-        self, source: Union[str, requests.Response, Path, BufferedIOBase, TextIOBase], **kwargs: Any
+        self,
+        source: Union[str, requests.Response, Path, BufferedIOBase, TextIOBase],
+        **kwargs: Any,
     ) -> DocumentConverterResult:  # TODO: deal with kwargs
         """
         Args:
@@ -222,10 +224,10 @@ class MarkItDown:
 
         # Convert
         return self._convert(input, extensions, **kwargs)
-    
+
     def convert_file_object(
         self, file_object: Union[BufferedIOBase, TextIOBase], **kwargs: Any
-    ) -> DocumentConverterResult: #TODO: deal with kwargs
+    ) -> DocumentConverterResult:  # TODO: deal with kwargs
         # Prepare a list of extensions to try (in order of priority)
         ext = kwargs.get("file_extension")
         extensions = [ext] if ext is not None else []
@@ -419,7 +421,7 @@ class MarkItDown:
         # Use puremagic to guess
         try:
             guesses = []
-            
+
             # Guess extensions for filepaths
             if isinstance(source, str):
                 guesses = puremagic.magic_file(source)

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -228,7 +228,7 @@ class MarkItDown:
     def convert_file_object(
         self, file_object: Union[BufferedIOBase, TextIOBase], **kwargs: Any
     ) -> DocumentConverterResult:  # TODO: deal with kwargs
-        # Prepare a list of extensions to try (in order of priority)
+        # Prepare a list of extensions to try (in order of priority
         ext = kwargs.get("file_extension")
         extensions = [ext] if ext is not None else []
 

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -175,9 +175,7 @@ class MarkItDown:
             warn("Plugins converters are already enabled.", RuntimeWarning)
 
     def convert(
-        self,
-        source: Union[str, requests.Response, Path, BufferedIOBase, TextIOBase],
-        **kwargs: Any,
+        self, source: Union[str, requests.Response, Path, BufferedIOBase, TextIOBase], **kwargs: Any
     ) -> DocumentConverterResult:  # TODO: deal with kwargs
         """
         Args:
@@ -224,17 +222,19 @@ class MarkItDown:
 
         # Convert
         return self._convert(input, extensions, **kwargs)
-
+    
     def convert_file_object(
         self, file_object: Union[BufferedIOBase, TextIOBase], **kwargs: Any
-    ) -> DocumentConverterResult:  # TODO: deal with kwargs
+    ) -> DocumentConverterResult: #TODO: deal with kwargs
         # Prepare a list of extensions to try (in order of priority)
         ext = kwargs.get("file_extension")
         extensions = [ext] if ext is not None else []
 
-        # Get extension alternatives from puremagic
-        for g in self._guess_ext_magic(source=file_object):
-            self._append_ext(extensions, g)
+        # TODO: Curently, there are some ongoing issues with puremagic's magic_stream function (incorrect guesses, unsupported file types, etc.)
+        # Only use puremagic as a last resort if no extensions were provided
+        if extensions == []:
+            for g in self._guess_ext_magic(source=file_object):
+                self._append_ext(extensions, g)
 
         # Create the ConverterInput object
         input = ConverterInput(input_type="object", file_object=file_object)
@@ -419,7 +419,7 @@ class MarkItDown:
         # Use puremagic to guess
         try:
             guesses = []
-
+            
             # Guess extensions for filepaths
             if isinstance(source, str):
                 guesses = puremagic.magic_file(source)
@@ -443,7 +443,7 @@ class MarkItDown:
                             pass
 
             # Guess extensions for file objects. Note that the puremagic's magic_stream function requires a BytesIO-like file source
-            # TODO: Figure out how to guess extensions for TextIO-like file sources (manually converting to BytesIO does not currently work)
+            # TODO: Figure out how to guess extensions for TextIO-like file sources (manually converting to BytesIO does not work)
             elif isinstance(source, BufferedIOBase):
                 guesses = puremagic.magic_stream(source)
 

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -10,7 +10,7 @@ from typing import Any, List, Optional, Union
 from pathlib import Path
 from urllib.parse import urlparse
 from warnings import warn
-from io import BufferedIOBase, TextIOBase
+from io import BufferedIOBase, TextIOBase, BytesIO
 
 # File-format detection
 import puremagic
@@ -416,7 +416,7 @@ class MarkItDown:
         """Use puremagic (a Python implementation of libmagic) to guess a file's extension based on the first few bytes."""
         # Use puremagic to guess
         try:
-            guesses = None
+            guesses = []
             
             # Guess extensions for filepaths
             if isinstance(source, str):
@@ -440,10 +440,11 @@ class MarkItDown:
                         except puremagic.main.PureError:
                             pass
 
-            # Guess extensions for file objects
-            elif isinstance(source, BufferedIOBase) or isinstance(source, TextIOBase):
+            # Guess extensions for file objects. Note that the puremagic's magic_stream function requires a BytesIO-like file source
+            # TODO: Figure out how to guess extensions for TextIO-like file sources (manually converting to BytesIO does not currently work)
+            elif isinstance(source, BufferedIOBase):
                 guesses = puremagic.magic_stream(source)
-                
+
             extensions = list()
             for g in guesses:
                 ext = g.extension.strip()

--- a/packages/markitdown/src/markitdown/converters/__init__.py
+++ b/packages/markitdown/src/markitdown/converters/__init__.py
@@ -20,6 +20,7 @@ from ._mp3_converter import Mp3Converter
 from ._outlook_msg_converter import OutlookMsgConverter
 from ._zip_converter import ZipConverter
 from ._doc_intel_converter import DocumentIntelligenceConverter
+from ._converter_input import ConverterInput
 
 __all__ = [
     "DocumentConverter",
@@ -42,4 +43,5 @@ __all__ = [
     "OutlookMsgConverter",
     "ZipConverter",
     "DocumentIntelligenceConverter",
+    "ConverterInput",
 ]

--- a/packages/markitdown/src/markitdown/converters/_bing_serp_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_bing_serp_converter.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 
 from ._base import DocumentConverter, DocumentConverterResult
 from ._markdownify import _CustomMarkdownify
+from ._converter_input import ConverterInput
 
 
 class BingSerpConverter(DocumentConverter):
@@ -21,7 +22,7 @@ class BingSerpConverter(DocumentConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a Bing SERP
         extension = kwargs.get("file_extension", "")
         if extension.lower() not in [".html", ".htm"]:
@@ -36,8 +37,8 @@ class BingSerpConverter(DocumentConverter):
 
         # Parse the file
         soup = None
-        with open(local_path, "rt", encoding="utf-8") as fh:
-            soup = BeautifulSoup(fh.read(), "html.parser")
+        file_obj = input.read_file(mode="rt", encoding="utf-8")
+        soup = BeautifulSoup(file_obj.read(), "html.parser")
 
         # Clean up some formatting
         for tptt in soup.find_all(class_="tptt"):

--- a/packages/markitdown/src/markitdown/converters/_bing_serp_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_bing_serp_converter.py
@@ -39,6 +39,7 @@ class BingSerpConverter(DocumentConverter):
         soup = None
         file_obj = input.read_file(mode="rt", encoding="utf-8")
         soup = BeautifulSoup(file_obj.read(), "html.parser")
+        file_obj.close()
 
         # Clean up some formatting
         for tptt in soup.find_all(class_="tptt"):

--- a/packages/markitdown/src/markitdown/converters/_bing_serp_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_bing_serp_converter.py
@@ -22,7 +22,9 @@ class BingSerpConverter(DocumentConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a Bing SERP
         extension = kwargs.get("file_extension", "")
         if extension.lower() not in [".html", ".htm"]:

--- a/packages/markitdown/src/markitdown/converters/_converter_input.py
+++ b/packages/markitdown/src/markitdown/converters/_converter_input.py
@@ -1,9 +1,11 @@
 from typing import Any, Union
 
+
 class ConverterInput:
     """
     Wrapper for inputs to converter functions.
     """
+
     def __init__(
         self,
         input_type: str = "filepath",
@@ -12,17 +14,17 @@ class ConverterInput:
     ):
         if input_type not in ["filepath", "object"]:
             raise ValueError(f"Invalid converter input type: {input_type}")
-        
+
         self.input_type = input_type
         self.filepath = filepath
         self.file_object = file_object
 
     def read_file(
         self,
-        mode: str = 'rb',
+        mode: str = "rb",
         encoding: Union[str, None] = None,
     ) -> Any:
         if self.input_type == "object":
             return self.file_object
-        
+
         return open(self.filepath, mode=mode, encoding=encoding)

--- a/packages/markitdown/src/markitdown/converters/_converter_input.py
+++ b/packages/markitdown/src/markitdown/converters/_converter_input.py
@@ -16,3 +16,13 @@ class ConverterInput:
         self.input_type = input_type
         self.filepath = filepath
         self.file_object = file_object
+
+    def read_file(
+        self,
+        mode: str = 'rb',
+        encoding: Union[str, None] = None,
+    ) -> Union[str, bytes, Any]:
+        if self.input_type == "object":
+            return self.file_object
+        
+        return open(self.filepath, mode=mode, encoding=encoding)

--- a/packages/markitdown/src/markitdown/converters/_converter_input.py
+++ b/packages/markitdown/src/markitdown/converters/_converter_input.py
@@ -21,7 +21,7 @@ class ConverterInput:
         self,
         mode: str = 'rb',
         encoding: Union[str, None] = None,
-    ) -> Union[str, bytes, Any]:
+    ) -> Any:
         if self.input_type == "object":
             return self.file_object
         

--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -37,7 +37,6 @@ class DocumentIntelligenceConverter(DocumentConverter):
             api_version=self.api_version,
             credential=DefaultAzureCredential(),
         )
-        self._priority = priority
 
     def convert(
         self, local_path: str, **kwargs: Any

--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -11,6 +11,7 @@ from azure.ai.documentintelligence.models import (
 from azure.identity import DefaultAzureCredential
 
 from ._base import DocumentConverter, DocumentConverterResult
+from ._converter_input import ConverterInput
 
 
 # TODO: currently, there is a bug in the document intelligence SDK with importing the "ContentFormat" enum.
@@ -39,7 +40,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
         )
 
     def convert(
-        self, local_path: str, **kwargs: Any
+        self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
         # Bail if extension is not supported by Document Intelligence
         extension = kwargs.get("file_extension", "")
@@ -59,9 +60,9 @@ class DocumentIntelligenceConverter(DocumentConverter):
         if extension.lower() not in docintel_extensions:
             return None
 
-        # Get the bytestring for the local path
-        with open(local_path, "rb") as f:
-            file_bytes = f.read()
+        # Get the bytestring from the converter input
+        file_obj = input.read_file(mode='rb')
+        file_bytes = file_obj.read()
 
         # Certain document analysis features are not availiable for office filetypes (.xlsx, .pptx, .html, .docx)
         if extension.lower() in [".xlsx", ".pptx", ".html", ".docx"]:

--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -61,7 +61,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
             return None
 
         # Get the bytestring from the converter input
-        file_obj = input.read_file(mode='rb')
+        file_obj = input.read_file(mode="rb")
         file_bytes = file_obj.read()
         file_obj.close()
 

--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -63,6 +63,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
         # Get the bytestring from the converter input
         file_obj = input.read_file(mode='rb')
         file_bytes = file_obj.read()
+        file_obj.close()
 
         # Certain document analysis features are not availiable for office filetypes (.xlsx, .pptx, .html, .docx)
         if extension.lower() in [".xlsx", ".pptx", ".html", ".docx"]:

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -8,6 +8,7 @@ from ._base import (
 
 from ._base import DocumentConverter
 from ._html_converter import HtmlConverter
+from ._converter_input import ConverterInput
 
 
 class DocxConverter(HtmlConverter):
@@ -20,18 +21,17 @@ class DocxConverter(HtmlConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a DOCX
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".docx":
             return None
 
         result = None
-        with open(local_path, "rb") as docx_file:
-            style_map = kwargs.get("style_map", None)
-
-            result = mammoth.convert_to_html(docx_file, style_map=style_map)
-            html_content = result.value
-            result = self._convert(html_content)
+        style_map = kwargs.get("style_map", None)
+        file_obj = input.read_file(mode="rb")
+        result = mammoth.convert_to_html(file_obj, style_map=style_map)
+        html_content = result.value
+        result = self._convert(html_content)
 
         return result

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -21,7 +21,9 @@ class DocxConverter(HtmlConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a DOCX
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".docx":

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -31,6 +31,7 @@ class DocxConverter(HtmlConverter):
         style_map = kwargs.get("style_map", None)
         file_obj = input.read_file(mode="rb")
         result = mammoth.convert_to_html(file_obj, style_map=style_map)
+        file_obj.close()
         html_content = result.value
         result = self._convert(html_content)
 

--- a/packages/markitdown/src/markitdown/converters/_html_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_html_converter.py
@@ -3,6 +3,7 @@ from bs4 import BeautifulSoup
 
 from ._base import DocumentConverter, DocumentConverterResult
 from ._markdownify import _CustomMarkdownify
+from ._converter_input import ConverterInput
 
 
 class HtmlConverter(DocumentConverter):
@@ -14,7 +15,7 @@ class HtmlConverter(DocumentConverter):
         super().__init__(priority=priority)
 
     def convert(
-        self, local_path: str, **kwargs: Any
+        self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
         # Bail if not html
         extension = kwargs.get("file_extension", "")
@@ -22,8 +23,8 @@ class HtmlConverter(DocumentConverter):
             return None
 
         result = None
-        with open(local_path, "rt", encoding="utf-8") as fh:
-            result = self._convert(fh.read())
+        file_obj = input.read_file(mode="rt", encoding="utf-8")
+        result = self._convert(file_obj.read())
 
         return result
 

--- a/packages/markitdown/src/markitdown/converters/_html_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_html_converter.py
@@ -25,6 +25,7 @@ class HtmlConverter(DocumentConverter):
         result = None
         file_obj = input.read_file(mode="rt", encoding="utf-8")
         result = self._convert(file_obj.read())
+        file_obj.close()
 
         return result
 

--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -73,6 +73,7 @@ class ImageConverter(MediaConverter):
             content_type = "image/jpeg"
         image_file = input.read_file(mode="rb")
         image_base64 = base64.b64encode(image_file.read()).decode("utf-8")
+        image_file.close()
         data_uri = f"data:{content_type};base64,{image_base64}"
 
         messages = [

--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -14,7 +14,9 @@ class ImageConverter(MediaConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not an image
         extension = kwargs.get("file_extension", "")
         if extension.lower() not in [".jpg", ".jpeg", ".png"]:
@@ -63,7 +65,9 @@ class ImageConverter(MediaConverter):
             text_content=md_content,
         )
 
-    def _get_llm_description(self, input: ConverterInput, extension, client, model, prompt=None):
+    def _get_llm_description(
+        self, input: ConverterInput, extension, client, model, prompt=None
+    ):
         if prompt is None or prompt.strip() == "":
             prompt = "Write a detailed caption for this image."
 

--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -30,6 +30,7 @@ class IpynbConverter(DocumentConverter):
         result = None
         file_obj = input.read_file(mode="rt", encoding="utf-8")
         notebook_content = json.load(file_obj)
+        file_obj.close()
         result = self._convert(notebook_content)
 
         return result

--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -7,6 +7,7 @@ from ._base import (
 )
 
 from .._exceptions import FileConversionException
+from ._converter_input import ConverterInput
 
 
 class IpynbConverter(DocumentConverter):
@@ -18,7 +19,7 @@ class IpynbConverter(DocumentConverter):
         super().__init__(priority=priority)
 
     def convert(
-        self, local_path: str, **kwargs: Any
+        self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
         # Bail if not ipynb
         extension = kwargs.get("file_extension", "")
@@ -27,9 +28,9 @@ class IpynbConverter(DocumentConverter):
 
         # Parse and convert the notebook
         result = None
-        with open(local_path, "rt", encoding="utf-8") as fh:
-            notebook_content = json.load(fh)
-            result = self._convert(notebook_content)
+        file_obj = input.read_file(mode="rt", encoding="utf-8")
+        notebook_content = json.load(file_obj)
+        result = self._convert(notebook_content)
 
         return result
 

--- a/packages/markitdown/src/markitdown/converters/_mp3_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_mp3_converter.py
@@ -1,8 +1,10 @@
 import tempfile
+import os
 from typing import Union
 from ._base import DocumentConverter, DocumentConverterResult
 from ._wav_converter import WavConverter
 from warnings import resetwarnings, catch_warnings
+from ._converter_input import ConverterInput
 
 # Optional Transcription support
 IS_AUDIO_TRANSCRIPTION_CAPABLE = False
@@ -33,11 +35,16 @@ class Mp3Converter(WavConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a MP3
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".mp3":
             return None
+
+        # Bail if a local path was not provided
+        if input.input_type != "filepath":
+            return None
+        local_path = input.filepath
 
         md_content = ""
 

--- a/packages/markitdown/src/markitdown/converters/_mp3_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_mp3_converter.py
@@ -35,7 +35,9 @@ class Mp3Converter(WavConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a MP3
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".mp3":

--- a/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
@@ -1,6 +1,7 @@
 import olefile
 from typing import Any, Union
 from ._base import DocumentConverter, DocumentConverterResult
+from ._converter_input import ConverterInput
 
 
 class OutlookMsgConverter(DocumentConverter):
@@ -17,7 +18,7 @@ class OutlookMsgConverter(DocumentConverter):
         super().__init__(priority=priority)
 
     def convert(
-        self, local_path: str, **kwargs: Any
+        self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
         # Bail if not a MSG file
         extension = kwargs.get("file_extension", "")
@@ -25,7 +26,8 @@ class OutlookMsgConverter(DocumentConverter):
             return None
 
         try:
-            msg = olefile.OleFileIO(local_path)
+            file_obj = input.read_file(mode="rt", encoding="utf-8")
+            msg = olefile.OleFileIO(file_obj)
             # Extract email metadata
             md_content = "# Email Message\n\n"
 
@@ -56,7 +58,7 @@ class OutlookMsgConverter(DocumentConverter):
 
         except Exception as e:
             raise FileConversionException(
-                f"Could not convert MSG file '{local_path}': {str(e)}"
+                f"Could not convert MSG file '{input.filepath}': {str(e)}"
             )
 
     def _get_stream_data(

--- a/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
@@ -26,8 +26,9 @@ class OutlookMsgConverter(DocumentConverter):
             return None
 
         try:
-            file_obj = input.read_file(mode="rt", encoding="utf-8")
+            file_obj = input.read_file(mode="rb")
             msg = olefile.OleFileIO(file_obj)
+
             # Extract email metadata
             md_content = "# Email Message\n\n"
 
@@ -51,6 +52,7 @@ class OutlookMsgConverter(DocumentConverter):
                 md_content += body
 
             msg.close()
+            file_obj.close()
 
             return DocumentConverterResult(
                 title=headers.get("Subject"), text_content=md_content.strip()

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -25,6 +25,8 @@ class PdfConverter(DocumentConverter):
         output = StringIO()
         file_obj = input.read_file(mode="rb")
         pdfminer.high_level.extract_text_to_fp(file_obj, output)
+        file_obj.close()
+
         return DocumentConverterResult(
             title=None,
             text_content=output.getvalue(),

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -16,7 +16,9 @@ class PdfConverter(DocumentConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a PDF
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".pdf":
@@ -31,4 +33,3 @@ class PdfConverter(DocumentConverter):
             title=None,
             text_content=output.getvalue(),
         )
-        

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,7 +1,9 @@
 import pdfminer
 import pdfminer.high_level
 from typing import Union
+from io import StringIO
 from ._base import DocumentConverter, DocumentConverterResult
+from ._converter_input import ConverterInput
 
 
 class PdfConverter(DocumentConverter):
@@ -14,13 +16,17 @@ class PdfConverter(DocumentConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a PDF
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".pdf":
             return None
 
+        output = StringIO()
+        file_obj = input.read_file(mode="rb")
+        pdfminer.high_level.extract_text_to_fp(file_obj, output)
         return DocumentConverterResult(
             title=None,
-            text_content=pdfminer.high_level.extract_text(local_path),
+            text_content=output.getvalue(),
         )
+        

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -4,6 +4,7 @@ from charset_normalizer import from_path
 from typing import Any, Union
 
 from ._base import DocumentConverter, DocumentConverterResult
+from ._converter_input import ConverterInput
 
 
 class PlainTextConverter(DocumentConverter):
@@ -15,8 +16,13 @@ class PlainTextConverter(DocumentConverter):
         super().__init__(priority=priority)
 
     def convert(
-        self, local_path: str, **kwargs: Any
+        self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
+        # Bail if a local path is not provided
+        if input.input_type != "filepath":
+            return None
+        local_path = input.filepath
+        
         # Guess the content type from any file extension that might be around
         content_type, _ = mimetypes.guess_type(
             "__placeholder" + kwargs.get("file_extension", "")

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -22,7 +22,7 @@ class PlainTextConverter(DocumentConverter):
         if input.input_type != "filepath":
             return None
         local_path = input.filepath
-        
+
         # Guess the content type from any file extension that might be around
         content_type, _ = mimetypes.guess_type(
             "__placeholder" + kwargs.get("file_extension", "")

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -1,6 +1,6 @@
 import mimetypes
 
-from charset_normalizer import from_path
+from charset_normalizer import from_path, from_bytes
 from typing import Any, Union
 
 from ._base import DocumentConverter, DocumentConverterResult
@@ -18,10 +18,8 @@ class PlainTextConverter(DocumentConverter):
     def convert(
         self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
-        # Bail if a local path is not provided
-        if input.input_type != "filepath":
-            return None
-        local_path = input.filepath
+        # Read file object from input
+        file_obj = input.read_file(mode="rb")
 
         # Guess the content type from any file extension that might be around
         content_type, _ = mimetypes.guess_type(
@@ -37,7 +35,8 @@ class PlainTextConverter(DocumentConverter):
         ):
             return None
 
-        text_content = str(from_path(local_path).best())
+        text_content = str(from_bytes(file_obj.read()).best())
+        file_obj.close()
         return DocumentConverterResult(
             title=None,
             text_content=text_content,

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -7,6 +7,7 @@ from typing import Union
 
 from ._base import DocumentConverterResult, DocumentConverter
 from ._html_converter import HtmlConverter
+from ._converter_input import ConverterInput
 
 
 class PptxConverter(HtmlConverter):
@@ -48,7 +49,7 @@ class PptxConverter(HtmlConverter):
         )
         return response.choices[0].message.content
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a PPTX
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".pptx":
@@ -56,7 +57,8 @@ class PptxConverter(HtmlConverter):
 
         md_content = ""
 
-        presentation = pptx.Presentation(local_path)
+        file_obj = input.read_file(mode="rb")
+        presentation = pptx.Presentation(file_obj)
         slide_num = 0
         for slide in presentation.slides:
             slide_num += 1

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -59,6 +59,8 @@ class PptxConverter(HtmlConverter):
 
         file_obj = input.read_file(mode="rb")
         presentation = pptx.Presentation(file_obj)
+        file_obj.close()
+        
         slide_num = 0
         for slide in presentation.slides:
             slide_num += 1

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -49,7 +49,9 @@ class PptxConverter(HtmlConverter):
         )
         return response.choices[0].message.content
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a PPTX
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".pptx":
@@ -60,7 +62,7 @@ class PptxConverter(HtmlConverter):
         file_obj = input.read_file(mode="rb")
         presentation = pptx.Presentation(file_obj)
         file_obj.close()
-        
+
         slide_num = 0
         for slide in presentation.slides:
             slide_num += 1

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -22,15 +22,15 @@ class RssConverter(DocumentConverter):
         extension = kwargs.get("file_extension", "")
         if extension.lower() not in [".xml", ".rss", ".atom"]:
             return None
-        # Bail if a local path is not provided
-        if input.input_type != "filepath":
-            return None
-        local_path = input.filepath
+        # Read file object from input
+        file_obj = input.read_file(mode="rb")
 
         try:
-            doc = minidom.parse(local_path)
+            doc = minidom.parse(file_obj)
         except BaseException as _:
             return None
+        file_obj.close()
+
         result = None
         if doc.getElementsByTagName("rss"):
             # A RSS feed must have a root element of <rss>

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 
 from ._markdownify import _CustomMarkdownify
 from ._base import DocumentConverter, DocumentConverterResult
+from ._converter_input import ConverterInput
 
 
 class RssConverter(DocumentConverter):
@@ -15,12 +16,17 @@ class RssConverter(DocumentConverter):
         super().__init__(priority=priority)
 
     def convert(
-        self, local_path: str, **kwargs
+        self, input: ConverterInput, **kwargs
     ) -> Union[None, DocumentConverterResult]:
         # Bail if not RSS type
         extension = kwargs.get("file_extension", "")
         if extension.lower() not in [".xml", ".rss", ".atom"]:
             return None
+        # Bail if a local path is not provided
+        if input.input_type != "filepath":
+            return None
+        local_path = input.filepath
+
         try:
             doc = minidom.parse(local_path)
         except BaseException as _:

--- a/packages/markitdown/src/markitdown/converters/_wav_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wav_converter.py
@@ -1,6 +1,7 @@
 from typing import Union
 from ._base import DocumentConverter, DocumentConverterResult
 from ._media_converter import MediaConverter
+from ._converter_input import ConverterInput
 
 # Optional Transcription support
 IS_AUDIO_TRANSCRIPTION_CAPABLE = False
@@ -22,11 +23,16 @@ class WavConverter(MediaConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a WAV
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".wav":
             return None
+        
+        # Bail if a local path was not provided
+        if input.input_type != "filepath":
+            return None
+        local_path = input.filepath
 
         md_content = ""
 

--- a/packages/markitdown/src/markitdown/converters/_wav_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wav_converter.py
@@ -23,12 +23,14 @@ class WavConverter(MediaConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a WAV
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".wav":
             return None
-        
+
         # Bail if a local path was not provided
         if input.input_type != "filepath":
             return None

--- a/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
@@ -31,6 +31,7 @@ class WikipediaConverter(DocumentConverter):
         soup = None
         file_obj = input.read_file(mode="rt", encoding="utf-8")
         soup = BeautifulSoup(file_obj.read(), "html.parser")
+        file_obj.close()
 
         # Remove javascript and style blocks
         for script in soup(["script", "style"]):

--- a/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 
 from ._base import DocumentConverter, DocumentConverterResult
 from ._markdownify import _CustomMarkdownify
+from ._converter_input import ConverterInput
 
 
 class WikipediaConverter(DocumentConverter):
@@ -16,7 +17,7 @@ class WikipediaConverter(DocumentConverter):
         super().__init__(priority=priority)
 
     def convert(
-        self, local_path: str, **kwargs: Any
+        self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
         # Bail if not Wikipedia
         extension = kwargs.get("file_extension", "")
@@ -28,8 +29,8 @@ class WikipediaConverter(DocumentConverter):
 
         # Parse the file
         soup = None
-        with open(local_path, "rt", encoding="utf-8") as fh:
-            soup = BeautifulSoup(fh.read(), "html.parser")
+        file_obj = input.read_file(mode="rt", encoding="utf-8")
+        soup = BeautifulSoup(file_obj.read(), "html.parser")
 
         # Remove javascript and style blocks
         for script in soup(["script", "style"]):

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -25,6 +25,8 @@ class XlsxConverter(HtmlConverter):
 
         file_obj = input.read_file(mode="rb")
         sheets = pd.read_excel(file_obj, sheet_name=None, engine="openpyxl")
+        file_obj.close()
+
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
@@ -50,6 +52,8 @@ class XlsConverter(HtmlConverter):
 
         file_obj = input.read_file(mode="rb")
         sheets = pd.read_excel(file_obj, sheet_name=None, engine="xlrd")
+        file_obj.close()
+
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -17,7 +17,9 @@ class XlsxConverter(HtmlConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a XLSX
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".xlsx":
@@ -44,7 +46,9 @@ class XlsConverter(HtmlConverter):
     Converts XLS files to Markdown, with each sheet presented as a separate Markdown table.
     """
 
-    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(
+        self, input: ConverterInput, **kwargs
+    ) -> Union[None, DocumentConverterResult]:
         # Bail if not a XLS
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".xls":

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from ._base import DocumentConverter, DocumentConverterResult
 from ._html_converter import HtmlConverter
+from ._converter_input import ConverterInput
 
 
 class XlsxConverter(HtmlConverter):
@@ -16,13 +17,14 @@ class XlsxConverter(HtmlConverter):
     ):
         super().__init__(priority=priority)
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a XLSX
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".xlsx":
             return None
 
-        sheets = pd.read_excel(local_path, sheet_name=None, engine="openpyxl")
+        file_obj = input.read_file(mode="rb")
+        sheets = pd.read_excel(file_obj, sheet_name=None, engine="openpyxl")
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
@@ -40,13 +42,14 @@ class XlsConverter(HtmlConverter):
     Converts XLS files to Markdown, with each sheet presented as a separate Markdown table.
     """
 
-    def convert(self, local_path, **kwargs) -> Union[None, DocumentConverterResult]:
+    def convert(self, input: ConverterInput, **kwargs) -> Union[None, DocumentConverterResult]:
         # Bail if not a XLS
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".xls":
             return None
 
-        sheets = pd.read_excel(local_path, sheet_name=None, engine="xlrd")
+        file_obj = input.read_file(mode="rb")
+        sheets = pd.read_excel(file_obj, sheet_name=None, engine="xlrd")
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"

--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -41,6 +41,7 @@ class YouTubeConverter(DocumentConverter):
         soup = None
         file_obj = input.read_file(mode="rt", encoding="utf-8")
         soup = BeautifulSoup(file_obj.read(), "html.parser")
+        file_obj.close()
 
         # Read the meta tags
         assert soup.title is not None and soup.title.string is not None

--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -1,10 +1,12 @@
 import re
+import json
 
 from typing import Any, Union, Dict, List
 from urllib.parse import parse_qs, urlparse
 from bs4 import BeautifulSoup
 
 from ._base import DocumentConverter, DocumentConverterResult
+from ._converter_input import ConverterInput
 
 
 # Optional YouTube transcription support
@@ -25,7 +27,7 @@ class YouTubeConverter(DocumentConverter):
         super().__init__(priority=priority)
 
     def convert(
-        self, local_path: str, **kwargs: Any
+        self, input: ConverterInput, **kwargs: Any
     ) -> Union[None, DocumentConverterResult]:
         # Bail if not YouTube
         extension = kwargs.get("file_extension", "")
@@ -37,8 +39,8 @@ class YouTubeConverter(DocumentConverter):
 
         # Parse the file
         soup = None
-        with open(local_path, "rt", encoding="utf-8") as fh:
-            soup = BeautifulSoup(fh.read(), "html.parser")
+        file_obj = input.read_file(mode="rt", encoding="utf-8")
+        soup = BeautifulSoup(file_obj.read(), "html.parser")
 
         # Read the meta tags
         assert soup.title is not None and soup.title.string is not None

--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -58,7 +58,7 @@ class ZipConverter(DocumentConverter):
         extension = kwargs.get("file_extension", "")
         if extension.lower() != ".zip":
             return None
-        
+
         # Bail if a local path is not provided
         if input.input_type != "filepath":
             return None
@@ -116,7 +116,7 @@ class ZipConverter(DocumentConverter):
                         # Skip the zip converter to avoid infinite recursion
                         if isinstance(converter, ZipConverter):
                             continue
-                        
+
                         # Create a ConverterInput for the parent converter and attempt conversion
                         input = ConverterInput(
                             input_type="filepath", filepath=file_path

--- a/packages/markitdown/tests/test_markitdown.py
+++ b/packages/markitdown/tests/test_markitdown.py
@@ -410,6 +410,7 @@ if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     test_markitdown_remote()
     test_markitdown_local_paths()
+    test_markitdown_local_objects()
     test_markitdown_exiftool()
     # test_markitdown_llm()
     print("All tests passed!")

--- a/packages/markitdown/tests/test_markitdown.py
+++ b/packages/markitdown/tests/test_markitdown.py
@@ -189,7 +189,7 @@ def test_markitdown_remote() -> None:
     #     assert test_string in result.text_content
 
 
-def test_markitdown_local() -> None:
+def test_markitdown_local_paths() -> None:
     markitdown = MarkItDown()
 
     # Test XLSX processing
@@ -272,6 +272,75 @@ def test_markitdown_local() -> None:
     assert "# Test" in result.text_content
 
 
+def test_markitdown_local_objects() -> None:
+    markitdown = MarkItDown()
+
+    # Test XLSX processing
+    with open(os.path.join(TEST_FILES_DIR, "test.xlsx"), "rb") as f:
+        result = markitdown.convert(f, file_extension=".xlsx")
+        validate_strings(result, XLSX_TEST_STRINGS)
+
+    # Test XLS processing
+    with open(os.path.join(TEST_FILES_DIR, "test.xls"), "rb") as f:
+        result = markitdown.convert(f, file_extension=".xls")
+        for test_string in XLS_TEST_STRINGS:
+            text_content = result.text_content.replace("\\", "")
+            assert test_string in text_content
+
+    # Test DOCX processing
+    with open(os.path.join(TEST_FILES_DIR, "test.docx"), "rb") as f:
+        result = markitdown.convert(f, file_extension=".docx")
+        validate_strings(result, DOCX_TEST_STRINGS)
+
+    # Test DOCX processing, with comments
+    with open(os.path.join(TEST_FILES_DIR, "test_with_comment.docx"), "rb") as f:
+        result = markitdown.convert(
+            f,
+            file_extension=".docx",
+            style_map="comment-reference => ",
+        )
+        validate_strings(result, DOCX_COMMENT_TEST_STRINGS)
+
+    # Test DOCX processing, with comments and setting style_map on init
+    markitdown_with_style_map = MarkItDown(style_map="comment-reference => ")
+    with open(os.path.join(TEST_FILES_DIR, "test_with_comment.docx"), "rb") as f:
+        result = markitdown_with_style_map.convert(f, file_extension=".docx")
+        validate_strings(result, DOCX_COMMENT_TEST_STRINGS)
+
+    # Test PPTX processing
+    with open(os.path.join(TEST_FILES_DIR, "test.pptx"), "rb") as f:
+        result = markitdown.convert(f, file_extension=".pptx")
+        validate_strings(result, PPTX_TEST_STRINGS)
+
+    # Test HTML processing
+    with open(
+        os.path.join(TEST_FILES_DIR, "test_blog.html"), "rt", encoding="utf-8"
+    ) as f:
+        result = markitdown.convert(f, file_extension=".html", url=BLOG_TEST_URL)
+        validate_strings(result, BLOG_TEST_STRINGS)
+
+    # Test Wikipedia processing
+    with open(
+        os.path.join(TEST_FILES_DIR, "test_wikipedia.html"), "rt", encoding="utf-8"
+    ) as f:
+        result = markitdown.convert(f, file_extension=".html", url=WIKIPEDIA_TEST_URL)
+        text_content = result.text_content.replace("\\", "")
+        validate_strings(result, WIKIPEDIA_TEST_STRINGS, WIKIPEDIA_TEST_EXCLUDES)
+
+    # Test Bing processing
+    with open(
+        os.path.join(TEST_FILES_DIR, "test_serp.html"), "rt", encoding="utf-8"
+    ) as f:
+        result = markitdown.convert(f, file_extension=".html", url=SERP_TEST_URL)
+        text_content = result.text_content.replace("\\", "")
+        validate_strings(result, SERP_TEST_STRINGS, SERP_TEST_EXCLUDES)
+
+    # Test MSG (Outlook email) processing
+    with open(os.path.join(TEST_FILES_DIR, "test_outlook_msg.msg"), "rb") as f:
+        result = markitdown.convert(f, file_extension=".msg")
+        validate_strings(result, MSG_TEST_STRINGS)
+
+
 @pytest.mark.skipif(
     skip_exiftool,
     reason="do not run if exiftool is not installed",
@@ -328,7 +397,7 @@ def test_markitdown_llm() -> None:
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     test_markitdown_remote()
-    test_markitdown_local()
+    test_markitdown_local_paths()
     test_markitdown_exiftool()
     # test_markitdown_llm()
     print("All tests passed!")

--- a/packages/markitdown/tests/test_markitdown.py
+++ b/packages/markitdown/tests/test_markitdown.py
@@ -335,10 +335,22 @@ def test_markitdown_local_objects() -> None:
         text_content = result.text_content.replace("\\", "")
         validate_strings(result, SERP_TEST_STRINGS, SERP_TEST_EXCLUDES)
 
+    # Test RSS processing
+    with open(os.path.join(TEST_FILES_DIR, "test_rss.xml"), "rb") as f:
+        result = markitdown.convert(f, file_extension=".xml")
+        text_content = result.text_content.replace("\\", "")
+        for test_string in RSS_TEST_STRINGS:
+            assert test_string in text_content
+
     # Test MSG (Outlook email) processing
     with open(os.path.join(TEST_FILES_DIR, "test_outlook_msg.msg"), "rb") as f:
         result = markitdown.convert(f, file_extension=".msg")
         validate_strings(result, MSG_TEST_STRINGS)
+
+    # Test JSON processing
+    with open(os.path.join(TEST_FILES_DIR, "test.json"), "rb") as f:
+        result = markitdown.convert(f, file_extension=".json")
+        validate_strings(result, JSON_TEST_STRINGS)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR allows MarkItDown to accept file objects as inputs for conversion. All of the individual converters have been refactored to accept a "ConverterInput" object that can hold either a file path or a file buffer, rather than just a local path. Additionally, a new conversion set up function for file objects has been added to the main class.