### PR TITLE
docs: quote extras install commands in package README

### DIFF
--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -10,7 +10,7 @@
 From PyPI:
 
 ```bash
-pip install markitdown[all]
+pip install 'markitdown[all]'
 ```
 
 From source:
@@ -18,7 +18,7 @@ From source:
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e packages/markitdown[all]
+pip install -e 'packages/markitdown[all]'
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- quote the extras install command in `packages/markitdown/README.md` so the PyPI page shows a shell-safe example
- quote the editable install example for consistency

## Verification
- updated the package README examples
- ran a small verification script to confirm the quoted commands are present and the unquoted forms are gone

Fixes #1574