### PR TITLE
fix: handle None return from llm_caption in PptxConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -123,7 +123,7 @@ class PptxConverter(DocumentConverter):
                                 client=llm_client,
                                 model=llm_model,
                                 prompt=kwargs.get("llm_prompt"),
-                            )
+                            ) or ""
                         except Exception:
                             # Unable to generate a description
                             pass


### PR DESCRIPTION
Fixes #1534

## Problem

`llm_caption()` is typed as `Union[None, str]` and can return `None` in two cases:
- When base64 encoding of the image data fails (exception caught internally)
- When the LLM response's `message.content` is `None` (some models can return this)

After the `try/except` block, the code does:
```python
alt_text = "\n".join([llm_description, alt_text]) or shape.name
```

If `llm_description` is `None`, this raises:
```
TypeError: sequence item 0: expected str instance, NoneType found
```

## Solution

Add `or ""` to the `llm_caption()` call so that a `None` return value falls back to the initialized default of `""`:

```python
llm_description = llm_caption(...) or ""
```

This is a one-character change that makes the behavior consistent: whether `llm_caption` raises an exception (caught by `except`) or returns `None`, `llm_description` remains an empty string.

## Testing

The fix is minimal and targets the exact line reported in the issue. The downstream `str.join()` call now works correctly in all cases:
- LLM returns a caption string → used as-is
- LLM returns `None` → treated as empty string (same as exception path)
- LLM raises an exception → `llm_description` stays `""` (existing behavior)