### PR TITLE
feat: Create MarkItDown web application

### DIFF
--- a/packages/markitdown-web/Dockerfile
+++ b/packages/markitdown-web/Dockerfile
@@ -1,0 +1,48 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the local markitdown package source first
+COPY ../markitdown /app/packages/markitdown
+
+# Copy the markitdown-web package source
+COPY . /app/packages/markitdown-web
+
+# Install the markitdown package and its dependencies
+# This assumes 'all' extras are desired for markitdown, adjust if not.
+RUN pip install --no-cache-dir /app/packages/markitdown[all]
+
+# Install the markitdown-web package and its dependencies (Flask)
+# This will also ensure markitdown (now installed) is recognized
+RUN pip install --no-cache-dir /app/packages/markitdown-web
+
+# Make port 5000 available to the world outside this container
+EXPOSE 5000
+
+# Define environment variable for Flask
+ENV FLASK_APP=markitdown_web.app
+ENV FLASK_RUN_HOST=0.0.0.0
+ENV FLASK_ENV=production 
+# Consider FLASK_ENV=development for debug mode if needed, but production is safer for a default Dockerfile
+
+# Run app.py when the container launches
+# Using `flask run` is generally preferred for development, 
+# but for production, a proper WSGI server like Gunicorn should be used.
+# For simplicity in this step, we'll use `python -m flask run`.
+# The app.py itself has `app.run()` which is also okay for simple cases but less configurable.
+# Let's use the command that directly executes the app.py's main block for now.
+# The app.py has: if __name__ == '__main__': app.run(debug=True, host='0.0.0.0')
+# We should modify app.py to listen on 0.0.0.0 to be accessible from outside the container.
+# And debug=False for production.
+
+# The CMD instruction should be:
+# CMD ["python", "packages/markitdown-web/src/markitdown_web/app.py"]
+#
+# However, before that, we need to ensure app.py is suitable for this.
+# The app.py currently has app.run(debug=True). This should be changed for production.
+# Let's defer the app.py modification to a later step if needed, or do it here.
+# For now, let's assume app.py will be run directly.
+
+CMD ["python", "packages/markitdown-web/src/markitdown_web/app.py"]

--- a/packages/markitdown-web/README.md
+++ b/packages/markitdown-web/README.md
@@ -1,0 +1,3 @@
+# MarkItDown Web
+
+A web interface for the `markitdown` conversion tool.

--- a/packages/markitdown-web/pyproject.toml
+++ b/packages/markitdown-web/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "markitdown-web"
+version = "0.1.0"
+description = "A web interface for the markitdown conversion tool."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = ["web", "markdown", "conversion"]
+authors = [
+  { name = "AI Agent" } 
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Framework :: Flask",
+]
+
+dependencies = [
+  "Flask>=2.0",
+  "markitdown" # This will refer to the local package
+]
+
+[project.urls]
+Source = "" # Add a source URL if you host this separately
+
+[tool.hatch.build.targets.wheel.sources]
+"src" = "src"
+
+[tool.hatch.envs.default.features]
+# Used by hatch build -t wheel
+# No specific features needed for a simple Flask app beyond dependencies
+all = []
+
+[project.scripts]
+# If you want a command to run the web app, e.g., using a production server
+# markitdown-web-run = "markitdown_web.__main__:main"
+
+[tool.hatch.envs.hatch-test]
+extra-dependencies = [
+  "pytest>=6.0",
+  "pytest-cov"
+]
+[tool.hatch.envs.hatch-test.scripts]
+test = "pytest tests"
+cov = "pytest --cov=src/markitdown_web --cov-report=html tests"

--- a/packages/markitdown-web/src/markitdown_web/app.py
+++ b/packages/markitdown-web/src/markitdown_web/app.py
@@ -1,0 +1,70 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, flash
+from werkzeug.utils import secure_filename
+from markitdown import MarkItDown # Assuming markitdown is installable/importable
+
+# Define the upload folder and ensure it exists
+UPLOAD_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tmp_uploads')
+if not os.path.exists(UPLOAD_FOLDER):
+    os.makedirs(UPLOAD_FOLDER)
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+app.config['SECRET_KEY'] = 'supersecretkey' # Needed for flash messages
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        flash('No file part')
+        return redirect(request.url)
+    file = request.files['file']
+    if file.filename == '':
+        flash('No selected file')
+        return redirect(request.url)
+    if file:
+        filename = secure_filename(file.filename)
+        filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        try:
+            file.save(filepath)
+
+            # Initialize MarkItDown
+            md = MarkItDown()
+            # Convert the file
+            result = md.convert(filepath)
+            markdown_content = result.text_content
+
+            # For now, we'll store it in the session or pass it to a new route.
+            # Let's assume we'll pass it to a template called 'result.html' (to be created in the next step)
+            # We'll use flash to pass the content for now, ideally it would be passed to render_template directly
+            # flash(markdown_content, 'markdown_result') # Flashing large content is not ideal.
+            # Instead, we will render a new template directly in the next step.
+            # For this step, let's just store it in a variable and prepare for the next step.
+
+            # Clean up the uploaded file
+            os.remove(filepath)
+
+            # Render the result template
+            return render_template('result.html', markdown_content=markdown_content)
+
+        except Exception as e:
+            flash(f'An error occurred during conversion: {str(e)}')
+            if os.path.exists(filepath):
+                os.remove(filepath) # Clean up if an error occurs after saving
+            return redirect(url_for('index'))
+        
+    return redirect(url_for('index'))
+
+
+@app.route('/hello') # Kept for testing if needed
+def hello_world():
+    return 'Hello, MarkItDown Web!'
+
+if __name__ == '__main__':
+    # Suitable for running in Docker. For local dev, debug=True is fine.
+    # The FLASK_ENV=production in Dockerfile would ideally set debug=False,
+    # but explicitly setting it here for direct python execution.
+    app.run(host='0.0.0.0', port=5000, debug=False)

