### PR TITLE
Remove Windows constraint

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "magika~=0.6.1",
   "charset-normalizer",
   "defusedxml",
-  "onnxruntime<=1.20.1; sys_platform == 'win32'",
+  "onnxruntime<=1.20.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The win32 constraint makes means that I cannot use the markdownit package outside of Windows. The onnxruntime package supports all 3 major OS, so the win32 constraint seems unnecessary.