### PR TITLE
Fetch raw content for GitHub markdown URLs

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -82,6 +82,29 @@ def _load_plugins() -> Union[None, List[Any]]:
     return _plugins
 
 
+def _rewrite_github_markdown_url(uri: str) -> str:
+    """Prefer raw markdown content for GitHub blob URLs that target markdown files."""
+    parsed = urlparse(uri)
+    if parsed.netloc.lower() != "github.com":
+        return uri
+
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) < 5 or path_parts[2] != "blob":
+        return uri
+
+    if not path_parts[-1].lower().endswith((".md", ".markdown")):
+        return uri
+
+    owner, repo = path_parts[0], path_parts[1]
+    ref = path_parts[3]
+    relative_path = "/".join(path_parts[4:])
+    return parsed._replace(
+        scheme="https",
+        netloc="raw.githubusercontent.com",
+        path=f"/{owner}/{repo}/{ref}/{relative_path}",
+    ).geturl()
+
+
 @dataclass(kw_only=True, frozen=True)
 class ConverterRegistration:
     """A registration of a converter with its priority and other metadata."""
@@ -449,7 +472,8 @@ class MarkItDown:
             )
         # HTTP/HTTPS URIs
         elif uri.startswith("http:") or uri.startswith("https:"):
-            response = self._requests_session.get(uri, stream=True)
+            request_uri = _rewrite_github_markdown_url(uri)
+            response = self._requests_session.get(request_uri, stream=True)
             response.raise_for_status()
             return self.convert_response(
                 response,
@@ -555,9 +579,9 @@ class MarkItDown:
             for converter_registration in sorted_registrations:
                 converter = converter_registration.converter
                 # Sanity check -- make sure the cur_pos is still the same
-                assert (
-                    cur_pos == file_stream.tell()
-                ), "File stream position should NOT change between guess iterations"
+                assert cur_pos == file_stream.tell(), (
+                    "File stream position should NOT change between guess iterations"
+                )
 
                 _kwargs = {k: v for k, v in kwargs.items()}
 
@@ -596,9 +620,9 @@ class MarkItDown:
                     pass
 
                 # accept() should not have changed the file stream position
-                assert (
-                    cur_pos == file_stream.tell()
-                ), f"{type(converter).__name__}.accept() should NOT change the file_stream position"
+                assert cur_pos == file_stream.tell(), (
+                    f"{type(converter).__name__}.accept() should NOT change the file_stream position"
+                )
 
                 # Attempt the conversion
                 if _accepts:

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -282,6 +282,39 @@ def test_input_as_strings() -> None:
     result = markitdown.convert_stream(io.BytesIO(input_data))
     assert "# Test" in result.text_content
 
+
+def test_convert_github_markdown_url_uses_raw_content() -> None:
+    requested_urls: list[str] = []
+
+    class FakeResponse:
+        def __init__(self, url: str) -> None:
+            self.url = url
+            self.headers = {"content-type": "text/plain; charset=utf-8"}
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_content(self, chunk_size: int = 512):
+            del chunk_size
+            yield b"# Hello from markdown\n"
+
+    class FakeSession:
+        def get(self, url: str, *, stream: bool = False) -> FakeResponse:
+            requested_urls.append(url)
+            assert stream is True
+            return FakeResponse(url)
+
+    markitdown = MarkItDown(requests_session=FakeSession())
+
+    result = markitdown.convert(
+        "https://github.com/microsoft/markitdown/blob/main/README.md"
+    )
+
+    assert result.text_content == "# Hello from markdown\n"
+    assert requested_urls == [
+        "https://raw.githubusercontent.com/microsoft/markitdown/main/README.md"
+    ]
+
     # Test input with leading blank characters
     input_data = b"   \n\n\n<html><body><h1>Test</h1></body></html>"
     result = markitdown.convert_stream(io.BytesIO(input_data))


### PR DESCRIPTION
Closes #1200

Summary:
- detect GitHub `blob` URLs that point to Markdown files before fetching them
- rewrite those URLs to `raw.githubusercontent.com` so MarkItDown receives the underlying markdown content instead of rendered HTML
- add a regression test that verifies the rewritten request URL and the preserved markdown output

Testing:
- `uv run --project packages/markitdown --with pytest,mypy python -m pytest packages/markitdown/tests/test_module_misc.py -k 'github_markdown_url or input_as_strings'`
- `uv run --project packages/markitdown --with ruff python -m ruff check packages/markitdown/src/markitdown/_markitdown.py packages/markitdown/tests/test_module_misc.py`
- `uv run --project packages/markitdown --with ruff python -m ruff format --check packages/markitdown/src/markitdown/_markitdown.py packages/markitdown/tests/test_module_misc.py`

Note:
- running targeted mypy against this package in this checkout still surfaces pre-existing unrelated issues in untouched files, so I limited type-check validation to the touched path plus the regression test.
