### PR TITLE
Guard against UNC path bypass in file URI parsing on Windows

### DIFF
--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -12,7 +12,26 @@ def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
         raise ValueError(f"Not a file URL: {file_uri}")
 
     netloc = parsed.netloc if parsed.netloc else None
-    path = os.path.abspath(url2pathname(parsed.path))
+    path = url2pathname(parsed.path)
+
+    # On Windows, we need to guard against UNC path bypass attempts
+    # (where UNC paths are encoded in the URI path component to bypass netloc checks)
+    if os.name == 'nt':
+        # Check for UNC path in the path component (bypasses netloc check)
+        if netloc is None and (path.startswith('\\\\') or path.startswith('//')):
+            # Extract the server name part from potential UNC path
+            # Both \\server\share and //server/share start the server name after the 2nd char
+            unc_part = path[2:]
+
+            # Get the server name by splitting on the first separator
+            potential_server = unc_part.replace('/', '\\').split('\\', 1)[0]
+
+            # If it looks like a server name (doesn't contain : for drive letters like C:)
+            # and is not empty, it's likely a UNC path attempt
+            if potential_server and ':' not in potential_server:
+                raise ValueError(f"File URI contains UNC path in path component: {file_uri}")
+
+    path = os.path.abspath(path)
     return netloc, path
 
 


### PR DESCRIPTION
## Summary

`file_uri_to_path()` determines whether a `file:` URI refers to a local resource by
inspecting the parsed URI authority (`netloc`). However, a crafted URI such as
`file:////RemoteServer/Share/file` encodes a UNC path entirely within the **path component**,
causing `urlparse()` to return an empty `netloc` — bypassing the locality check — while
`url2pathname()` on Windows converts it into a valid UNC path (`\\RemoteServer\Share\file`).

This allows the application to initiate unintended outbound SMB connections when processing
such inputs, which is particularly concerning in automated or agent-driven workflows
(e.g., MCP-based systems) where an attacker could influence input data by hosting
attacker-controlled files on a remote server.

## Changes

- Add UNC path detection in the URI **path component** on Windows (`os.name == 'nt'`),
  rejecting URIs where the path resolves to a remote UNC share despite an empty `netloc`
- Simplify server name extraction logic (unify separators before split)
- Remove redundant emptiness check