### PR TITLE
fix: handle None llm_description in PptxConverter (fixes #1534)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -147,7 +147,7 @@ class PptxConverter(DocumentConverter):
                         pass
 
                     # Prepare the alt, escaping any special characters
-                    alt_text = "\n".join([llm_description, alt_text]) or shape.name
+                    alt_text = "\n".join([llm_description or "", alt_text or ""]) or shape.name
                     alt_text = re.sub(r"[\r\n\[\]]", " ", alt_text)
                     alt_text = re.sub(r"\s+", " ", alt_text).strip()
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -560,6 +560,19 @@ def test_markitdown_llm_parameters() -> None:
     assert len(messages) == 1
     assert messages[0]["content"][0]["text"] == test_prompt
 
+def test_pptx_null_llm_caption() -> None:
+    """Test that a None response from llm_caption does not cause a crash (Issue #1534)."""
+    from unittest.mock import patch
+    
+    with patch("markitdown.converters._pptx_converter.llm_caption", return_value=None) as mock_llm_caption:
+        markitdown = MarkItDown(llm_client="dummy_client", llm_model="dummy_model")
+        
+        # Test PPTX file - should not crash
+        result = markitdown.convert(os.path.join(TEST_FILES_DIR, "test.pptx"))
+        
+        # Ensure it was called
+        assert mock_llm_caption.called
+
 
 @pytest.mark.skipif(
     skip_llm,


### PR DESCRIPTION
Fixes #1534 — `PptxConverter` crashes with an `UnboundLocalError/TypeError` when the model returns `None` for image captions.

In `_pptx_converter.py`, changed the alt text assembly to coerce `None` variables to empty strings before joining them:
`alt_text = "\n".join([llm_description or "", alt_text or ""]) or shape.name`

Added a mocked test case in `test_module_misc.py` (`test_pptx_null_llm_caption`) that verifies `markitdown` survives a `None` return from `llm_caption`.
