### PR TITLE
Pin Markdownify version.

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "beautifulsoup4",
   "requests",
   "mammoth",
-  "markdownify",
+  "markdownify~=0.14.1",
   "numpy",
   "python-pptx",
   "pandas",

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -347,11 +347,10 @@ class MarkItDown:
                 _kwargs["_parent_converters"] = self._page_converters
 
                 # If we hit an error log it and keep trying
-                # try:
-                if True:
+                try:
                     res = converter.convert(local_path, **_kwargs)
-                # except Exception:
-                #    error_trace = ("\n\n" + traceback.format_exc()).strip()
+                except Exception:
+                    error_trace = ("\n\n" + traceback.format_exc()).strip()
 
                 if res is not None:
                     # Normalize the content

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -347,10 +347,11 @@ class MarkItDown:
                 _kwargs["_parent_converters"] = self._page_converters
 
                 # If we hit an error log it and keep trying
-                try:
+                # try:
+                if True:
                     res = converter.convert(local_path, **_kwargs)
-                except Exception:
-                    error_trace = ("\n\n" + traceback.format_exc()).strip()
+                # except Exception:
+                #    error_trace = ("\n\n" + traceback.format_exc()).strip()
 
                 if res is not None:
                     # Normalize the content


### PR DESCRIPTION
Markdownify has released version 1.0.0 with breaking changes. Pin the version to 0.14.1 to maintain compatibility with the current codebase. 

TODO: Create an issue to update the dependency to 1.0.0