### PR TITLE
Bump versions of mammoth and pdfminer.six (#1492)

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -41,7 +41,7 @@ all = [
   "openpyxl",
   "xlrd",
   "lxml",
-  "pdfminer.six",
+  "pdfminer.six>=20251107",
   "olefile",
   "pydub",
   "SpeechRecognition",

--- a/packages/markitdown/src/markitdown/__about__.py
+++ b/packages/markitdown/src/markitdown/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present Adam Fourney <adamfo@microsoft.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
[*](url) Updated pyproject to require a minimum version of pdfminer.six to ensure CVE-2025-64512 is patched.   



Have we got a patch, l am creating to many actions here. All is it 9k, Questions  Thogjuts Git. Please