### PR TITLE
fix: initialize res = None to prevent UnboundLocalError (#81)

### DIFF
--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -10,7 +10,7 @@
 From PyPI:
 
 ```bash
-pip install markitdown[all]
+pip install 'markitdown[all]'
 ```
 
 From source:
@@ -18,7 +18,7 @@ From source:
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e packages/markitdown[all]
+pip install -e 'packages/markitdown[all]'
 ```
 
 ## Usage

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -601,6 +601,7 @@ class MarkItDown:
                 ), f"{type(converter).__name__}.accept() should NOT change the file_stream position"
 
                 # Attempt the conversion
+                res = None
                 if _accepts:
                     try:
                         res = converter.convert(file_stream, stream_info, **_kwargs)


### PR DESCRIPTION
## Summary

Fixes issue #81 - UnboundLocalError: local variable 'res' referenced before assignment

When `converter.accepts()` returns False, the `res` variable is never assigned, causing an UnboundLocalError when checking `if res is not None`.

## Fix

Initialize `res = None` before the conversion attempt, ensuring the variable is always defined.

## Testing

This fix prevents the UnboundLocalError by ensuring `res` is initialized to `None` before the conditional block that assigns it.