### PR TITLE
increase chunk size from 512 bytes to 64 KB for HTTP response reading

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -518,7 +518,7 @@ class MarkItDown:
 
         # Read into BytesIO
         buffer = io.BytesIO()
-        for chunk in response.iter_content(chunk_size=512):
+        for chunk in response.iter_content(chunk_size=65536):
             buffer.write(chunk)
         buffer.seek(0)
 


### PR DESCRIPTION
## Objective
Enhance performance when reading HTTP response content chunks.

## Changes
- A minor performance enhancement to the HTTP response content read loop in the `convert_response` method, that increases the chunk size from 512 bytes to 64KB.
- 64 KB aligns with industry best practices as a common chunk size in computer networking protocols, balancing memory usage and throughput.
- 64 KB is consistent with the chunk size proposed in #1510