### PR TITLE
Fix #183: Blank cells in .xlsx would return NaN in the markdown.

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -84,7 +84,7 @@ class XlsxConverter(DocumentConverter):
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = sheets[s].to_html(index=False, na_rep="")
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs
@@ -146,7 +146,7 @@ class XlsConverter(DocumentConverter):
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = sheets[s].to_html(index=False, na_rep="")
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs


### PR DESCRIPTION
This minimal PR adds `na_rep=""` as an argument to `to_html` in pandas, resolving issue #183.

---

The discussions in #52 are working towards a solution that gives the user options, but since several weeks have passed and the issue is still in the base branch, a minimal fix may help.