### PR TITLE
Send CLI validation errors to stderr

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -215,7 +215,7 @@ def _handle_output(args, result: DocumentConverterResult):
 
 
 def _exit_with_error(message: str):
-    print(message)
+    print(message, file=sys.stderr)
     sys.exit(1)
 
 

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -27,8 +27,22 @@ def test_invalid_flag() -> None:
     assert "SYNTAX" in result.stderr, "Expected 'SYNTAX' to appear in STDERR"
 
 
+def test_docintel_requires_endpoint() -> None:
+    result = subprocess.run(
+        ["python", "-m", "markitdown", "--use-docintel"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0, f"CLI exited with error: {result.stderr}"
+    assert (
+        "Document Intelligence Endpoint is required" in result.stderr
+    ), "Expected error to appear in STDERR"
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     test_version()
     test_invalid_flag()
+    test_docintel_requires_endpoint()
     print("All tests passed!")


### PR DESCRIPTION
## Problem
When CLI validation fails (e.g., missing Document Intelligence endpoint), `markitdown` prints the error message to stdout. This makes it harder to distinguish valid output from errors and breaks common shell patterns that rely on stderr for failures.

## Why this change
Errors should flow to stderr so users can safely pipe/redirect stdout without losing error visibility.

## What changed
- Send `_exit_with_error` output to stderr.
- Added a CLI test that verifies the missing-docintel-endpoint error is emitted on stderr.

## Testing
- `python -m pytest packages/markitdown/tests/test_cli_misc.py`