### PR TITLE
Perf: Optimize non-seekable stream buffering using shutil.copyfileobj

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -362,11 +362,7 @@ class MarkItDown:
         # Check if we have a seekable stream. If not, load the entire stream into memory.
         if not stream.seekable():
             buffer = io.BytesIO()
-            while True:
-                chunk = stream.read(4096)
-                if not chunk:
-                    break
-                buffer.write(chunk)
+            shutil.copyfileobj(stream, buffer)
             buffer.seek(0)
             stream = buffer
 


### PR DESCRIPTION
## Objective
Optimize buffering of non-seekable streams by replacing the manual chunk reading loop with `shutil.copyfileobj()`. The proposed method is more memory efficient with fewer buffer reallocations, all while maintaining the existing buffer growth pattern. Proposed code changes enhance code readability and maintainability.

## Changes
- In the `convert.stream()` method, replace the `while True` statement with `shutil.copyfileobj()`, 
- `shutil.copyfileobj()` uses a larger internal buffer size of 64KB instead of the current 4KB
- `shutil.copyfileobj()` leverages a C-optimized implemented, reducing Python bytecode overhead

**Example Performance Enhancement** 
For a 10MB non-seekable stream:
- **Before:** ~2,560 loop iterations with 4KB chunks
- **After:** ~160 iterations with 64KB chunks (16x fewer)
