### PR TITLE
fix (docs): correct typos

### DIFF
--- a/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
+++ b/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
@@ -33,7 +33,7 @@ def register_converters(markitdown: MarkItDown, **kwargs):
 
 class RtfConverter(DocumentConverter):
     """
-    Converts an RTF file to in the simplest possible way.
+    Converts an RTF file in the simplest possible way.
     """
 
     def accepts(
@@ -60,7 +60,7 @@ class RtfConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,
     ) -> DocumentConverterResult:
-        # Read the file stream into an str using hte provided charset encoding, or using the system default
+        # Read the file stream into a str using the provided charset encoding, or using the system default
         encoding = stream_info.charset or locale.getpreferredencoding()
         stream_data = file_stream.read().decode(encoding)
 

--- a/packages/markitdown-sample-plugin/tests/test_sample_plugin.py
+++ b/packages/markitdown-sample-plugin/tests/test_sample_plugin.py
@@ -13,7 +13,7 @@ RTF_TEST_STRINGS = {
 
 
 def test_converter() -> None:
-    """Tests the RTF converter dirctly."""
+    """Tests the RTF converter directly."""
     with open(os.path.join(TEST_FILES_DIR, "test.rtf"), "rb") as file_stream:
         converter = RtfConverter()
         result = converter.convert(

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -51,7 +51,7 @@ class DocumentConverter:
         """
         Return a quick determination on if the converter should attempt converting the document.
         This is primarily based `stream_info` (typically, `stream_info.mimetype`, `stream_info.extension`).
-        In cases where the data is retrieved via HTTP, the `steam_info.url` might also be referenced to
+        In cases where the data is retrieved via HTTP, the `stream_info.url` might also be referenced to
         make a determination (e.g., special converters for Wikipedia, YouTube etc).
         Finally, it is conceivable that the `stream_info.filename` might be used to in cases
         where the filename is well-known (e.g., `Dockerfile`, `Makefile`, etc)
@@ -71,7 +71,7 @@ class DocumentConverter:
 
         Parameters:
         - file_stream: The file-like object to convert. Must support seek(), tell(), and read() methods.
-        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, set)
+        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset)
         - kwargs: Additional keyword arguments for the converter.
 
         Returns:
@@ -92,7 +92,7 @@ class DocumentConverter:
 
         Parameters:
         - file_stream: The file-like object to convert. Must support seek(), tell(), and read() methods.
-        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, set)
+        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset)
         - kwargs: Additional keyword arguments for the converter.
 
         Returns:

--- a/packages/markitdown/src/markitdown/_exceptions.py
+++ b/packages/markitdown/src/markitdown/_exceptions.py
@@ -41,7 +41,7 @@ class UnsupportedFormatException(MarkItDownException):
 
 class FailedConversionAttempt(object):
     """
-    Represents an a single attempt to convert a file.
+    Represents a single attempt to convert a file.
     """
 
     def __init__(self, converter: Any, exc_info: Optional[tuple] = None):

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -580,7 +580,7 @@ class MarkItDown:
                 # Add the list of converters for nested processing
                 _kwargs["_parent_converters"] = self._converters
 
-                # Add legaxy kwargs
+                # Add legacy kwargs
                 if stream_info is not None:
                     if stream_info.extension is not None:
                         _kwargs["file_extension"] = stream_info.extension
@@ -631,7 +631,7 @@ class MarkItDown:
         )
 
     def register_page_converter(self, converter: DocumentConverter) -> None:
-        """DEPRECATED: User register_converter instead."""
+        """DEPRECATED: Use register_converter instead."""
         warn(
             "register_page_converter is deprecated. Use register_converter instead.",
             DeprecationWarning,

--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -207,7 +207,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
     def _analysis_features(self, stream_info: StreamInfo) -> List[str]:
         """
         Helper needed to determine which analysis features to use.
-        Certain document analysis features are not availiable for
+        Certain document analysis features are not available for
         office filetypes (.xlsx, .pptx, .html, .docx)
         """
         mimetype = (stream_info.mimetype or "").lower()

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -30,7 +30,7 @@ ACCEPTED_FILE_EXTENSIONS = [".docx"]
 
 class DocxConverter(HtmlConverter):
     """
-    Converts DOCX files to Markdown. Style information (e.g.m headings) and tables are preserved where possible.
+    Converts DOCX files to Markdown. Style information (e.g., headings) and tables are preserved where possible.
     """
 
     def __init__(self):

--- a/packages/markitdown/src/markitdown/converters/_epub_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_epub_converter.py
@@ -25,7 +25,7 @@ MIME_TYPE_MAPPING = {
 
 class EpubConverter(HtmlConverter):
     """
-    Converts EPUB files to Markdown. Style information (e.g.m headings) and tables are preserved where possible.
+    Converts EPUB files to Markdown. Style information (e.g., headings) and tables are preserved where possible.
     """
 
     def __init__(self):

--- a/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
@@ -54,7 +54,7 @@ class OutlookMsgConverter(DocumentConverter):
         finally:
             file_stream.seek(cur_pos)
 
-        # Brue force, check if it's an Outlook file
+        # Brute force, check if it's an Outlook file
         try:
             if olefile is not None:
                 msg = olefile.OleFileIO(file_stream)

--- a/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
+++ b/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
@@ -24,7 +24,7 @@ def transcribe_audio(file_stream: BinaryIO, *, audio_format: str = "wav") -> str
     # Check for installed dependencies
     if _dependency_exc_info is not None:
         raise MissingDependencyException(
-            "Speech transcription requires installing MarkItdown with the [audio-transcription] optional dependencies. E.g., `pip install markitdown[audio-transcription]` or `pip install markitdown[all]`"
+            "Speech transcription requires installing MarkItDown with the [audio-transcription] optional dependencies. E.g., `pip install markitdown[audio-transcription]` or `pip install markitdown[all]`"
         ) from _dependency_exc_info[
             1
         ].with_traceback(  # type: ignore[union-attr]

--- a/packages/markitdown/tests/test_cli_vectors.py
+++ b/packages/markitdown/tests/test_cli_vectors.py
@@ -27,7 +27,7 @@ TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 TEST_FILES_URL = "https://raw.githubusercontent.com/microsoft/markitdown/refs/heads/main/packages/markitdown/tests/test_files"
 
 
-# Prepare CLI test vectors (remove vectors that require mockig the url)
+# Prepare CLI test vectors (remove vectors that require mocking the url)
 CLI_TEST_VECTORS: List[FileTestVector] = []
 for test_vector in GENERAL_TEST_VECTORS:
     if test_vector.url is not None:
@@ -96,7 +96,7 @@ def test_output_to_file(shared_tmp_dir, test_vector) -> None:
 
 @pytest.mark.parametrize("test_vector", CLI_TEST_VECTORS)
 def test_input_from_stdin_without_hints(shared_tmp_dir, test_vector) -> None:
-    """Test that the CLI readds from stdin correctly."""
+    """Test that the CLI reads from stdin correctly."""
 
     test_input = b""
     with open(os.path.join(TEST_FILES_DIR, test_vector.filename), "rb") as stream:

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -126,7 +126,7 @@ def test_stream_info_operations() -> None:
             **{keyword: f"{keyword}.2"}
         )
 
-        # Make sure the targted attribute is updated
+        # Make sure the targeted attribute is updated
         assert getattr(updated_stream_info, keyword) == f"{keyword}.2"
 
         # Make sure the other attributes are unchanged
@@ -143,7 +143,7 @@ def test_stream_info_operations() -> None:
             StreamInfo(**{keyword: f"{keyword}.2"})
         )
 
-        # Make sure the targted attribute is updated
+        # Make sure the targeted attribute is updated
         assert getattr(updated_stream_info, keyword) == f"{keyword}.2"
 
         # Make sure the other attributes are unchanged


### PR DESCRIPTION
## Summary

Fix typos, grammatical errors, and minor code issues across comments, docstrings, and error messages. No behavioral changes.

## Changes

### Typo fixes

| File | Line | Before | After |
|------|------|--------|-------|
| `_base_converter.py` | 54 | `steam_info.url` | `stream_info.url` |
| `_base_converter.py` | 74, 95 | `(mimetype, extension, charset, set)` | `(mimetype, extension, charset)` |
| `_markitdown.py` | 583 | `# Add legaxy kwargs` | `# Add legacy kwargs` |
| `_markitdown.py` | 634 | `User register_converter` | `Use register_converter` |
| `_outlook_msg_converter.py` | 57 | `# Brue force` | `# Brute force` |
| `_exceptions.py` | 43 | `Represents an a single attempt` | `Represents a single attempt` |
| `_exceptions.py` | 72 | `provided no execution info` | `provided no exception info` |
| `_docx_converter.py` | 33 | `(e.g.m headings)` | `(e.g., headings)` |
| `_epub_converter.py` | 28 | `(e.g.m headings)` | `(e.g., headings)` |
| `_transcribe_audio.py` | 27 | `MarkItdown` | `MarkItDown` |
| `_doc_intel_converter.py` | 210 | `not availiable for` | `not available for` |
| `test_cli_vectors.py` | 30 | `require mockig the url` | `require mocking the url` |
| `test_cli_vectors.py` | 99 | `CLI readds from stdin` | `CLI reads from stdin` |
| `test_module_misc.py` | 129, 146 | `the targted attribute` | `the targeted attribute` |
| `test_sample_plugin.py` | 16 | `converter dirctly` | `converter directly` |

### Grammar fixes

| File | Line | Before | After |
|------|------|--------|-------|
| `_markitdown.py` | 250 | `Plugins converters are already enabled` | `Plugin converters are already enabled` |
| `_plugin.py` (sample) | 36 | `Converts an RTF file to in the simplest` | `Converts an RTF file in the simplest` |
| `_plugin.py` (sample) | 63 | `an str using hte provided` | `a str using the provided` |

### Inconsistency fixes

| File | Line | Before | After |
|------|------|--------|-------|
| `_markitdown.py` | 653 | `PRIORITY_SPECIFIC_FILE_FORMAT (== 10)` | `PRIORITY_GENERIC_FILE_FORMAT (== 10)` |
| `__main__.py` | 104 | `--use-plugin option` | `--use-plugins option` |
| `_exceptions.py` | 72 | double space after dash in error msg | single space (consistent with next line) |

### Code cleanup

| File | Description |
|------|-------------|
| `_plain_text_converter.py` | Removed unused `mammoth` import and `_dependency_exc_info` (copy-paste artifact from docx converter) |
| `_pptx_converter_with_ocr.py` | Removed duplicate `from typing import BinaryIO, Any, Optional` line |

## Files changed (15)

- `packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py`
- `packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py`
- `packages/markitdown-sample-plugin/tests/test_sample_plugin.py`
- `packages/markitdown/src/markitdown/__main__.py`
- `packages/markitdown/src/markitdown/_base_converter.py`
- `packages/markitdown/src/markitdown/_exceptions.py`
- `packages/markitdown/src/markitdown/_markitdown.py`
- `packages/markitdown/src/markitdown/converters/_doc_intel_converter.py`
- `packages/markitdown/src/markitdown/converters/_docx_converter.py`
- `packages/markitdown/src/markitdown/converters/_epub_converter.py`
- `packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py`
- `packages/markitdown/src/markitdown/converters/_plain_text_converter.py`
- `packages/markitdown/src/markitdown/converters/_transcribe_audio.py`
- `packages/markitdown/tests/test_cli_vectors.py`
- `packages/markitdown/tests/test_module_misc.py`