### PR TITLE
Fix: youTube transcript error "no element found: line 1, column 0"

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -45,7 +45,7 @@ all = [
   "olefile",
   "pydub",
   "SpeechRecognition",
-  "youtube-transcript-api~=1.0.0",
+  "youtube-transcript-api~=1.1.0",
   "azure-ai-documentintelligence",
   "azure-identity"
 ]


### PR DESCRIPTION
Fixes: #1429 #1383 

**summary:**
- upgraded version of `youtube-transcript-api` to `youtube-transcript-api~=1.1.0` 

**reference:** https://github.com/jdepoix/youtube-transcript-api/issues/320
 