### PR TITLE
Fix: Add Timeout Parameter to HTTP Requests in MarkItDown Class

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -442,7 +442,7 @@ class MarkItDown:
             )
         # HTTP/HTTPS URIs
         elif uri.startswith("http:") or uri.startswith("https:"):
-            response = self._requests_session.get(uri, stream=True)
+            response = self._requests_session.get(uri, stream=True, timeout=kwargs.get("timeout", None))
             response.raise_for_status()
             return self.convert_response(
                 response,


### PR DESCRIPTION
This pull request addresses Issue #1167, where HTTP/HTTPS requests could hang indefinitely if the server fails to close the stream. To prevent this, a timeout parameter has been added to the requests.get() call within the convert_uri method.

🔧 Change Summary
Before:
```python
response = self._requests_session.get(uri, stream=True)
```

After:
```python
response = self._requests_session.get(uri, stream=True, timeout=kwargs.get("timeout", None))
```

This change allows users to optionally specify a timeout via kwargs, ensuring better control over request behavior and avoiding indefinite hangs.

✅ Benefits

- Prevents hanging on unresponsive servers
- Enables customizable timeout handling
- Backward-compatible: defaults to None if not provided