### PR TITLE
Document Azure API key usage for Azure Document Intelligence conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ To use Microsoft Document Intelligence for conversion:
 markitdown path-to-file.pdf -o document.md -d -e "<document_intelligence_endpoint>"
 ```
 
+You can also set the Azure Document Intelligence API key using an environment variable:
+
+```bash
+export AZURE_API_KEY="your-api-key"
+markitdown path-to-file.pdf -o document.md -d -e "<document_intelligence_endpoint>"
+```
+
+This is useful when you're not logged in with Azure CLI or want to directly use an API key.
+
 More information about how to set up an Azure Document Intelligence Resource can be found [here](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/how-to-guides/create-document-intelligence-resource?view=doc-intel-4.0.0)
 
 ### Python API


### PR DESCRIPTION
## Summary
This PR updates the documentation for Azure Document Intelligence conversion to clarify that users can provide credentials via the `AZURE_API_KEY` environment variable.

## Changes
- Added an example in `README.md` showing how to set `AZURE_API_KEY`
- Added a short note explaining when this approach is useful (e.g., when not signed in via Azure CLI)

## Why
`AZURE_API_KEY` support already exists in `main`, but the README did not clearly describe how to use it for Document Intelligence conversion. This change makes the setup path more discoverable for users.

## Impact
- Documentation-only change
- No code or behavior changes