### PR TITLE
feat: support API version selection for Document Intelligence

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -211,6 +211,10 @@ class MarkItDown:
                 if docintel_types is not None:
                     docintel_args["file_types"] = docintel_types
 
+                docintel_version = kwargs.get("docintel_api_version")
+                if docintel_version is not None:
+                    docintel_args["api_version"] = docintel_version
+
                 self.register_converter(
                     DocumentIntelligenceConverter(**docintel_args),
                 )


### PR DESCRIPTION
### Description

Added support for specifying the Azure Document Intelligence API version via the `docintel_api_version` parameter in the `MarkItDown` class. This allows clients to customize the API version used by the converter.

### Changes

- Added `docintel_api_version` parameter to the `MarkItDown` class constructor (via kwargs)
- Passed the specified version to the Document Intelligence converter if provided

### Example Usage

```py
md = MarkItDown(
    docintel_endpoint="your_endpoint",
    docintel_credential="your_credential",
    docintel_api_version="2024-11-30"  # Specify preferred API version
)
```

### Related Issues

Closes [#1243](https://github.com/microsoft/markitdown/issues/1243) — Allow setting `api_version` for Document Intelligence endpoint