### PR TITLE
Quote extras in PyPI install docs

### DIFF
--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -10,7 +10,7 @@
 From PyPI:
 
 ```bash
-pip install markitdown[all]
+pip install 'markitdown[all]'
 ```
 
 From source:
@@ -18,7 +18,7 @@ From source:
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e packages/markitdown[all]
+pip install -e 'packages/markitdown[all]'
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary\n- quote markitdown[all] in PyPI README install commands\n\n## Testing\n- grep -Rns "markitdown\[all\]" packages/markitdown/README.md\n\nFixes #1574