### PR TITLE
fix(pdf): handle partially numbered lists in PDF conversion (#68)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,5 +1,6 @@
 import sys
 import io
+import re
 
 from typing import BinaryIO, Any
 
@@ -72,6 +73,14 @@ class PdfConverter(DocumentConverter):
             )
 
         assert isinstance(file_stream, io.IOBase)  # for mypy
+        text = pdfminer.high_level.extract_text(file_stream)
+        
+        # Simple heuristic to handle "partially numbered lists" often found in 
+        # MasterFormat docs (e.g. .1, .2, etc) by converting them into 
+        # bulleted lists.
+        # See: https://github.com/microsoft/markitdown/issues/68
+        text = re.sub(r"(?m)^(\s*)(\.\d+)", r"\1- \2", text)
+
         return DocumentConverterResult(
-            markdown=pdfminer.high_level.extract_text(file_stream),
+            markdown=text,
         )


### PR DESCRIPTION
Fixes #68

This PR addresses the issue where partially numbered lists (common in MasterFormat documents, e.g., `.1`, `.2`) are extracted as plain text lines indistinguishable from regular paragraphs.

**Changes:**
- Adds a lightweight regex post-processing step in `_pdf_converter.py` to identify lines starting with `.Number` and convert them into Markdown lists (`- .Number`).
- This keeps the solution dependency-free and lightweight as requested by maintainers.

**Verification:**
- Verified that lines like `.1 Item` are now converted to `- .1 Item`.
- Ran standard tests to ensure no regressions.