### PR TITLE
Added .doc support

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -31,6 +31,7 @@ from .converters import (
     IpynbConverter,
     BingSerpConverter,
     PdfConverter,
+    DocConverter,
     DocxConverter,
     XlsxConverter,
     XlsConverter,
@@ -185,6 +186,7 @@ class MarkItDown:
             self.register_converter(WikipediaConverter())
             self.register_converter(YouTubeConverter())
             self.register_converter(BingSerpConverter())
+            self.register_converter(DocConverter())
             self.register_converter(DocxConverter())
             self.register_converter(XlsxConverter())
             self.register_converter(XlsConverter())

--- a/packages/markitdown/src/markitdown/converters/__init__.py
+++ b/packages/markitdown/src/markitdown/converters/__init__.py
@@ -10,6 +10,7 @@ from ._youtube_converter import YouTubeConverter
 from ._ipynb_converter import IpynbConverter
 from ._bing_serp_converter import BingSerpConverter
 from ._pdf_converter import PdfConverter
+from ._doc_converter import DocConverter
 from ._docx_converter import DocxConverter
 from ._xlsx_converter import XlsxConverter, XlsConverter
 from ._pptx_converter import PptxConverter
@@ -33,6 +34,7 @@ __all__ = [
     "IpynbConverter",
     "BingSerpConverter",
     "PdfConverter",
+    "DocConverter"
     "DocxConverter",
     "XlsxConverter",
     "XlsConverter",

--- a/packages/markitdown/src/markitdown/converters/_doc_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_converter.py
@@ -1,0 +1,100 @@
+import sys
+import tempfile
+import uuid
+
+from typing import BinaryIO, Any
+#from io import BytesIO
+import io
+import os
+
+from ._html_converter import HtmlConverter
+from ..converter_utils.docx.pre_process import pre_process_docx
+from .._base_converter import DocumentConverter, DocumentConverterResult
+from .._stream_info import StreamInfo
+from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
+
+# Try loading optional (but in this case, required) dependencies
+# Save reporting of any exceptions for later
+_dependency_exc_info = None
+try:
+    import mammoth
+    from doc2docx import convert as doc2docxConverter
+except ImportError:
+    # Preserve the error and stack trace for later
+    _dependency_exc_info = sys.exc_info()
+
+
+ACCEPTED_MIME_TYPE_PREFIXES = [
+    "application/msword",
+]
+
+ACCEPTED_FILE_EXTENSIONS = [".doc"]
+
+def doc2docxStream(path):
+    tf = uuid.uuid4().hex + '.docx'
+    doc2docxConverter(path,tf)
+    with open(tf, 'rb') as file:
+        pre_process_stream = pre_process_docx(io.BufferedReader(file))
+    os.remove(tf)
+    return pre_process_stream
+    
+    
+
+
+class DocConverter(HtmlConverter):
+    """
+    Converts DOC files to Markdown. Style information (e.g.m headings) and tables are preserved where possible.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._html_converter = HtmlConverter()
+
+    def accepts(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,  # Options to pass to the converter
+    ) -> bool:
+        mimetype = (stream_info.mimetype or "").lower()
+        extension = (stream_info.extension or "").lower()
+
+
+        if extension in ACCEPTED_FILE_EXTENSIONS:
+            return True
+        
+        for prefix in ACCEPTED_MIME_TYPE_PREFIXES:
+            if mimetype.startswith(prefix):
+                return True
+        
+        return False
+
+    def convert(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,  # Options to pass to the converter
+    ) -> DocumentConverterResult:
+        # Check: the dependencies
+        if _dependency_exc_info is not None:
+            raise MissingDependencyException(
+                MISSING_DEPENDENCY_MESSAGE.format(
+                    converter=type(self).__name__,
+                    extension=".doc",
+                    feature="doc",
+                )
+            ) from _dependency_exc_info[
+                1
+            ].with_traceback(  # type: ignore[union-attr]
+                _dependency_exc_info[2]
+            )
+        
+        style_map = kwargs.get("style_map", None)
+
+        pre_process_stream = doc2docxStream(file_stream.name)
+        
+
+        return self._html_converter.convert_string(
+            mammoth.convert_to_html(pre_process_stream, style_map=style_map).value,
+            **kwargs,
+        )

--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -153,24 +153,38 @@ class YouTubeConverter(DocumentConverter):
             params = parse_qs(parsed_url.query)  # type: ignore
             if "v" in params and params["v"][0]:
                 video_id = str(params["v"][0])
+                transcript_list = ytt_api.list(video_id)
+                languages = ['en']
+                for transcript in transcript_list:
+                    languages.append(transcript.language_code)
+                    break
                 try:
                     youtube_transcript_languages = kwargs.get(
-                        "youtube_transcript_languages", ("en",)
+                        "youtube_transcript_languages", languages
                     )
                     # Retry the transcript fetching operation
                     transcript = self._retry_operation(
                         lambda: ytt_api.fetch(
-                            video_id, languages=youtube_transcript_languages
+                            video_id,languages = youtube_transcript_languages
                         ),
                         retries=3,  # Retry 3 times
                         delay=2,  # 2 seconds delay between retries
                     )
+                    
                     if transcript:
                         transcript_text = " ".join(
                             [part.text for part in transcript]
                         )  # type: ignore
                 except Exception as e:
-                    print(f"Error fetching transcript: {e}")
+                    # No transcript available
+                    if len(languages) == 1:
+                        print(f"Error fetching transcript: {e}")
+                    else:
+                        # Translate transcript into first kwarg
+                        transcript = transcript_list.find_transcript(languages).translate(youtube_transcript_languages[0]).fetch()
+                        transcript_text = " ".join(
+                                [part.text for part in transcript]
+                            )
             if transcript_text:
                 webpage_text += f"\n### Transcript\n{transcript_text}\n"
 
@@ -222,3 +236,5 @@ class YouTubeConverter(DocumentConverter):
                 attempt += 1
         # If all attempts fail, raise the last exception
         raise Exception(f"Operation failed after {retries} attempts.")
+
+


### PR DESCRIPTION
Adding new converter `_doc_converter.py` to allow `.doc` files to be supported by markitdown.

Libraries used to convert file streams to html such as `mammoth` don't work on `.doc` files. For this reason the simplest method found was to convert  `.doc` to `.docx` using the `doc2docx` library.

