### PR TITLE
docs: clarify supported input formats for Markdown conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ MarkItDown currently supports the conversion from:
 - ZIP files (iterates over contents)
 - Youtube URLs
 - EPubs
-- ... and more!
+- ... and more
+
+to **Markdown**!
 
 ## Why Markdown?
 


### PR DESCRIPTION
Clarified supported formats list with "to Markdown" ending