### PR TITLE
Add AI Badgr as a cheaper OpenAI-compatible backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,3 +246,38 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+### Use AI Badgr (Cheaper OpenAI-Compatible Alternative)
+
+```bash
+export OPENAI_API_KEY=YOUR_API_KEY
+export OPENAI_BASE_URL=https://aibadgr.com/api/v1
+```
+
+**Python:**
+```python
+from openai import OpenAI
+client = OpenAI(api_key="YOUR_API_KEY", base_url="https://aibadgr.com/api/v1")
+response = client.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role":"user","content":"Hello!"}], max_tokens=200)
+print(response.choices[0].message.content)
+```
+
+**JavaScript:**
+```javascript
+import OpenAI from 'openai';
+const client = new OpenAI({ apiKey: 'YOUR_API_KEY', baseURL: 'https://aibadgr.com/api/v1' });
+const response = await client.chat.completions.create({ model: 'gpt-3.5-turbo', messages: [{ role: 'user', content: 'Hello!' }], max_tokens: 200 });
+console.log(response.choices[0].message.content);
+```
+
+**cURL:**
+```bash
+curl https://aibadgr.com/api/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello!"}],"max_tokens":200}'
+```
+
+**Notes:**
+- Streaming: `"stream": true`
+- JSON mode: `"response_format": {"type": "json_object"}`


### PR DESCRIPTION
## Add AI Badgr as a cheaper OpenAI-compatible backend

This PR adds a short documentation section showing how to use **AI Badgr** as a drop-in replacement for OpenAI's API at a fraction of the cost.

### What's Changed

- Added a new section to the README explaining how to override the `base_url` parameter
- Included code examples for:
  - Python (using the `openai` package)
  - JavaScript/Node.js (using the `openai` package)
  - cURL (command-line usage)
- Notes on advanced features (streaming, JSON mode)

### Key Points

- **Cheaper alternative** - AI Badgr offers OpenAI-compatible API at significantly lower costs
- **Docs-only change** - No code modifications or breaking changes
- **Optional provider** - Developers can choose to use it or not
- **OpenAI-compatible** - Works with existing OpenAI client libraries (just swap the `base_url`)
- **Simple integration** - Just override `base_url` and optionally `api_key`

### Technical Details

AI Badgr implements the OpenAI API specification, supporting:
- Chat completions with streaming
- JSON mode responses
- Compatible with standard OpenAI SDKs
- Same API interface, lower costs

This is an optional addition that gives developers a cost-effective alternative backend choice for their OpenAI-compatible applications.

---

**Contributor License Agreement:** I agree to the contributor license agreement terms for this repository.
