### PR TITLE
Added FastAPI server to handle file conversion to markdown

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI, File, UploadFile
+import markitdown
+
+app = FastAPI()
+
+@app.post("/convert")
+async def convert_to_markdown(file: UploadFile = File(...)):
+    content = await file.read()  # Read the file content
+    markdown_text = markitdown.convert(content.decode("utf-8"))  # Convert to markdown
+    return {"markdown": markdown_text}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="127.0.0.1", port=8000)
+


### PR DESCRIPTION
This PR introduces a FastAPI server that allows users to upload a file, which is then converted to Markdown using the Markitdown library.


What I Added:
- A new server.py file implementing a FastAPI-based API.
- A /convert endpoint that accepts file uploads and returns the Markdown conversion result.
- Integration of the Markitdown library to process file contents.


How It Works:
- Users send a POST request to /convert with a file as input.
- The server reads the file content and passes it to Markitdown for conversion.
- The API returns a JSON response containing the Markdown text.