### PR TITLE
 Support Async LLM Client, reuse llm_caption helper

### DIFF
--- a/packages/markitdown/src/markitdown/__init__.py
+++ b/packages/markitdown/src/markitdown/__init__.py
@@ -8,7 +8,7 @@ from ._markitdown import (
     PRIORITY_SPECIFIC_FILE_FORMAT,
     PRIORITY_GENERIC_FILE_FORMAT,
 )
-from ._base_converter import DocumentConverterResult, DocumentConverter
+from ._base_converter import DocumentConverterResult, AsyncDocumentConverterResult, DocumentConverter
 from ._stream_info import StreamInfo
 from ._exceptions import (
     MarkItDownException,
@@ -23,6 +23,7 @@ __all__ = [
     "MarkItDown",
     "DocumentConverter",
     "DocumentConverterResult",
+    "AsyncDocumentConverterResult",
     "MarkItDownException",
     "MissingDependencyException",
     "FailedConversionAttempt",

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -1,7 +1,4 @@
-import os
-import tempfile
-from warnings import warn
-from typing import Any, Union, BinaryIO, Optional, List
+from typing import Any, BinaryIO, Optional, Awaitable
 from ._stream_info import StreamInfo
 
 
@@ -41,6 +38,14 @@ class DocumentConverterResult:
         """Return the converted Markdown text."""
         return self.markdown
 
+class AsyncDocumentConverterResult:
+    """The result of converting a document to Markdown."""
+
+    def __init__(
+        self,
+        text_content: Awaitable[str],
+    ):
+        self.text_content = text_content
 
 class DocumentConverter:
     """Abstract superclass of all DocumentConverters."""

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -1,11 +1,9 @@
-import copy
 import mimetypes
 import os
 import re
 import sys
 import shutil
-import tempfile
-import warnings
+import asyncio
 import traceback
 import io
 from dataclasses import dataclass
@@ -599,6 +597,9 @@ class MarkItDown:
                         )
                     finally:
                         file_stream.seek(cur_pos)
+
+                if asyncio.iscoroutine(res):
+                    return res
 
                 if res is not None:
                     # Normalize the content

--- a/packages/markitdown/src/markitdown/converters/_llm_caption.py
+++ b/packages/markitdown/src/markitdown/converters/_llm_caption.py
@@ -49,8 +49,8 @@ def llm_caption(
     # Call the OpenAI API
     response = client.chat.completions.create(model=model, messages=messages)
     if asyncio.iscoroutine(response):
-        async def read_content():
+        async def read_content(response):
             response = await response
             return response.choices[0].message.content
-        return read_content()
+        return read_content(response)
     return response.choices[0].message.content


### PR DESCRIPTION
Example Code:
```python
import asyncio
from g4f.client import AsyncClient
from markitdown import MarkItDown

import g4f.debug
g4f.debug.logging = True

async def main():
    client = AsyncClient()
    md = MarkItDown(
        llm_client=client,
        llm_model="PollinationsAI:openai",
    )

    print(await (md.convert(open("waterfall.jpeg", "rb")).text_content))

asyncio.run(main())
```