### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
+++ b/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
@@ -60,7 +60,7 @@ class RtfConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,
     ) -> DocumentConverterResult:
-        # Read the file stream into an str using hte provided charset encoding, or using the system default
+        # Read the file stream into an str using the provided charset encoding, or using the system default
         encoding = stream_info.charset or locale.getpreferredencoding()
         stream_data = file_stream.read().decode(encoding)
 

--- a/packages/markitdown-sample-plugin/tests/test_sample_plugin.py
+++ b/packages/markitdown-sample-plugin/tests/test_sample_plugin.py
@@ -13,7 +13,7 @@ RTF_TEST_STRINGS = {
 
 
 def test_converter() -> None:
-    """Tests the RTF converter dirctly."""
+    """Tests the RTF converter directly."""
     with open(os.path.join(TEST_FILES_DIR, "test.rtf"), "rb") as file_stream:
         converter = RtfConverter()
         result = converter.convert(

--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -207,7 +207,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
     def _analysis_features(self, stream_info: StreamInfo) -> List[str]:
         """
         Helper needed to determine which analysis features to use.
-        Certain document analysis features are not availiable for
+        Certain document analysis features are not available for
         office filetypes (.xlsx, .pptx, .html, .docx)
         """
         mimetype = (stream_info.mimetype or "").lower()

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -126,7 +126,7 @@ def test_stream_info_operations() -> None:
             **{keyword: f"{keyword}.2"}
         )
 
-        # Make sure the targted attribute is updated
+        # Make sure the targeted attribute is updated
         assert getattr(updated_stream_info, keyword) == f"{keyword}.2"
 
         # Make sure the other attributes are unchanged
@@ -143,7 +143,7 @@ def test_stream_info_operations() -> None:
             StreamInfo(**{keyword: f"{keyword}.2"})
         )
 
-        # Make sure the targted attribute is updated
+        # Make sure the targeted attribute is updated
         assert getattr(updated_stream_info, keyword) == f"{keyword}.2"
 
         # Make sure the other attributes are unchanged


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>