### PR TITLE
fix: handle missing m:t text in OMML math runs (fixes #1512)

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -373,7 +373,7 @@ class oMath2Latex(Tag2Method):
         @todo \text (latex pure text support)
         """
         _str = []
-        for s in elm.findtext("./{0}t".format(OMML_NS)):
+        for s in (elm.findtext("./{0}t".format(OMML_NS)) or ""):
             # s = s if isinstance(s,unicode) else unicode(s,'utf-8')
             _str.append(self._t_dict.get(s, s))
         return escape_latex(BLANK.join(_str))

--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -1,9 +1,12 @@
+import logging
 import zipfile
 from io import BytesIO
 from typing import BinaryIO
 from xml.etree import ElementTree as ET
 
 from bs4 import BeautifulSoup, Tag
+
+logger = logging.getLogger(__name__)
 
 from .math.omml import OMML_NS, oMath2Latex
 
@@ -109,9 +112,15 @@ def _pre_process_math(content: bytes) -> bytes:
     """
     soup = BeautifulSoup(content.decode(), features="xml")
     for tag in soup.find_all("oMathPara"):
-        _replace_equations(tag)
+        try:
+            _replace_equations(tag)
+        except Exception:
+            logger.warning("Failed to convert oMathPara equation to LaTeX", exc_info=True)
     for tag in soup.find_all("oMath"):
-        _replace_equations(tag)
+        try:
+            _replace_equations(tag)
+        except Exception:
+            logger.warning("Failed to convert oMath equation to LaTeX", exc_info=True)
     return str(soup).encode()
 
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -274,6 +274,28 @@ def test_docx_equations() -> None:
     assert block_equations, "No block equations found in the document."
 
 
+def test_docx_equations_omit_empty_run() -> None:
+    """Regression test: m:r elements without m:t child must not crash the
+    OMML-to-LaTeX conversion and must not cause other equations to be lost."""
+    from markitdown.converter_utils.docx.pre_process import _pre_process_math
+
+    # An oMath with one formatting-only m:r (no m:t) followed by a normal m:r
+    content = (
+        b'<?xml version="1.0" encoding="UTF-8"?>'
+        b'<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+        b'            xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">'
+        b"<w:body><w:p>"
+        b"<m:oMath>"
+        b"  <m:r><m:rPr><m:sty m:val=\"bi\"/></m:rPr></m:r>"
+        b"  <m:r><m:t>x</m:t></m:r>"
+        b"</m:oMath>"
+        b"</w:p></w:body></w:document>"
+    )
+    result = _pre_process_math(content).decode()
+    # The equation should be present and wrapped in $ signs
+    assert "$x$" in result
+
+
 def test_input_as_strings() -> None:
     markitdown = MarkItDown()
 


### PR DESCRIPTION
Fixes #1512

## Problem

When converting a DOCX file with mathematical equations, if any `m:r` element inside an `oMath` block has no `m:t` child (for example, a formatting-only run containing only `m:rPr`), `ElementTree.findtext()` returns `None`. The `do_r` method in `omml.py` then does:

```python
for s in elm.findtext("./{ns}t".format(...)):  # iterates over None → TypeError
```

This `TypeError` propagates up through `_pre_process_math` → `pre_process_docx`, where a file-level `try/except` catches it and falls back to the raw, unmodified DOCX XML. Since mammoth cannot render OMML markup, **all equations in the document silently disappear** from the converted markdown output.

## Solution

1. **`omml.py` — `do_r`**: use `(elm.findtext(...) or "")` so an absent `m:t` element yields an empty string instead of crashing.

2. **`pre_process.py` — `_pre_process_math`**: wrap each individual equation replacement in its own `try/except` with a warning log. This means a single un-convertible equation no longer causes every other equation in the document to be lost.

## Testing

- Existing `test_docx_equations` continues to pass.
- New regression test `test_docx_equations_omit_empty_run` directly exercises an `m:r` with only `m:rPr` (no `m:t`) and asserts that the surrounding equation is still converted to `$x$`.