### PR TITLE
docs: clarify OCR requires markitdown-ocr plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MarkItDown currently supports the conversion from:
 - PowerPoint
 - Word
 - Excel
-- Images (EXIF metadata and OCR)
+- Images (EXIF metadata and OCR — requires `markitdown-ocr` plugin)
 - Audio (EXIF metadata and speech transcription)
 - HTML
 - Text-based formats (CSV, JSON, XML)
@@ -161,6 +161,14 @@ print(result.text_content)
 ```
 
 If no `llm_client` is provided the plugin still loads, but OCR is silently skipped and the standard built-in converter is used instead.
+
+**CLI Usage:**
+
+```bash
+pip install markitdown-ocr
+export OPENAI_API_KEY="your-api-key"
+markitdown --use-plugins document_with_images.pdf -o document.md
+```
 
 See [`packages/markitdown-ocr/README.md`](packages/markitdown-ocr/README.md) for detailed documentation.
 


### PR DESCRIPTION
## Summary
This PR addresses issue #1601: OCR is not working for PDFs with embedded images.

The README currently lists "Images (EXIF metadata and OCR)" as a built-in feature, but OCR for PDFs actually requires the separate `markitdown-ocr` plugin to be installed and configured.

## Changes
- Updated feature list to clarify OCR requires `markitdown-ocr` plugin
- Added CLI usage example for the OCR plugin
- Addresses the confusion reported in issue #1601

## Testing
- [x] Documentation builds correctly
- [x] CLI example added matches plugin documentation