### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ cd markitdown
 pip install -e 'packages/markitdown[all]'
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/microsoft-markitdown).
+
 ## Usage
 
 ### Command-Line


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/microsoft-markitdown).