### PR TITLE
Fix string formatting in FileConversionException error message

### DIFF
--- a/packages/markitdown/src/markitdown/_exceptions.py
+++ b/packages/markitdown/src/markitdown/_exceptions.py
@@ -69,7 +69,7 @@ class FileConversionException(MarkItDownException):
                 message = f"File conversion failed after {len(attempts)} attempts:\n"
                 for attempt in attempts:
                     if attempt.exc_info is None:
-                        message += " -  {type(attempt.converter).__name__} provided no execution info."
+                        message += f" -  {type(attempt.converter).__name__} provided no execution info."
                     else:
                         message += f" - {type(attempt.converter).__name__} threw {attempt.exc_info[0].__name__} with message: {attempt.exc_info[1]}\n"
 


### PR DESCRIPTION
## Problem
The error message formatting in FileConversionException class is incorrect due to a missing f-string prefix, preventing proper display of the converter type name.

## Changes
- Added `f` prefix to enable string interpolation in error message
- Ensures proper display of converter class name in exception messages

## Testing
- [ ] Verify exception message correctly displays converter class name
- [ ] Ensure other exception messages are formatted correctly

## Related Issues
None

## Notes
This is a simple string formatting fix with no functional logic changes.