### PR TITLE
Add configurable Azure Document Intelligence analysis features via CLI and kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ To use Microsoft Document Intelligence for conversion:
 markitdown path-to-file.pdf -o document.md -d -e "<document_intelligence_endpoint>"
 ```
 
+You can also customize analysis features (repeatable or comma-separated):
+
+```bash
+markitdown path-to-file.pdf -d -e "<document_intelligence_endpoint>" --docintel-feature FORMULAS --docintel-feature OCR_HIGH_RESOLUTION,STYLE_FONT
+```
+
+If `--docintel-feature` is not specified, the default features are `FORMULAS`, `OCR_HIGH_RESOLUTION`, and `STYLE_FONT` for OCR-capable formats (e.g., PDF and images). For `.docx`, `.pptx`, `.xlsx`, and `.html`, no analysis features are sent by default.
+
 More information about how to set up an Azure Document Intelligence Resource can be found [here](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/how-to-guides/create-document-intelligence-resource?view=doc-intel-4.0.0)
 
 ### Python API

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -221,6 +221,10 @@ class MarkItDown:
                 if docintel_version is not None:
                     docintel_args["api_version"] = docintel_version
 
+                docintel_features = kwargs.get("docintel_features")
+                if docintel_features is not None:
+                    docintel_args["analysis_features"] = docintel_features
+
                 self.register_converter(
                     DocumentIntelligenceConverter(**docintel_args),
                 )

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3 -m pytest
 import subprocess
 from markitdown import __version__
+from markitdown.__main__ import _parse_docintel_features
 
 # This file contains CLI tests that are not directly tested by the FileTestVectors.
 # This includes things like help messages, version numbers, and invalid flags.
@@ -27,8 +28,39 @@ def test_invalid_flag() -> None:
     assert "SYNTAX" in result.stderr, "Expected 'SYNTAX' to appear in STDERR"
 
 
+def test_parse_docintel_features() -> None:
+    assert _parse_docintel_features(["FORMULAS", "STYLE_FONT,ocrHighResolution"]) == [
+        "FORMULAS",
+        "STYLE_FONT",
+        "ocrHighResolution",
+    ]
+
+
+def test_parse_docintel_features_none() -> None:
+    assert _parse_docintel_features(None) is None
+
+
+def test_parse_docintel_features_empty() -> None:
+    assert _parse_docintel_features([" ", ","]) is None
+
+
+def test_docintel_feature_requires_use_docintel() -> None:
+    result = subprocess.run(
+        ["python", "-m", "markitdown", "--docintel-feature", "FORMULAS"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "--docintel-feature requires --use-docintel." in result.stdout
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     test_version()
     test_invalid_flag()
+    test_parse_docintel_features()
+    test_parse_docintel_features_none()
+    test_parse_docintel_features_empty()
+    test_docintel_feature_requires_use_docintel()
     print("All tests passed!")

--- a/packages/markitdown/tests/test_docintel_features.py
+++ b/packages/markitdown/tests/test_docintel_features.py
@@ -1,0 +1,84 @@
+import pytest
+from markitdown.converters._doc_intel_converter import (
+    DEFAULT_DOCINTEL_ANALYSIS_FEATURES,
+    DocumentIntelligenceConverter,
+    DocumentIntelligenceFileType,
+    DocumentAnalysisFeature,
+    _dependency_exc_info,
+)
+from markitdown._stream_info import StreamInfo
+
+if _dependency_exc_info is not None:
+    pytest.skip(
+        "azure-ai-documentintelligence is not installed", allow_module_level=True
+    )
+
+
+def _make_converter():
+    conv = DocumentIntelligenceConverter.__new__(DocumentIntelligenceConverter)
+    conv._file_types = [
+        DocumentIntelligenceFileType.DOCX,
+        DocumentIntelligenceFileType.PPTX,
+        DocumentIntelligenceFileType.XLSX,
+        DocumentIntelligenceFileType.PDF,
+    ]
+    conv._analysis_features_override = None
+    return conv
+
+
+def test_docintel_default_analysis_features_for_pdf():
+    conv = _make_converter()
+    stream_info = StreamInfo(mimetype="application/pdf", extension=".pdf")
+
+    assert conv._analysis_features(stream_info) == DEFAULT_DOCINTEL_ANALYSIS_FEATURES
+
+
+def test_docintel_default_analysis_features_for_no_ocr_documents():
+    conv = _make_converter()
+    stream_info = StreamInfo(
+        mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        extension=".docx",
+    )
+
+    assert conv._analysis_features(stream_info) == []
+
+
+def test_docintel_analysis_features_can_be_set_on_converter():
+    conv = _make_converter()
+    conv._analysis_features_override = [
+        DocumentAnalysisFeature.LANGUAGES,
+        DocumentAnalysisFeature.QUERY_FIELDS,
+    ]
+    stream_info = StreamInfo(mimetype="application/pdf", extension=".pdf")
+
+    assert conv._analysis_features(stream_info) == [
+        DocumentAnalysisFeature.LANGUAGES,
+        DocumentAnalysisFeature.QUERY_FIELDS,
+    ]
+
+
+def test_docintel_analysis_features_can_be_overridden_per_request():
+    conv = _make_converter()
+    stream_info = StreamInfo(mimetype="application/pdf", extension=".pdf")
+
+    assert conv._analysis_features(
+        stream_info,
+        feature_overrides=[
+            "FORMULAS",
+            "ocr_high_resolution",
+            "DocumentAnalysisFeature.STYLE_FONT",
+            "formulas",
+        ],
+    ) == [
+        DocumentAnalysisFeature.FORMULAS,
+        DocumentAnalysisFeature.OCR_HIGH_RESOLUTION,
+        DocumentAnalysisFeature.STYLE_FONT,
+    ]
+
+
+def test_docintel_analysis_features_invalid_value_raises():
+    conv = _make_converter()
+    stream_info = StreamInfo(mimetype="application/pdf", extension=".pdf")
+
+    with pytest.raises(ValueError):
+        conv._analysis_features(stream_info, feature_overrides=["not_a_real_feature"])

--- a/packages/markitdown/tests/test_docintel_html.py
+++ b/packages/markitdown/tests/test_docintel_html.py
@@ -9,6 +9,7 @@ from markitdown._stream_info import StreamInfo
 def _make_converter(file_types):
     conv = DocumentIntelligenceConverter.__new__(DocumentIntelligenceConverter)
     conv._file_types = file_types
+    conv._analysis_features_override = None
     return conv
 
 


### PR DESCRIPTION
## Summary

This PR makes Azure Document Intelligence analysis features configurable while preserving the existing default behavior.

### What changed

- Added CLI support for custom DI analysis features:
  - `--docintel-feature` (repeatable and comma-separated)
- Added Python kwargs support:
  - `MarkItDown(..., docintel_features=[...])`
  - per-call override via `convert(..., docintel_features=[...])`
- Switched feature handling to SDK constants (`DocumentAnalysisFeature`) for type safety
- Added normalization for common feature input forms (e.g. `FORMULAS`, `ocr_high_resolution`, `DocumentAnalysisFeature.STYLE_FONT`)
- Added validation for invalid feature names (raises `ValueError`)
- Kept default behavior when features are not specified:
  - OCR-capable formats: `FORMULAS`, `OCR_HIGH_RESOLUTION`, `STYLE_FONT`
  - `.docx`, `.pptx`, `.xlsx`, `.html`: no analysis features
- Updated README:
  - documented CLI feature option
  - documented default feature behavior when not specified
  - removed Python feature-customization sample section per latest doc direction

## Why

- Users need to control DI analysis features depending on accuracy/cost/performance requirements.
- The previous implementation had fixed features and limited flexibility.
- Using SDK constants improves safety and reduces string-based errors.