### PR TITLE
Add `--docintel-api-version` to CLI and document default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ To use Microsoft Document Intelligence for conversion:
 markitdown path-to-file.pdf -o document.md -d -e "<document_intelligence_endpoint>"
 ```
 
+You can also specify a Document Intelligence API version:
+
+```bash
+markitdown path-to-file.pdf -d -e "<document_intelligence_endpoint>" --docintel-api-version 2024-07-31-preview
+```
+
+If `--docintel-api-version` is not specified, the default API version is `2024-07-31-preview`.
 More information about how to set up an Azure Document Intelligence Resource can be found [here](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/how-to-guides/create-document-intelligence-resource?view=doc-intel-4.0.0)
 
 ### Python API

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -9,6 +9,8 @@ from importlib.metadata import entry_points
 from .__about__ import __version__
 from ._markitdown import MarkItDown, StreamInfo, DocumentConverterResult
 
+DEFAULT_DOCINTEL_API_VERSION = "2024-07-31-preview"
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -89,6 +91,11 @@ def main():
         "--endpoint",
         type=str,
         help="Document Intelligence Endpoint. Required if using Document Intelligence.",
+    )
+    parser.add_argument(
+        "--docintel-api-version",
+        type=str,
+        help=f"Document Intelligence API version to use (default: {DEFAULT_DOCINTEL_API_VERSION}).",
     )
 
     parser.add_argument(
@@ -172,6 +179,8 @@ def main():
             )
         sys.exit(0)
 
+    if args.docintel_api_version is not None and not args.use_docintel:
+        _exit_with_error("--docintel-api-version requires --use-docintel.")
     if args.use_docintel:
         if args.endpoint is None:
             _exit_with_error(
@@ -180,9 +189,14 @@ def main():
         elif args.filename is None:
             _exit_with_error("Filename is required when using Document Intelligence.")
 
-        markitdown = MarkItDown(
-            enable_plugins=args.use_plugins, docintel_endpoint=args.endpoint
-        )
+        markitdown_kwargs = {
+            "enable_plugins": args.use_plugins,
+            "docintel_endpoint": args.endpoint,
+            "docintel_api_version": args.docintel_api_version
+            or DEFAULT_DOCINTEL_API_VERSION,
+        }
+
+        markitdown = MarkItDown(**markitdown_kwargs)
     else:
         markitdown = MarkItDown(enable_plugins=args.use_plugins)
 

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -27,8 +27,20 @@ def test_invalid_flag() -> None:
     assert "SYNTAX" in result.stderr, "Expected 'SYNTAX' to appear in STDERR"
 
 
+def test_docintel_api_version_requires_use_docintel() -> None:
+    result = subprocess.run(
+        ["python", "-m", "markitdown", "--docintel-api-version", "2024-07-31-preview"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "--docintel-api-version requires --use-docintel." in result.stdout
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     test_version()
     test_invalid_flag()
+    test_docintel_api_version_requires_use_docintel()
     print("All tests passed!")


### PR DESCRIPTION
## Summary
This PR adds a new CLI option, `--docintel-api-version`, so users can explicitly choose the Azure Document Intelligence API version when running with `--use-docintel`.

## Changes
- Added `--docintel-api-version` to the CLI.
- Passed the selected value through to `MarkItDown(..., docintel_api_version=...)`.
- Preserved the current default by using `2024-07-31-preview` when the option is not provided.
- Added validation to ensure `--docintel-api-version` is only accepted with `--use-docintel`.
- Added/updated CLI test coverage for the new validation behavior.
- Updated README with usage examples and default-version notes.

## Why
Document Intelligence API versions can differ by environment and rollout timing.  
Allowing explicit version selection improves reproducibility and makes debugging easier.

## Backward compatibility
- No breaking change.
- Existing behavior remains the same if the new option is not used.

## Example
```bash
markitdown input.pdf -d -e "<document_intelligence_endpoint>" --docintel-api-version 2024-07-31-preview
```