### PR TITLE
Extract DOCX images into document-specific folders and fix the empty image links extra from website

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -1,5 +1,5 @@
 import sys
-
+import os
 from typing import BinaryIO, Any
 
 from ._html_converter import HtmlConverter
@@ -52,13 +52,47 @@ class DocxConverter(HtmlConverter):
 
         return False
 
+    def _get_document_name(self, stream_info: StreamInfo) -> str:
+        """
+        Extract document name from StreamInfo
+        """
+        # First try to extract from filename attribute
+        if stream_info.filename:
+            basename = os.path.basename(stream_info.filename)
+            name, _ = os.path.splitext(basename)
+            if name:
+                print(f"[DEBUG] Extracted document name from filename: {name}")
+                return name
+        
+        # If local_path exists, try to extract from local path
+        if stream_info.local_path:
+            basename = os.path.basename(stream_info.local_path)
+            name, _ = os.path.splitext(basename)
+            if name:
+                print(f"[DEBUG] Extracted document name from local_path: {name}")
+                return name
+                
+        # If URL exists, try to extract from URL
+        if stream_info.url:
+            basename = os.path.basename(stream_info.url)
+            name, _ = os.path.splitext(basename)
+            if name:
+                print(f"[DEBUG] Extracted document name from URL: {name}")
+                return name
+        
+        # Default name
+        return "docx_document"
+
     def convert(
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
-        # Check: the dependencies
+        print(f"[DEBUG] DocxConverter.convert called with kwargs: {kwargs}")
+        print(f"[DEBUG] StreamInfo: filename={stream_info.filename}, local_path={stream_info.local_path}, url={stream_info.url}")
+        
+        # Check dependencies
         if _dependency_exc_info is not None:
             raise MissingDependencyException(
                 MISSING_DEPENDENCY_MESSAGE.format(
@@ -72,9 +106,29 @@ class DocxConverter(HtmlConverter):
                 _dependency_exc_info[2]
             )
 
+        # If conversion_name not explicitly provided, try to extract from stream_info
+        if "conversion_name" not in kwargs:
+            conversion_name = self._get_document_name(stream_info)
+            kwargs["conversion_name"] = conversion_name
+            print(f"[DEBUG] Setting conversion_name to: {conversion_name}")
+
         style_map = kwargs.get("style_map", None)
         pre_process_stream = pre_process_docx(file_stream)
-        return self._html_converter.convert_string(
-            mammoth.convert_to_html(pre_process_stream, style_map=style_map).value,
+        
+        # Convert to HTML and pass necessary parameters to HTML converter
+        html_content = mammoth.convert_to_html(pre_process_stream, style_map=style_map).value
+        
+        # Create new StreamInfo to pass to HTML converter
+        html_stream_info = stream_info.copy_and_update(
+            mimetype="text/html",
+            extension=".html"
+        )
+        
+        print(f"[DEBUG] Calling HTML converter with parameters: conversion_name={kwargs.get('conversion_name')}")
+        # Use io.BytesIO to create binary stream
+        from io import BytesIO
+        return self._html_converter.convert(
+            file_stream=BytesIO(html_content.encode("utf-8")),
+            stream_info=html_stream_info,
             **kwargs,
         )

--- a/packages/markitdown/src/markitdown/converters/_html_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_html_converter.py
@@ -61,7 +61,6 @@ class HtmlConverter(DocumentConverter):
             webpage_text = _CustomMarkdownify(**kwargs).convert_soup(soup)
 
         assert isinstance(webpage_text, str)
-        converter = _CustomMarkdownify(image_output_dir="assets")
         # remove leading and trailing \n
         webpage_text = webpage_text.strip()
 

--- a/packages/markitdown/src/markitdown/converters/_html_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_html_converter.py
@@ -61,7 +61,7 @@ class HtmlConverter(DocumentConverter):
             webpage_text = _CustomMarkdownify(**kwargs).convert_soup(soup)
 
         assert isinstance(webpage_text, str)
-
+        converter = _CustomMarkdownify(image_output_dir="assets")
         # remove leading and trailing \n
         webpage_text = webpage_text.strip()
 

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -104,7 +104,8 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         Supports categorized storage in subfolders by document name
         """
         alt = el.attrs.get("alt", None) or ""
-        src = el.attrs.get("src", None) or ""
+        # src = el.attrs.get("src", None) or ""
+        src = el.attrs.get("src", None) or el.attrs.get("data-src", None) or ""
         title = el.attrs.get("title", None) or ""
         title_part = ' "%s"' % title.replace('"', r"\"") if title else ""
         
@@ -166,8 +167,14 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
                 print(f"[ERROR] {error_msg}", file=sys.stderr)
                 import traceback
                 traceback.print_exc(file=sys.stderr)
+                # If extraction fails, revert to original truncating behavior
+                src = src.split(",")[0] + "..."
                 return f"![{alt}](image_error.png)  <!-- {error_msg} -->"
-                
+
+        # Process other data URIs that are not images (truncate them)
+        elif src.startswith("data:") and not self.options.get("keep_data_uris", False):
+            src = src.split(",")[0] + "..."
+            
         # Return Markdown format image reference
         return f"![{alt}]({src}{title_part})"
 

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -115,7 +115,7 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         ):
             return alt
 
-        # Process data URI format images
+        # Process data URI format images -- Update from here
         if src.startswith("data:image") and not self.options.get("keep_data_uris", False):
             try:
                 # Parse MIME type

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -115,7 +115,7 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         ):
             return alt
 
-        # Process data URI format images -- Update from here
+        # Process data URI format images
         if src.startswith("data:image") and not self.options.get("keep_data_uris", False):
             try:
                 # Parse MIME type


### PR DESCRIPTION
Hi, 

This PR improves the DOCX conversion process by extracting embedded images from DOCX documents and saving them into document-specific subfolders. Instead of embedding base64-encoded images directly in the markdown output (which increases file size and rendering load), we now extract the images to the filesystem and reference them in the markdown. 

### Changes
`_markdownify.py`

- Added capability to extract base64 encoded images from data URIs and save them to the filesystem
- Implemented document-specific subfolder organization using the source document's name
- Created a unique file naming system using `SHA-256` hash to prevent name collisions
- Modified image references in markdown to point to the extracted files instead of embedding base64 data.
- Added support for data-src attribute as an alternative to src for handling lazy-loaded images.
- Improved error handling with fallback to the original truncation behavior if extraction fails.


`_docx_converter.py`

- Added functionality to extract and pass the document name through the conversion pipeline.
- Enhanced to maintain the document context during HTML intermediary conversion.


**Example for DOCX**
Before:

`![My Image](data:image/png;base64...)`

After:

`![Image 1](assets/document_name/image_a1b2c3.png)`


File structure:
```bash
assets/
  └── document_name/
      ├── image_a1b2c3.png
      └── image_d4e5f6.jpg
````

**Example for website**

Before:

`![]()`

After:

`![image1](images-links)`




