### PR TITLE
fix: add quotes to pip install commands in package README

### DIFF
--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -10,7 +10,7 @@
 From PyPI:
 
 ```bash
-pip install markitdown[all]
+pip install 'markitdown[all]'
 ```
 
 From source:
@@ -18,7 +18,7 @@ From source:
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e packages/markitdown[all]
+pip install -e 'packages/markitdown[all]'
 ```
 
 ## Usage


### PR DESCRIPTION
The install commands without quotes fail in some shells (e.g., zsh). Using quoted version 'markitdown[all]' works universally.

Closes #1574