### PR TITLE
Have the MarkItDown MCP server read MARKITDOWN_ENABLE_PLUGINS from ENV

### DIFF
--- a/packages/markitdown-mcp/Dockerfile
+++ b/packages/markitdown-mcp/Dockerfile
@@ -3,8 +3,10 @@ FROM python:3.13-slim-bullseye
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EXIFTOOL_PATH=/usr/bin/exiftool
 ENV FFMPEG_PATH=/usr/bin/ffmpeg
+ENV MARKITDOWN_ENABLE_PLUGINS=True
 
 # Runtime dependency
+# NOTE: Add any additional MarkItDown plugins here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     exiftool

--- a/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
+++ b/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
@@ -1,5 +1,6 @@
 import contextlib
 import sys
+import os
 from collections.abc import AsyncIterator
 from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
@@ -19,7 +20,15 @@ mcp = FastMCP("markitdown")
 @mcp.tool()
 async def convert_to_markdown(uri: str) -> str:
     """Convert a resource described by an http:, https:, file: or data: URI to markdown"""
-    return MarkItDown().convert_uri(uri).markdown
+    return MarkItDown(enable_plugins=check_plugins_enabled()).convert_uri(uri).markdown
+
+
+def check_plugins_enabled() -> bool:
+    return os.getenv("MARKITDOWN_ENABLE_PLUGINS", "false").strip().lower() in (
+        "true",
+        "1",
+        "yes",
+    )
 
 
 def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlette:


### PR DESCRIPTION
This PR allows the MarkItDown MCP server to read the MARKITDOWN_ENABLE_PLUGINS environment variable to enable 3rd party plugins.

If running the MCP server natively, simple set the environment variable as usual. E.g., 

```bash
export MARKITDOWN_ENABLE_PLUGINS=True
markitdown-mcp --http
```

If running via Docker, plugins are enabled by default, but no plugins are installed. Update the Dockerfile to install any desired plugins. (See comment in the file)
