### PR TITLE
Unable to convert HTML to Markdown

### DIFF
--- a/src/markitdown/__main__.py
+++ b/src/markitdown/__main__.py
@@ -84,7 +84,9 @@ def main():
             )
         elif args.filename is None:
             raise ValueError("Filename is required when using Document Intelligence.")
-        markitdown = MarkItDown(exiftool_path=which_exiftool, docintel_endpoint=args.endpoint)
+        markitdown = MarkItDown(
+            exiftool_path=which_exiftool, docintel_endpoint=args.endpoint
+        )
     else:
         markitdown = MarkItDown(exiftool_path=which_exiftool)
 

--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -1703,7 +1703,7 @@ class MarkItDown:
     ) -> DocumentConverterResult:
         # Deduplicate the list of extensions
         extensions = list(set(extensions))
-        
+
         error_trace = ""
         for ext in extensions + [None]:  # Try last with no extension
             for converter in self._page_converters:

--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -1701,7 +1701,6 @@ class MarkItDown:
     def _convert(
         self, local_path: str, extensions: List[Union[str, None]], **kwargs
     ) -> DocumentConverterResult:
-
         error_trace = ""
         for ext in extensions + [None]:  # Try last with no extension
             for converter in self._page_converters:

--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -91,7 +91,14 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         # Explicitly cast options to the expected type if necessary
         super().__init__(**options)
 
-    def convert_hn(self, n: int, el: Any, text: str, convert_as_inline: bool) -> str:
+    def convert_hn(
+        self,
+        n: int,
+        el: Any,
+        text: str,
+        convert_as_inline: Optional[bool] = False,
+        **kwargs,
+    ) -> str:
         """Same as usual, but be sure to start with a new line"""
         if not convert_as_inline:
             if not re.search(r"^\n", text):
@@ -99,7 +106,9 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
 
         return super().convert_hn(n, el, text, convert_as_inline)  # type: ignore
 
-    def convert_a(self, el: Any, text: str, convert_as_inline: bool):
+    def convert_a(
+        self, el: Any, text: str, convert_as_inline: Optional[bool] = False, **kwargs
+    ):
         """Same as usual converter, but removes Javascript links and escapes URIs."""
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
         if not text:
@@ -135,7 +144,9 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             else text
         )
 
-    def convert_img(self, el: Any, text: str, convert_as_inline: bool) -> str:
+    def convert_img(
+        self, el: Any, text: str, convert_as_inline: Optional[bool] = False, **kwargs
+    ) -> str:
         """Same as usual converter, but removes data URIs"""
 
         alt = el.attrs.get("alt", None) or ""

--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -1701,8 +1701,6 @@ class MarkItDown:
     def _convert(
         self, local_path: str, extensions: List[Union[str, None]], **kwargs
     ) -> DocumentConverterResult:
-        # Deduplicate the list of extensions
-        extensions = list(set(extensions))
 
         error_trace = ""
         for ext in extensions + [None]:  # Try last with no extension
@@ -1765,6 +1763,8 @@ class MarkItDown:
             return
         ext = ext.strip()
         if ext == "":
+            return
+        if ext in extensions:
             return
         # if ext not in extensions:
         extensions.append(ext)

--- a/src/markitdown/_markitdown.py
+++ b/src/markitdown/_markitdown.py
@@ -1701,6 +1701,9 @@ class MarkItDown:
     def _convert(
         self, local_path: str, extensions: List[Union[str, None]], **kwargs
     ) -> DocumentConverterResult:
+        # Deduplicate the list of extensions
+        extensions = list(set(extensions))
+        
         error_trace = ""
         for ext in extensions + [None]:  # Try last with no extension
             for converter in self._page_converters:


### PR DESCRIPTION
Problem description:
- I encountered a case where I could not convert from HTML to Markdown.

Problem solved:
- Fixed the problem of the function inherited from `markdownify.MarkdownConverter` not having `current_tags` causing an error by using `kwargs`, also set the default value for `convert_as_inline`.

Extensions:
- Deduplicated the list of extensions.