### PR TITLE
fix: update base image from slim-bullseye to slim-bookworm in Dockerfile

### DIFF
--- a/packages/markitdown-mcp/Dockerfile
+++ b/packages/markitdown-mcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EXIFTOOL_PATH=/usr/bin/exiftool


### PR DESCRIPTION
This PR addresses the same issue reported in #1434.

The root cause is the outdated ExifTool version shipped with the bullseye base image. By upgrading the Docker base image from bullseye to bookworm, the build pulls a significantly newer ExifTool, which resolves the problem without additional workarounds.

This keeps the Dockerfile simple while fixing the underlying dependency mismatch.