### PR TITLE
fix: update default Document Intelligence API version to 2024-11-30

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -134,7 +134,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
         self,
         *,
         endpoint: str,
-        api_version: str = "2024-07-31-preview",
+        api_version: str = "2024-11-30",
         credential: AzureKeyCredential | TokenCredential | None = None,
         file_types: List[DocumentIntelligenceFileType] = [
             DocumentIntelligenceFileType.DOCX,
@@ -152,7 +152,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         Args:
             endpoint (str): The endpoint for the Document Intelligence service.
-            api_version (str): The API version to use. Defaults to "2024-07-31-preview".
+            api_version (str): The API version to use. Defaults to "2024-11-30".
             credential (AzureKeyCredential | TokenCredential | None): The credential to use for authentication.
             file_types (List[DocumentIntelligenceFileType]): The file types to accept. Defaults to all supported file types.
         """


### PR DESCRIPTION
Fixes #1473

## Problem

The default `api_version` in `DocumentIntelligenceConverter` was hardcoded to `"2024-07-31-preview"`, which is an outdated preview version that is **not compatible** with Azure AI Foundry Document Intelligence service endpoints.

The Azure AI Document Intelligence SDK's own default is `"2024-11-30"`, but markitdown was overriding it with the older preview version. This caused failures when users tried to use markitdown with Azure AI Foundry endpoints without explicitly specifying `docintel_api_version`.

## Solution

Update the default `api_version` from `"2024-07-31-preview"` to `"2024-11-30"` (the GA stable version). This version is compatible with both classic Azure Document Intelligence endpoints and Azure AI Foundry service endpoints.

## Testing

The change is a one-line default value update. Users who need the older preview version can still pass `docintel_api_version="2024-07-31-preview"` explicitly. No behavioral changes for users who already specify their api_version.