### PR TITLE
feat: sort pptx shapes to be parsed in top-to-bottom, left-to-right order

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MarkItDown is a lightweight Python utility for converting various files to Markd
 At present, MarkItDown supports:
 
 - PDF
-- PowerPoint
+- PowerPoint (reading in top-to-bottom, left-to-right order)
 - Word
 - Excel
 - Images (EXIF metadata and OCR)

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -160,10 +160,12 @@ class PptxConverter(DocumentConverter):
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
-                    for subshape in shape.shapes:
+                    sorted_shapes = sorted(shape.shapes, key=attrgetter('top', 'left'))
+                    for subshape in sorted_shapes:
                         get_shape_content(subshape, **kwargs)
-
-            for shape in slide.shapes:
+            
+            sorted_shapes = sorted(slide.shapes, key=attrgetter('top', 'left'))
+            for shape in sorted_shapes:
                 get_shape_content(shape, **kwargs)
 
             md_content = md_content.strip()

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -6,6 +6,7 @@ import re
 import html
 
 from typing import BinaryIO, Any
+from operator import attrgetter
 
 from ._html_converter import HtmlConverter
 from ._llm_caption import llm_caption

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -160,11 +160,11 @@ class PptxConverter(DocumentConverter):
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
-                    sorted_shapes = sorted(shape.shapes, key=attrgetter('top', 'left'))
+                    sorted_shapes = sorted(shape.shapes, key=attrgetter("top", "left"))
                     for subshape in sorted_shapes:
                         get_shape_content(subshape, **kwargs)
-            
-            sorted_shapes = sorted(slide.shapes, key=attrgetter('top', 'left'))
+
+            sorted_shapes = sorted(slide.shapes, key=attrgetter("top", "left"))
             for shape in sorted_shapes:
                 get_shape_content(shape, **kwargs)
 


### PR DESCRIPTION
Currently, markitdown parses pptx shapes in Z-order, the order in which shapes are stacked on top of each other starting from the back to the front. 

There are repos that parse pptx to markdown which read the shapes in a normal reading order (top-to-bottom, left-to-right order) like https://github.com/ssine/pptx2md/blob/39bef65b312035baeade932aad8d221e37daae5f/pptx2md/parser.py#L249.

There are also stackoverflow posts that explain how to implement this code: https://stackoverflow.com/questions/51999656/how-to-extract-text-from-powerpoint-text-boxes-in-their-order-within-the-presen

I've simply copied over what @ssine has created in his repo, as it's the cleanest implementation.