### PR TITLE
docs: add MiniMax as OpenAI-compatible provider (M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ result = md.convert("example.jpg")
 print(result.text_content)
 ```
 
+Any OpenAI-compatible client works. For example, to use [MiniMax](https://www.minimaxi.com):
+
+```python
+from markitdown import MarkItDown
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="YOUR_MINIMAX_API_KEY",
+    base_url="https://api.minimax.io/v1",
+)
+md = MarkItDown(llm_client=client, llm_model="MiniMax-M2.5")
+result = md.convert("example.jpg")
+print(result.text_content)
+```
+
 ### Docker
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ client = OpenAI(
     api_key="YOUR_MINIMAX_API_KEY",
     base_url="https://api.minimax.io/v1",
 )
-md = MarkItDown(llm_client=client, llm_model="MiniMax-M2.5")
+md = MarkItDown(llm_client=client, llm_model="MiniMax-M2.7")
 result = md.convert("example.jpg")
 print(result.text_content)
 ```

--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ client = OpenAI(
     api_key="YOUR_MINIMAX_API_KEY",
     base_url="https://api.minimax.io/v1",
 )
-md = MarkItDown(llm_client=client, llm_model="MiniMax-M2.7")
+# Default to MiniMax-M3 (latest flagship); "MiniMax-M2.7" is also supported.
+md = MarkItDown(llm_client=client, llm_model="MiniMax-M3")
 result = md.convert("example.jpg")
 print(result.text_content)
 ```

--- a/packages/markitdown-ocr/README.md
+++ b/packages/markitdown-ocr/README.md
@@ -83,6 +83,21 @@ md = MarkItDown(
 )
 ```
 
+Or with [MiniMax](https://www.minimaxi.com):
+
+```python
+from openai import OpenAI
+
+md = MarkItDown(
+    enable_plugins=True,
+    llm_client=OpenAI(
+        api_key="YOUR_MINIMAX_API_KEY",
+        base_url="https://api.minimax.io/v1",
+    ),
+    llm_model="MiniMax-M2.5",
+)
+```
+
 ## How It Works
 
 When `MarkItDown(enable_plugins=True, llm_client=..., llm_model=...)` is called:

--- a/packages/markitdown-ocr/README.md
+++ b/packages/markitdown-ocr/README.md
@@ -94,7 +94,7 @@ md = MarkItDown(
         api_key="YOUR_MINIMAX_API_KEY",
         base_url="https://api.minimax.io/v1",
     ),
-    llm_model="MiniMax-M2.5",
+    llm_model="MiniMax-M2.7",
 )
 ```
 

--- a/packages/markitdown-ocr/README.md
+++ b/packages/markitdown-ocr/README.md
@@ -94,7 +94,8 @@ md = MarkItDown(
         api_key="YOUR_MINIMAX_API_KEY",
         base_url="https://api.minimax.io/v1",
     ),
-    llm_model="MiniMax-M2.7",
+    # Default to MiniMax-M3 (latest flagship); "MiniMax-M2.7" is also supported.
+    llm_model="MiniMax-M3",
 )
 ```
 


### PR DESCRIPTION
## Summary
Add MiniMax as an OpenAI-compatible provider example in documentation, defaulting to the latest MiniMax-M3 model.

## Changes
- Add MiniMax provider example to main README
- Add MiniMax provider example to markitdown-ocr README
- Default to MiniMax-M3 (latest flagship); MiniMax-M2.7 is also supported

## Why
MiniMax provides an OpenAI-compatible API, making it a drop-in alternative. MiniMax-M3 is the latest flagship model (512K context window, 128K max output, image input support).

## Testing
- Documentation-only change, no code modifications