### PR TITLE
Fix PPTX conversion when LLM caption is None

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -124,13 +124,17 @@ class PptxConverter(DocumentConverter):
                                 model=llm_model,
                                 prompt=kwargs.get("llm_prompt"),
                             )
+                            if llm_description is None:
+                                llm_description = ""
                         except Exception:
                             # Unable to generate a description
                             pass
 
                     # Also grab any description embedded in the deck
                     try:
-                        alt_text = shape._element._nvXxPr.cNvPr.attrib.get("descr", "")
+                        alt_text = (
+                            shape._element._nvXxPr.cNvPr.attrib.get("descr", "") or ""
+                        )
                     except Exception:
                         # Unable to get alt text
                         pass

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -456,6 +456,21 @@ def test_markitdown_llm_parameters() -> None:
     assert messages[0]["content"][0]["text"] == test_prompt
 
 
+def test_markitdown_pptx_none_llm_description(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PPTX conversion should handle null LLM captions without raising TypeError."""
+
+    monkeypatch.setattr(
+        "markitdown.converters._pptx_converter.llm_caption",
+        lambda *args, **kwargs: None,
+    )
+
+    markitdown = MarkItDown(llm_client=MagicMock(), llm_model="gpt-4o")
+    result = markitdown.convert(os.path.join(TEST_FILES_DIR, "test.pptx"))
+
+    # Conversion should succeed and still include regular PPTX-derived content.
+    validate_strings(result, PPTX_TEST_STRINGS)
+
+
 @pytest.mark.skipif(
     skip_llm,
     reason="do not run llm tests without a key",


### PR DESCRIPTION
Summary
- Handle None returned by llm_caption in PptxConverter.
- Normalize embedded PPTX descr alt text to a string before joining.
- Add regression test for PPTX conversion with llm_caption mocked to return None.

Why
Issue #1534 reports a TypeError in PPTX conversion when an LLM returns None for image captioning.

Testing
- .venv/bin/pytest packages/markitdown/tests/test_module_misc.py::test_markitdown_pptx_none_llm_description packages/markitdown/tests/test_module_misc.py::test_markitdown_llm_parameters -q