### PR TITLE
Switched from the stdlib minidom parser to defusedxml.

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "markdownify",
   "magika~=0.6.1",
   "charset-normalizer",
+  "defusedxml",
 ]
 
 [project.optional-dependencies]

--- a/packages/markitdown/src/markitdown/converters/_epub_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_epub_converter.py
@@ -1,6 +1,7 @@
 import os
 import zipfile
-import xml.dom.minidom as minidom
+from defusedxml import minidom
+from xml.dom.minidom import Document
 
 from typing import BinaryIO, Any, Dict, List
 
@@ -128,7 +129,7 @@ class EpubConverter(HtmlConverter):
                 markdown="\n\n".join(markdown_content), title=metadata["title"]
             )
 
-    def _get_text_from_node(self, dom: minidom.Document, tag_name: str) -> str | None:
+    def _get_text_from_node(self, dom: Document, tag_name: str) -> str | None:
         """Convenience function to extract a single occurrence of a tag (e.g., title)."""
         texts = self._get_all_texts_from_nodes(dom, tag_name)
         if len(texts) > 0:
@@ -136,9 +137,7 @@ class EpubConverter(HtmlConverter):
         else:
             return None
 
-    def _get_all_texts_from_nodes(
-        self, dom: minidom.Document, tag_name: str
-    ) -> List[str]:
+    def _get_all_texts_from_nodes(self, dom: Document, tag_name: str) -> List[str]:
         """Helper function to extract all occurrences of a tag (e.g., multiple authors)."""
         texts: List[str] = []
         for node in dom.getElementsByTagName(tag_name):

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -1,4 +1,5 @@
-from xml.dom import minidom
+from defusedxml import minidom
+from xml.dom.minidom import Document, Element
 from typing import BinaryIO, Any, Union
 from bs4 import BeautifulSoup
 
@@ -97,7 +98,7 @@ class RssConverter(DocumentConverter):
         else:
             raise ValueError("Unknown feed type")
 
-    def _parse_atom_type(self, doc: minidom.Document) -> DocumentConverterResult:
+    def _parse_atom_type(self, doc: Document) -> DocumentConverterResult:
         """Parse the type of an Atom feed.
 
         Returns None if the feed type is not recognized or something goes wrong.
@@ -129,7 +130,7 @@ class RssConverter(DocumentConverter):
             title=title,
         )
 
-    def _parse_rss_type(self, doc: minidom.Document) -> DocumentConverterResult:
+    def _parse_rss_type(self, doc: Document) -> DocumentConverterResult:
         """Parse the type of an RSS feed.
 
         Returns None if the feed type is not recognized or something goes wrong.
@@ -176,7 +177,7 @@ class RssConverter(DocumentConverter):
             return content
 
     def _get_data_by_tag_name(
-        self, element: minidom.Element, tag_name: str
+        self, element: Element, tag_name: str
     ) -> Union[str, None]:
         """Get data from first child element with the given tag name.
         Returns None when no such element is found.


### PR DESCRIPTION
This pull request introduces changes to improve XML handling in the `markitdown` package by replacing the use of the standard `xml.dom.minidom` module with the more secure `defusedxml.minidom`. The changes also update type annotations to use `Document` and `Element` directly from `xml.dom.minidom`. These updates enhance security and maintain consistency in type annotations.

### Security Improvements:
* Added `defusedxml` as a dependency in `pyproject.toml` to replace the standard `xml.dom.minidom` for safer XML parsing. (`packages/markitdown/pyproject.toml`, [packages/markitdown/pyproject.tomlR32](diffhunk://#diff-085f6e9a2204c2d8b4b1ab22e53d2e31734cba206720578dcb047b67d17ac0e3R32))
* Replaced imports of `xml.dom.minidom` with `defusedxml.minidom` in `_epub_converter.py` and `_rss_converter.py` for improved security. (`packages/markitdown/src/markitdown/converters/_epub_converter.py`, [[1]](diffhunk://#diff-caf424ac3de562e3ac4f360897b82170efd6bda95ced08b6be0417dd4a7b0a82L3-R4); `packages/markitdown/src/markitdown/converters/_rss_converter.py`, [[2]](diffhunk://#diff-c23fd723e2e21d7301fcc13969d391d97b69561a87d9a8a8c38a56c2791fbc7fL1-R2)

### Code Consistency:
* Updated type annotations in `_epub_converter.py` to use `Document` from `xml.dom.minidom` instead of `minidom.Document`. (`packages/markitdown/src/markitdown/converters/_epub_converter.py`, [packages/markitdown/src/markitdown/converters/_epub_converter.pyL131-R140](diffhunk://#diff-caf424ac3de562e3ac4f360897b82170efd6bda95ced08b6be0417dd4a7b0a82L131-R140))
* Updated type annotations in `_rss_converter.py` to use `Document` and `Element` directly, ensuring consistent usage across methods. (`packages/markitdown/src/markitdown/converters/_rss_converter.py`, [[1]](diffhunk://#diff-c23fd723e2e21d7301fcc13969d391d97b69561a87d9a8a8c38a56c2791fbc7fL100-R101) [[2]](diffhunk://#diff-c23fd723e2e21d7301fcc13969d391d97b69561a87d9a8a8c38a56c2791fbc7fL132-R133) [[3]](diffhunk://#diff-c23fd723e2e21d7301fcc13969d391d97b69561a87d9a8a8c38a56c2791fbc7fL179-R180)