### PR TITLE
docs(readme): fix typo 'instrutions' → 'instructions'

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -54,7 +54,7 @@ Once mounted, all files under data will be accessible under `/workdir` in the co
 
 It is recommended to use the Docker image when running the MCP server for Claude Desktop.
 
-Follow [these instrutions](https://modelcontextprotocol.io/quickstart/user#for-claude-desktop-users) to access Claude's `claude_desktop_config.json` file.
+Follow [these instructions](https://modelcontextprotocol.io/quickstart/user#for-claude-desktop-users) to access Claude's `claude_desktop_config.json` file.
 
 Edit it to include the following JSON entry:
 
@@ -102,7 +102,7 @@ To debug the MCP server you can use the `mcpinspector` tool.
 npx @modelcontextprotocol/inspector
 ```
 
-You can then connect to the insepctor through the specified host and port (e.g., `http://localhost:5173/`).
+You can then connect to the inspector through the specified host and port (e.g., `http://localhost:5173/`).
 
 If using STDIO:
 * select `STDIO` as the transport type,
@@ -127,7 +127,7 @@ Finally:
 
 ## Security Considerations
 
-The server does not support authentication, and runs with the privileges if the user running it. For this reason, when running in SSE or Streamable HTTP mode, it is recommended to run the server bound to `localhost` (default).
+The server does not support authentication and runs with the privileges of the user running it. For this reason, when running in SSE or Streamable HTTP mode, it is recommended to run the server bound to `localhost` (default).
 
 
 ## Trademarks


### PR DESCRIPTION
### Summary

This PR addresses minor typo and grammar corrections in the `README.md` file of the `markitdown-mcp` package.

### Changes

**Spelling fixes:**

* `instrutions` → `instructions`
* `insepctor` → `inspector`

**Other improvements:**

* Minor grammar adjustments
* Consistency fixes (punctuation, casing)

### Rationale

Improves clarity and readability of the documentation for users and contributors.

### Scope

* Documentation-only changes
* No impact on functionality, build, or runtime behavior