### PR TITLE
Incorporated options to embed or save images off of PDF

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -42,6 +42,7 @@ all = [
   "xlrd",
   "lxml",
   "pdfminer.six",
+  "pymupdf4llm",
   "olefile",
   "pydub",
   "SpeechRecognition",
@@ -53,7 +54,7 @@ pptx = ["python-pptx"]
 docx = ["mammoth", "lxml"]
 xlsx = ["pandas", "openpyxl"]
 xls = ["pandas", "xlrd"]
-pdf = ["pdfminer.six"]
+pdf = ["pdfminer.six", "pymupdf4llm"]
 outlook = ["olefile"]
 audio-transcription = ["pydub", "SpeechRecognition"]
 youtube-transcription = ["youtube-transcript-api"]

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -3,6 +3,7 @@ import io
 
 from typing import BinaryIO, Any
 
+import pymupdf4llm
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
@@ -58,6 +59,7 @@ class PdfConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Check the dependencies
+        
         if _dependency_exc_info is not None:
             raise MissingDependencyException(
                 MISSING_DEPENDENCY_MESSAGE.format(
@@ -72,6 +74,16 @@ class PdfConverter(DocumentConverter):
             )
 
         assert isinstance(file_stream, io.IOBase)  # for mypy
+        
+        use_pdf4llm = kwargs.get("use_pdf4llm", False)
+        
+        if use_pdf4llm:
+            args_pdf4llm = kwargs.get("args_pdf4llm", {})
+            
+            return DocumentConverterResult(
+                markdown=pymupdf4llm.to_markdown(file_stream, **args_pdf4llm)
+            )
+        
         return DocumentConverterResult(
             markdown=pdfminer.high_level.extract_text(file_stream),
         )


### PR DESCRIPTION
### Short summary

Provided an option to use `pymupdf4llm` package for embedding base64 encodings of the images from PDF files into the output markdown. In addition, it allows you to save extracted images locally and refer to them from the markdown in the corresponding positions through the use of additional optional arguments as stated in [pymupdf4llm API](https://pymupdf.readthedocs.io/en/latest/pymupdf4llm/api.html#pymupdf4llm-api).

### Changes
- Added an optional boolean kwarg `use_pdf4llm` in `_pdf_converter.py`
- Added another dict kwarg called `args_pdf4llm` to configure the use of `pymupdf4llm`. The dictionary is according to the [original package API](https://pymupdf.readthedocs.io/en/latest/pymupdf4llm/api.html#pymupdf4llm-api).
- Added optional dependency `use_pdf4llm` to `pyproject.toml`

### Usage

```python
from markitdown import MarkItDown

# To save images and have them referred to
arguments = {
    "page_chunks": False,
    "write_images": True,
    "image_path": "imgs/",
    "image_format": "jpeg",
    "dpi": 150
}

# To keep image embeddings inside the resulting markdown
arguments = {
    "page_chunks": False,
    "write_images": False,
    "embed_images": True,
    "dpi": 150
}

md = MarkItDown(enable_builtins=True)
response = md.convert("input.pdf", use_pdf4llm=True, args_pdf4llm=arguments)
```

### Related issue
Addressed #1238