--- a/packages/markitdown-web/src/markitdown_web/templates/index.html
+++ b/packages/markitdown-web/src/markitdown_web/templates/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>MarkItDown Web - Upload</title>
+    <style>
+      body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+      .container { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+      h1 { color: #333; }
+      label { display: block; margin-bottom: 8px; font-weight: bold; }
+      input[type="file"] { margin-bottom: 20px; border: 1px solid #ddd; padding: 10px; border-radius: 4px; width: calc(100% - 22px); }
+      input[type="submit"] { background-color: #007bff; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
+      input[type="submit"]:hover { background-color: #0056b3; }
+      .flashes { list-style-type: none; margin: 0; padding: 0; margin-bottom: 15px; }
+      .flashes li { padding: 10px; background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; border-radius: 4px; margin-bottom: 5px; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <ul class=flashes>
+          {% for message in messages %}
+            <li>{{ message }}</li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+      {% endwith %}
+      <h1>Upload File for Markdown Conversion</h1>
+      <form method="POST" action="/upload" enctype="multipart/form-data">
+        <label for="file">Choose a file:</label>
+        <input type="file" id="file" name="file" required>
+        <input type="submit" value="Convert to Markdown">
+      </form>
+    </div>
+  </body>
+</html>

--- a/packages/markitdown-web/src/markitdown_web/templates/result.html
+++ b/packages/markitdown-web/src/markitdown_web/templates/result.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>MarkItDown Web - Conversion Result</title>
+    <style>
+      body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+      .container { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+      h1 { color: #333; }
+      textarea { width: 98%; min-height: 400px; border: 1px solid #ddd; padding: 10px; border-radius: 4px; font-family: monospace; font-size: 14px; }
+      a { color: #007bff; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .back-link { margin-top: 20px; display: inline-block; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Conversion Result</h1>
+      <textarea readonly>{{ markdown_content }}</textarea>
+      <div class="back-link">
+        <a href="{{ url_for('index') }}">Convert another file</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/packages/markitdown-web/tests/__init__.py
+++ b/packages/markitdown-web/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the 'tests' directory as a package.

--- a/packages/markitdown-web/tests/sample.txt
+++ b/packages/markitdown-web/tests/sample.txt
@@ -1,0 +1,1 @@
+Hello World for testing.

--- a/packages/markitdown-web/tests/test_app.py
+++ b/packages/markitdown-web/tests/test_app.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+from markitdown_web.app import app as flask_app
+from io import BytesIO
+
+@pytest.fixture
+def app_fixture():
+    flask_app.config.update({
+        "TESTING": True,
+        "SECRET_KEY": "testsecretkey",
+        "WTF_CSRF_ENABLED": False,
+    })
+    upload_folder = os.path.join(flask_app.root_path, 'tmp_uploads')
+    if not os.path.exists(upload_folder):
+        os.makedirs(upload_folder)
+    yield flask_app
+
+@pytest.fixture
+def client(app_fixture):
+    return app_fixture.test_client()
+
+def test_index_page(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"Upload File for Markdown Conversion" in response.data
+
+def test_upload_no_file_part(client):
+    response = client.post('/upload', data={})
+    assert response.status_code == 302
+    response = client.get(response.location)
+    assert b"No file part" in response.data
+
+def test_upload_empty_filename(client):
+    data = {'file': (BytesIO(b""), '')}
+    response = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert response.status_code == 302
+    response = client.get(response.location)
+    assert b"No selected file" in response.data
+
+def test_upload_success(client):
+    data = {'file': (BytesIO(b"Test content for markdown conversion."), 'test.txt')}
+    response = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    assert b"Conversion Result" in response.data
+    assert b"Test content for markdown conversion." in response.data
+    # The sample.txt created earlier is not used by this test directly,
+    # but the upload functionality is tested.
+    # The actual conversion logic is mocked/assumed to be handled by the `markitdown` library.


### PR DESCRIPTION
This commit introduces a web application for the MarkItDown utility.

Key features include:
- A Flask-based web server.
- File upload functionality via a web interface.
- Conversion of uploaded files to Markdown using the core `markitdown` library.
- Display of the converted Markdown content on a results page.
- Basic error handling for file uploads and conversion.
- A Dockerfile for containerizing the web application.
- Initial unit tests for the web application routes and functionality.

The new web application is located in the `packages/markitdown-web` directory, and includes its own `pyproject.toml` for dependencies and a `src` layout for the Flask app. The `markitdown` package is included as a local dependency.