### PR TITLE
chore/1574-readme-typo-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To install MarkItDown, use pip: `pip install 'markitdown[all]'`. Alternatively, 
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e 'packages/markitdown[all]'
+pip install packages/markitdown[all]
 ```
 
 ## Usage


### PR DESCRIPTION
Small typo issue raised
resolves #1574

Hello,

When I was installing this tool, I saw that the command wasn't right. As it stands, with -e and single quotes in the pip install, the command doesn't work. 

I'm on ubuntu 24.04 and the command 'pip install markitdown[all]' is what I needed to run to get it installed properly. 

Also noticed someone else has raised this issue, which i've linked.

This tool looks nice! I'll keep on using it and make PR's if needed.