### PR TITLE
feat(audio-transcription): add language hint

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -110,6 +110,12 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "-l",
+        "--language",
+        help="Language code for audio transcription (e.g., 'en-US', 'fr-FR', 'es-ES'). Default is 'en-US'.",
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
@@ -144,6 +150,15 @@ def main():
                 _exit_with_error(f"Invalid charset: {charset_hint}")
         else:
             charset_hint = None
+
+    language_hint = args.language
+    if language_hint is not None:
+        language_hint = language_hint.strip()
+        if len(language_hint) > 0:
+            if language_hint.count("-") != 1:
+                _exit_with_error(f"Invalid language: {language_hint}")
+        else:
+            language_hint = None
 
     stream_info = None
     if (
@@ -191,10 +206,14 @@ def main():
             sys.stdin.buffer,
             stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
+            language=language_hint,
         )
     else:
         result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
+            args.filename,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+            language=language_hint,
         )
 
     _handle_output(args, result)

--- a/packages/markitdown/src/markitdown/converters/_audio_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_audio_converter.py
@@ -91,7 +91,10 @@ class AudioConverter(DocumentConverter):
         # Transcribe
         if audio_format:
             try:
-                transcript = transcribe_audio(file_stream, audio_format=audio_format)
+                language = kwargs.get("language", "en-US")
+                transcript = transcribe_audio(
+                    file_stream, audio_format=audio_format, language=language
+                )
                 if transcript:
                     md_content += "\n\n### Audio Transcript:\n" + transcript
             except MissingDependencyException:

--- a/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
+++ b/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
@@ -20,7 +20,9 @@ except ImportError:
     _dependency_exc_info = sys.exc_info()
 
 
-def transcribe_audio(file_stream: BinaryIO, *, audio_format: str = "wav") -> str:
+def transcribe_audio(
+    file_stream: BinaryIO, *, audio_format: str = "wav", language: str = "en-US"
+) -> str:
     # Check for installed dependencies
     if _dependency_exc_info is not None:
         raise MissingDependencyException(
@@ -45,5 +47,5 @@ def transcribe_audio(file_stream: BinaryIO, *, audio_format: str = "wav") -> str
     recognizer = sr.Recognizer()
     with sr.AudioFile(audio_source) as source:
         audio = recognizer.record(source)
-        transcript = recognizer.recognize_google(audio).strip()
+        transcript = recognizer.recognize_google(audio, language=language).strip()
         return "[No speech detected]" if transcript == "" else transcript


### PR DESCRIPTION
Add a language hint, so the audio transcription can support more than just US english (which is kept as default).

Closes #1310 