### PR TITLE
fix: handle None sys.stdout.encoding in CLI output

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -206,11 +206,11 @@ def _handle_output(args, result: DocumentConverterResult):
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(result.markdown)
     else:
-        # Handle stdout encoding errors more gracefully
+        # Handle stdout encoding errors more gracefully, with fallback for
+        # cases where sys.stdout.encoding is None (e.g. redirected streams).
+        encoding = sys.stdout.encoding or "utf-8"
         print(
-            result.markdown.encode(sys.stdout.encoding, errors="replace").decode(
-                sys.stdout.encoding
-            )
+            result.markdown.encode(encoding, errors="replace").decode(encoding)
         )
 
 


### PR DESCRIPTION
Fixes #1597

## Problem

When `sys.stdout.encoding` is `None` (e.g. when stdout is replaced with a
raw binary stream, or in certain CI/redirected environments), the current
`_handle_output` code in `__main__.py` calls:

```python
result.markdown.encode(sys.stdout.encoding, errors="replace")
```

This raises `TypeError: encode() argument 'encoding' must be str, not None`
instead of the expected `UnicodeEncodeError`, making the CLI crash with an
unhelpful error.

## Solution

Fall back to `"utf-8"` when `sys.stdout.encoding` is `None`:

```python
encoding = sys.stdout.encoding or "utf-8"
print(result.markdown.encode(encoding, errors="replace").decode(encoding))
```

The existing `errors="replace"` handling is preserved, so non-UTF-8
terminals (e.g. Windows cp1252) still work correctly.

## Testing

Manually verified that the existing `errors="replace"` path continues to
work, and that the `None` fallback is triggered correctly:

```python
import sys
enc = None
# Before: raises TypeError
# After: falls back to utf-8 safely
encoding = enc or "utf-8"
print("test \uff89".encode(encoding, errors="replace").decode(encoding))
```