### PR TITLE
feat: Add binary generation and Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release Binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build binary on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: markitdown-linux-x64
+            executable_name: markitdown
+          - os: macos-latest
+            artifact_name: markitdown-macos-x64
+            executable_name: markitdown
+          - os: windows-latest
+            artifact_name: markitdown-windows-x64.exe
+            executable_name: markitdown.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12' 
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .[all] pyinstaller
+
+      - name: Build with PyInstaller
+        # Note: --collect-all magika is required for file type inference
+        run: |
+          pyinstaller --onefile --name markitdown --collect-all magika scripts/cli.py
+
+      - name: Rename binary for platform
+        shell: bash
+        run: |
+          mv dist/${{ matrix.executable_name }} dist/${{ matrix.artifact_name }}
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/${{ matrix.artifact_name }}

--- a/homebrew/markitdown.rb
+++ b/homebrew/markitdown.rb
@@ -1,0 +1,27 @@
+class Markitdown < Formula
+  desc "Python tool for converting files and office documents to Markdown"
+  homepage "https://github.com/microsoft/markitdown"
+  version "0.1.4" # Update this on new releases
+  license "MIT"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/microsoft/markitdown/releases/download/v#{version}/markitdown-macos-x64"
+    sha256 "REPLACE_WITH_REAL_SHA256_WHEN_RELEASED"
+  elsif OS.mac? && Hardware::CPU.arm?
+    # For now, using x64 binary on ARM via Rosetta until we add ARM runners to CI
+    url "https://github.com/microsoft/markitdown/releases/download/v#{version}/markitdown-macos-x64"
+    sha256 "REPLACE_WITH_REAL_SHA256_WHEN_RELEASED"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/microsoft/markitdown/releases/download/v#{version}/markitdown-linux-x64"
+    sha256 "REPLACE_WITH_REAL_SHA256_WHEN_RELEASED"
+  end
+
+  def install
+    bin.install "markitdown-macos-x64" => "markitdown" if OS.mac?
+    bin.install "markitdown-linux-x64" => "markitdown" if OS.linux?
+  end
+
+  test do
+    system "#{bin}/markitdown", "--version"
+  end
+end

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,0 +1,4 @@
+from markitdown.__main__ import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds support for generating standalone binaries and installing via Homebrew, addressing #25.

### Changes
1. **GitHub Actions Workflow**: Added `.github/workflows/release.yml` to build binaries for macOS, Linux, and Windows using `pyinstaller` on every tag starting with `v*`.
2. **Shim Script**: Added `scripts/cli.py` to serve as a proper entry point for PyInstaller, ensuring `magika` resources and imports are handled correctly.
3. **Homebrew Formula**: Added `homebrew/markitdown.rb`. This formula uses the binary release strategy (tracking the GitHub Releases) to enable installation via `brew tap`.

### Why this approach?
A standard Homebrew Core submission is currently blocked because `onnxruntime` does not publish source distributions (sdist) on PyPI, which is a requirement for Homebrew Core Python formulas. This PR provides a working alternative (Binary Tap) that unblocks users immediately while waiting for upstream dependency changes.

### Verification
- Verified locally that `pyinstaller` builds a functional binary using the shim script.
- Verified `dist/markitdown --help` runs correctly.