### PR TITLE
Fix python.lang.security.use-defused-xml-parse.use-defused-xml-parse--tmp-c83c1369-f7f5-4288-aea7-04caa47d28e4-packages-markitdown-src-markitdown-converter_utils-docx-math-omml.py

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
   "markdownify",
   "magika~=0.6.1",
   "charset-normalizer",
+
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]
@@ -75,6 +77,8 @@ features = ["all"]
 features = ["all"]
 extra-dependencies = [
   "openai",
+
+    "defusedxml>=0.7.1",
 ]
 
 [tool.hatch.envs.types]
@@ -82,6 +86,8 @@ features = ["all"]
 extra-dependencies = [
   "openai",
   "mypy>=1.0.0",
+
+    "defusedxml>=0.7.1",
 ]
 
 [tool.hatch.envs.types.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+defusedxml>=0.7.1


### PR DESCRIPTION
This PR fixes python.lang.security.use-defused-xml-parse.use-defused-xml-parse--tmp-c83c1369-f7f5-4288-aea7-04caa47d28e4-packages-markitdown-src-markitdown-converter_utils-docx-math-omml.py.