### PR TITLE
Don't have ZipConverter accept OOXML files.

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -77,6 +77,10 @@ class ZipConverter(DocumentConverter):
         try:
             # Extract the zip file safely
             with zipfile.ZipFile(local_path, "r") as zipObj:
+                # Bail if we discover it's an Office OOXML file
+                if "[Content_Types].xml" in zipObj.namelist():
+                    return None
+
                 # Safeguard against path traversal
                 for member in zipObj.namelist():
                     member_path = os.path.normpath(os.path.join(extraction_dir, member))


### PR DESCRIPTION
When things go wrong parsing Office documents, the ZipConverter is often used as a fallback, since OOXML files are, in fact, zips. However, this is almost always an undesirable behavior. Have the ZipConverter bail if it sees what looks like OOXML. 