### PR TITLE
Updated packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py to fix security vulnerability [python.lang.security.use-defused-xml-parse.use-defused-xml-parse]

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -6,7 +6,7 @@ Adapted from https://github.com/xiilei/dwml/blob/master/dwml/omml.py
 On 25/03/2025
 """
 
-import xml.etree.ElementTree as ET
+from defusedxml import ElementTree as ET
 
 from .latex_dict import (
     CHARS,


### PR DESCRIPTION
**Context and Purpose:**

            This PR automatically remediates a security vulnerability:
            - **Description:** The native Python `xml` library is vulnerable to XML External Entity (XXE) attacks.  These attacks can leak confidential data and "XML bombs" can cause denial of service. Do not use this library to parse untrusted input. Instead  the Python documentation recommends using `defusedxml`.
            - **Rule ID:** python.lang.security.use-defused-xml-parse.use-defused-xml-parse
            - **Severity:** MEDIUM
            - **File:** packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
            - **Lines Affected:** 44 - 44

            This change is necessary to protect the application from potential security risks associated with this vulnerability.

            **Solution Implemented:**

            The automated remediation process has applied the necessary changes to the affected code in `packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py` to resolve the identified issue.

            Please review the changes to ensure they are correct and integrate as expected.
            