### PR TITLE
Clarify plugin-first OCR extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ markitdown --use-plugins path-to-file.pdf
 
 To find available plugins, search GitHub for the hashtag `#markitdown-plugin`. To develop a plugin, see `packages/markitdown-sample-plugin`.
 
+Plugins are the recommended extension path for optional or backend-specific functionality, especially when an extension:
+
+- adds non-default dependencies
+- depends on external services or model runtimes
+- changes converter behavior only for opt-in users
+
 #### markitdown-ocr Plugin
 
 The `markitdown-ocr` plugin adds OCR support to PDF, DOCX, PPTX, and XLSX converters, extracting text from embedded images using LLM Vision — the same `llm_client` / `llm_model` pattern that MarkItDown already uses for image descriptions. No new ML libraries or binary dependencies required.
@@ -143,7 +149,7 @@ pip install markitdown-ocr
 pip install openai  # or any OpenAI-compatible client
 ```
 
-**Usage:**
+**Usage (Python API):**
 
 Pass the same `llm_client` and `llm_model` you would use for image descriptions:
 

--- a/packages/markitdown-ocr/README.md
+++ b/packages/markitdown-ocr/README.md
@@ -26,12 +26,6 @@ pip install openai
 
 ## Usage
 
-### Command Line
-
-```bash
-markitdown document.pdf --use-plugins --llm-client openai --llm-model gpt-4o
-```
-
 ### Python API
 
 Pass `llm_client` and `llm_model` to `MarkItDown()` exactly as you would for image descriptions:
@@ -51,6 +45,12 @@ print(result.text_content)
 ```
 
 If no `llm_client` is provided the plugin still loads, but OCR is silently skipped — falling back to the standard built-in converter.
+
+### Command Line
+
+MarkItDown's built-in CLI can enable installed plugins with `--use-plugins`, but it does not currently construct Python client objects such as `OpenAI()` for you.
+
+For that reason, this plugin is primarily configured through the Python API shown above, where you can pass `llm_client` and `llm_model` directly to `MarkItDown(...)`.
 
 ### Custom Prompt
 
@@ -99,6 +99,8 @@ When a file is converted:
 3. Each image is sent to the LLM with an extraction prompt
 4. The returned text is inserted inline, preserving document structure
 5. If the LLM call fails, conversion continues without that image's text
+
+This plugin is one example of the broader plugin-first extension model in MarkItDown: backend-specific OCR or document-processing logic can live in separately installed packages without changing the default core behavior.
 
 ## Supported File Formats
 

--- a/packages/markitdown-sample-plugin/README.md
+++ b/packages/markitdown-sample-plugin/README.md
@@ -71,6 +71,8 @@ sample_plugin = "markitdown_sample_plugin"
 
 Here, the value of `sample_plugin` can be any key, but should ideally be the name of the plugin. The value is the fully qualified name of the package implementing the plugin.
 
+If your plugin needs optional configuration, you can also read additional keyword arguments passed through `MarkItDown(enable_plugins=True, **kwargs)` from `register_converters(markitdown, **kwargs)`.
+
 
 ## Installation
 


### PR DESCRIPTION
## Summary

This PR makes the plugin extension path clearer in the documentation, especially for OCR-related integrations.

It focuses on three small documentation improvements:

- clarify in the main README that plugins are the recommended path for optional or backend-specific functionality
- update the `markitdown-ocr` README so its usage guidance matches the current product surface more closely
- document in the sample plugin README that plugins can read optional keyword arguments from `register_converters(markitdown, **kwargs)`

## Problem

While exploring OCR extension paths, I found a few places where the current docs can be read as more permissive or more direct than the current implementation actually is:

- the main README does not explicitly say when plugin-first is the preferred extension model
- the `markitdown-ocr` README includes a CLI example that suggests the built-in CLI can fully configure an LLM client for the plugin
- the sample plugin docs do not explicitly mention that plugin authors can read optional kwargs passed through `MarkItDown(enable_plugins=True, **kwargs)`

These are small issues, but together they make it harder to understand how third-party OCR or backend-specific extensions should be integrated.

## What this PR changes

### Main README

Adds a short note in the Plugins section explaining that plugins are the recommended extension path when an extension:

- adds non-default dependencies
- depends on external services or model runtimes
- changes converter behavior only for opt-in users

### `packages/markitdown-ocr/README.md`

- removes the command-line example that could be interpreted as fully configuring an LLM-backed plugin via the built-in CLI
- clarifies that the plugin is primarily configured through the Python API, where `llm_client` and `llm_model` can be passed directly
- adds a short sentence positioning the OCR package as an example of the broader plugin-first extension model

### `packages/markitdown-sample-plugin/README.md`

Adds a short note that plugin authors can read optional configuration from `register_converters(markitdown, **kwargs)`.

## Non-goals

This PR does not:

- change any runtime behavior
- add new plugin APIs
- add any new dependencies
- add or integrate any provider-specific OCR backend

## Why this design

I kept this PR documentation-only to make the current extension model easier to understand without changing behavior.

## Backward compatibility

No behavior changes. Documentation only.

## Related context

Related discussion: #1650
