### PR TITLE
fix: preserve HTML tables in Outlook .msg conversion

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
@@ -1,8 +1,10 @@
+import io
 import sys
 from typing import Any, Union, BinaryIO
 from .._stream_info import StreamInfo
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
+from ._html_converter import HtmlConverter
 
 # Try loading optional (but in this case, required) dependencies
 # Save reporting of any exceptions for later
@@ -19,6 +21,11 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ]
 
 ACCEPTED_FILE_EXTENSIONS = [".msg"]
+HTML_BODY_BINARY_STREAM = "__substg1.0_10130102"
+HTML_BODY_TEXT_STREAMS = [
+    "__substg1.0_1013001F",
+    "__substg1.0_1013001E",
+]
 
 
 class OutlookMsgConverter(DocumentConverter):
@@ -28,6 +35,9 @@ class OutlookMsgConverter(DocumentConverter):
     - Email headers (From, To, Subject)
     - Email body content
     """
+
+    def __init__(self) -> None:
+        self._html_converter = HtmlConverter()
 
     def accepts(
         self,
@@ -112,8 +122,10 @@ class OutlookMsgConverter(DocumentConverter):
 
         md_content += "\n## Content\n\n"
 
-        # Get email body
-        body = self._get_stream_data(msg, "__substg1.0_1000001F")
+        # Prefer the HTML body when it is present so Outlook tables survive as tables.
+        body = self._get_html_body(msg, **kwargs)
+        if body is None:
+            body = self._get_stream_data(msg, "__substg1.0_1000001F")
         if body:
             md_content += body
 
@@ -124,8 +136,41 @@ class OutlookMsgConverter(DocumentConverter):
             title=headers.get("Subject"),
         )
 
-    def _get_stream_data(self, msg: Any, stream_path: str) -> Union[str, None]:
-        """Helper to safely extract and decode stream data from the MSG file."""
+    def _get_html_body(self, msg: Any, **kwargs: Any) -> Union[str, None]:
+        html_data = self._get_stream_bytes(msg, HTML_BODY_BINARY_STREAM)
+        if html_data:
+            try:
+                markdown = self._html_converter.convert(
+                    io.BytesIO(html_data),
+                    StreamInfo(mimetype="text/html", extension=".html"),
+                    **kwargs,
+                ).markdown.strip()
+            except Exception:
+                markdown = None
+
+            if markdown:
+                return markdown
+
+        for stream_path in HTML_BODY_TEXT_STREAMS:
+            html_text = self._get_stream_data(msg, stream_path)
+            if not html_text:
+                continue
+
+            try:
+                markdown = self._html_converter.convert_string(
+                    html_text,
+                    **kwargs,
+                ).markdown.strip()
+            except Exception:
+                markdown = None
+
+            if markdown:
+                return markdown
+
+        return None
+
+    def _get_stream_bytes(self, msg: Any, stream_path: str) -> Union[bytes, None]:
+        """Helper to safely extract raw stream data from the MSG file."""
         assert olefile is not None
         assert isinstance(
             msg, olefile.OleFileIO
@@ -133,17 +178,24 @@ class OutlookMsgConverter(DocumentConverter):
 
         try:
             if msg.exists(stream_path):
-                data = msg.openstream(stream_path).read()
-                # Try UTF-16 first (common for .msg files)
-                try:
-                    return data.decode("utf-16-le").strip()
-                except UnicodeDecodeError:
-                    # Fall back to UTF-8
-                    try:
-                        return data.decode("utf-8").strip()
-                    except UnicodeDecodeError:
-                        # Last resort - ignore errors
-                        return data.decode("utf-8", errors="ignore").strip()
+                return msg.openstream(stream_path).read()
         except Exception:
             pass
         return None
+
+    def _get_stream_data(self, msg: Any, stream_path: str) -> Union[str, None]:
+        """Helper to safely extract and decode stream data from the MSG file."""
+        data = self._get_stream_bytes(msg, stream_path)
+        if data is None:
+            return None
+
+        # Try UTF-16 first (common for .msg files)
+        try:
+            return data.decode("utf-16-le").strip()
+        except UnicodeDecodeError:
+            # Fall back to UTF-8
+            try:
+                return data.decode("utf-8").strip()
+            except UnicodeDecodeError:
+                # Last resort - ignore errors
+                return data.decode("utf-8", errors="ignore").strip()

--- a/packages/markitdown/tests/test_outlook_msg_converter.py
+++ b/packages/markitdown/tests/test_outlook_msg_converter.py
@@ -1,0 +1,78 @@
+from io import BytesIO
+from types import SimpleNamespace
+
+from markitdown import StreamInfo
+from markitdown.converters._outlook_msg_converter import OutlookMsgConverter
+from markitdown.converters import _outlook_msg_converter as outlook_msg_converter
+
+
+def _utf16_stream(value: str) -> bytes:
+    return value.encode("utf-16-le")
+
+
+def _install_fake_olefile(monkeypatch, streams: dict[str, bytes]) -> None:
+    class FakeOleFileIO:
+        def __init__(self, _file_stream):
+            self._streams = streams
+
+        def exists(self, stream_path: str) -> bool:
+            return stream_path in self._streams
+
+        def openstream(self, stream_path: str) -> BytesIO:
+            return BytesIO(self._streams[stream_path])
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(outlook_msg_converter, "_dependency_exc_info", None)
+    monkeypatch.setattr(
+        outlook_msg_converter,
+        "olefile",
+        SimpleNamespace(OleFileIO=FakeOleFileIO),
+    )
+
+
+def test_convert_prefers_html_body_when_present(monkeypatch):
+    _install_fake_olefile(
+        monkeypatch,
+        {
+            "__substg1.0_0C1F001F": _utf16_stream("sender@example.com"),
+            "__substg1.0_0E04001F": _utf16_stream("recipient@example.com"),
+            "__substg1.0_0037001F": _utf16_stream("HTML table email"),
+            "__substg1.0_1000001F": _utf16_stream("plain fallback body"),
+            "__substg1.0_10130102": (
+                b"<html><body><p>Summary</p><table><tr><th>Name</th><th>Value</th></tr>"
+                b"<tr><td>Alpha</td><td>1</td></tr></table></body></html>"
+            ),
+        },
+    )
+
+    result = OutlookMsgConverter().convert(
+        BytesIO(b"fake msg payload"),
+        StreamInfo(extension=".msg", mimetype="application/vnd.ms-outlook"),
+    )
+
+    assert result.title == "HTML table email"
+    assert "**Subject:** HTML table email" in result.markdown
+    assert "Summary" in result.markdown
+    assert "| Name | Value |" in result.markdown
+    assert "| Alpha | 1 |" in result.markdown
+    assert "plain fallback body" not in result.markdown
+
+
+def test_convert_falls_back_to_plain_text_body(monkeypatch):
+    _install_fake_olefile(
+        monkeypatch,
+        {
+            "__substg1.0_0037001F": _utf16_stream("Plain text email"),
+            "__substg1.0_1000001F": _utf16_stream("plain text body"),
+        },
+    )
+
+    result = OutlookMsgConverter().convert(
+        BytesIO(b"fake msg payload"),
+        StreamInfo(extension=".msg", mimetype="application/vnd.ms-outlook"),
+    )
+
+    assert result.title == "Plain text email"
+    assert "plain text body" in result.markdown


### PR DESCRIPTION
Closes #1567

## Summary
- prefer the Outlook HTML body streams when converting `.msg` files
- run HTML bodies through the existing HTML-to-Markdown path so tables stay tables
- fall back to the plain-text body when no HTML body is available
- add regression coverage for both the HTML-body and plain-text fallback paths

## Testing
- `hatch test tests/test_outlook_msg_converter.py 'tests/test_module_vectors.py::test_guess_stream_info[test_vector4]' 'tests/test_module_vectors.py::test_convert_local[test_vector4]' 'tests/test_module_vectors.py::test_convert_stream_with_hints[test_vector4]' 'tests/test_module_vectors.py::test_convert_stream_without_hints[test_vector4]' 'tests/test_module_vectors.py::test_convert_file_uri[test_vector4]' 'tests/test_module_vectors.py::test_convert_data_uri[test_vector4]'`\n- `uvx black --check packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py packages/markitdown/tests/test_outlook_msg_converter.py`\n- `hatch run types:check src/markitdown/converters/_outlook_msg_converter.py tests/test_outlook_msg_converter.py`