### PR TITLE
feat(docker): adding native GHCR container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: ci
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.REGISTRY }}/${{ github.repository }}
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -153,10 +153,13 @@ print(result.text_content)
 
 ### Docker
 
+We recommend you to use a specific tag, just as follow :
+
 ```sh
-docker build -t markitdown:latest .
-docker run --rm -i markitdown:latest < ~/your-file.pdf > output.md
+docker run --rm -i ghcr.io/microsoft/markitdown:v0.1.2 < ~/your-file.pdf > output.md
 ```
+
+It is nevertheless possible to use the latest tag.
 
 ## Contributing
 


### PR DESCRIPTION
Originally, if the user want to use Docker on this project, this are the steps he was gonna do :
- Clone the Repo
- Build the Docker image using `docker build -t markitdown:latest .`
- Run the command `docker run --rm -i markitdown:latest < ~/your-file.pdf > output.md`

With this PR, i am hopping to simplify this procedure so that testing (and trying this repo out, for example to check if it correspond to our need) can be simplified to :
- Run the command `docker run --rm -i ghcr.io/microsoft/markitdown:latest < ~/your-file.pdf > output.md`