### PR TITLE
Ensure safe ExifTool usage: require >= 12.24

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_exiftool.py
+++ b/packages/markitdown/src/markitdown/converters/_exiftool.py
@@ -13,6 +13,23 @@ def exiftool_metadata(
     if not exiftool_path:
         return {}
 
+    # Verify exiftool version
+    try:
+        version_output = subprocess.run(
+            [exiftool_path, "-ver"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        version = float(version_output)
+        if version < 12.24:
+            raise RuntimeError(
+                f"ExifTool version {version} is vulnerable to CVE-2021-22204. "
+                "Please upgrade to version 12.24 or later."
+            )
+    except (subprocess.CalledProcessError, ValueError) as e:
+        raise RuntimeError("Failed to verify ExifTool version.") from e
+
     # Run exiftool
     cur_pos = file_stream.tell()
     try:

--- a/packages/markitdown/src/markitdown/converters/_exiftool.py
+++ b/packages/markitdown/src/markitdown/converters/_exiftool.py
@@ -1,7 +1,11 @@
 import json
-import subprocess
 import locale
-from typing import BinaryIO, Any, Union
+import subprocess
+from typing import Any, BinaryIO, Union
+
+
+def _parse_version(version: str) -> tuple:
+    return tuple(map(int, (version.split("."))))
 
 
 def exiftool_metadata(
@@ -21,10 +25,11 @@ def exiftool_metadata(
             text=True,
             check=True,
         ).stdout.strip()
-        version = float(version_output)
-        if version < 12.24:
+        version = _parse_version(version_output)
+        min_version = (12, 24)
+        if version < min_version:
             raise RuntimeError(
-                f"ExifTool version {version} is vulnerable to CVE-2021-22204. "
+                f"ExifTool version {version_output} is vulnerable to CVE-2021-22204. "
                 "Please upgrade to version 12.24 or later."
             )
     except (subprocess.CalledProcessError, ValueError) as e:


### PR DESCRIPTION
This PR adds safety measures when markitdown invokes ExifTool, to avoid exposure to known issues (e.g., CVE-2021-22204).

- Changes

  - Run exiftool -ver beforehand and fail fast if the version is below 12.24.

- Impact

  - On environments without ExifTool or with versions < 12.24, the feature aborts with a clear message.

- Testing

  - Verify the failure path with ExifTool < 12.24.

  - Verify normal operation with ExifTool ≥ 12.24.