### PR TITLE
feat: Add environment variable configuration for OCR service and image resize

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/__about__.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Contributors
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.1.0"
+__version__ = "0.1.1-resize"

--- a/packages/markitdown-ocr/src/markitdown_ocr/_ocr_service.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_ocr_service.py
@@ -4,10 +4,16 @@ Provides LLM Vision-based image text extraction.
 """
 
 import base64
-from typing import Any, BinaryIO
+import os
+from typing import Any, BinaryIO, Optional
 from dataclasses import dataclass
 
 from markitdown import StreamInfo
+
+# Environment variable names for OCR configuration
+OCR_API_KEY_ENV = "MARKITDOWN_OCR_API_KEY"
+OCR_API_BASE_ENV = "MARKITDOWN_OCR_API_BASE"
+OCR_MODEL_ENV = "MARKITDOWN_OCR_MODEL"
 
 
 @dataclass
@@ -44,6 +50,53 @@ class LLMVisionOCRService:
             "Return ONLY the extracted text, maintaining the original "
             "layout and order. Do not add any commentary or description."
         )
+
+    @classmethod
+    def from_env(cls, default_prompt: str | None = None) -> "LLMVisionOCRService":
+        """
+        Create LLMVisionOCRService from environment variables.
+
+        Required environment variables:
+            MARKITDOWN_OCR_API_KEY: API key for the OpenAI-compatible service
+            MARKITDOWN_OCR_MODEL: Model name (e.g., 'gpt-4o', 'gemini-2.0-flash')
+
+        Optional environment variables:
+            MARKITDOWN_OCR_API_BASE: API base URL (defaults to OpenAI's API)
+
+        Args:
+            default_prompt: Default prompt for OCR extraction
+
+        Returns:
+            LLMVisionOCRService instance
+
+        Raises:
+            ValueError: If required environment variables are not set
+        """
+        api_key = os.environ.get(OCR_API_KEY_ENV)
+        model = os.environ.get(OCR_MODEL_ENV)
+
+        if not api_key:
+            raise ValueError(
+                f"Missing required environment variable: {OCR_API_KEY_ENV}"
+            )
+        if not model:
+            raise ValueError(
+                f"Missing required environment variable: {OCR_MODEL_ENV}"
+            )
+
+        # Import OpenAI here to allow the module to load without it
+        try:
+            from openai import OpenAI
+        except ImportError:
+            raise ImportError(
+                "OpenAI package is required for LLMVisionOCRService. "
+                "Install it with: pip install openai"
+            )
+
+        api_base = os.environ.get(OCR_API_BASE_ENV)
+        client = OpenAI(api_key=api_key, base_url=api_base)
+
+        return cls(client=client, model=model, default_prompt=default_prompt)
 
     def extract_text(
         self,

--- a/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
@@ -4,6 +4,7 @@ Extracts images from PDFs and performs OCR while maintaining document context.
 """
 
 import io
+import os
 import sys
 from typing import Any, BinaryIO, Optional
 
@@ -25,9 +26,13 @@ except ImportError:
     _dependency_exc_info = sys.exc_info()
 
 
-def _extract_images_from_page(page: Any) -> list[dict]:
+def _extract_images_from_page(page: Any, max_dimension: int = 1500) -> list[dict]:
     """
     Extract images from a PDF page by rendering page regions.
+
+    Args:
+        page: PDF page object from pdfplumber
+        max_dimension: Maximum width/height for resized images (default: 1500)
 
     Returns:
         List of dicts with 'stream', 'bbox', 'name', 'y_pos' keys
@@ -73,6 +78,13 @@ def _extract_images_from_page(page: Any) -> list[dict]:
                         # Convert to RGB if needed (handle CMYK, etc.)
                         if pil_img.mode not in ("RGB", "L"):
                             pil_img = pil_img.convert("RGB")
+
+                        # Resize large images to reduce LLM Vision API load
+                        # Target: max 1500 pixels width/height (suitable for OCR)
+                        if pil_img.width > max_dimension or pil_img.height > max_dimension:
+                            scale = min(max_dimension / pil_img.width, max_dimension / pil_img.height)
+                            new_size = (int(pil_img.width * scale), int(pil_img.height * scale))
+                            pil_img = pil_img.resize(new_size, Image.LANCZOS)
 
                         # Save to stream as PNG
                         img_stream = io.BytesIO()
@@ -132,9 +144,19 @@ class PdfConverterWithOCR(DocumentConverter):
     Maintains document structure while extracting text from images inline.
     """
 
-    def __init__(self, ocr_service: Optional[LLMVisionOCRService] = None):
+    def __init__(
+        self,
+        ocr_service: Optional[LLMVisionOCRService] = None,
+        max_image_dimension: Optional[int] = None,
+    ):
         super().__init__()
         self.ocr_service = ocr_service
+        # Use provided value, or read from environment variable, or default to 1500
+        if max_image_dimension is None:
+            max_image_dimension = int(os.environ.get("MARKITDOWN_MAX_IMAGE_DIMENSION", "1500"))
+        if max_image_dimension <= 0:
+            raise ValueError("max_image_dimension must be a positive integer")
+        self.max_image_dimension = max_image_dimension
 
     def accepts(
         self,
@@ -310,25 +332,31 @@ class PdfConverterWithOCR(DocumentConverter):
 
         return DocumentConverterResult(markdown=markdown)
 
-    def _extract_page_images(self, pdf_bytes: io.BytesIO, page_num: int) -> list[dict]:
+    def _extract_page_images(
+        self, pdf_bytes: io.BytesIO, page_num: int, max_dimension: Optional[int] = None
+    ) -> list[dict]:
         """
         Extract images from a PDF page using pdfplumber.
 
         Args:
             pdf_bytes: PDF file as BytesIO
             page_num: Page number (1-indexed)
+            max_dimension: Maximum width/height for resized images (optional, uses instance default if not provided)
 
         Returns:
             List of image info dicts with 'stream', 'bbox', 'name', 'y_pos'
         """
         images = []
 
+        # Use provided max_dimension or fall back to instance default
+        dimension_limit = max_dimension if max_dimension is not None else self.max_image_dimension
+
         try:
             pdf_bytes.seek(0)
             with pdfplumber.open(pdf_bytes) as pdf:
                 if page_num <= len(pdf.pages):
                     page = pdf.pages[page_num - 1]  # 0-indexed
-                    images = _extract_images_from_page(page)
+                    images = _extract_images_from_page(page, dimension_limit)
         except Exception:
             pass
 

--- a/packages/markitdown-ocr/src/markitdown_ocr/_plugin.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_plugin.py
@@ -3,10 +3,16 @@ Plugin registration for markitdown-ocr.
 Registers OCR-enhanced converters with priority-based replacement strategy.
 """
 
+import os
 from typing import Any
 from markitdown import MarkItDown
 
-from ._ocr_service import LLMVisionOCRService
+from ._ocr_service import (
+    LLMVisionOCRService,
+    OCR_API_KEY_ENV,
+    OCR_API_BASE_ENV,
+    OCR_MODEL_ENV,
+)
 from ._pdf_converter_with_ocr import PdfConverterWithOCR
 from ._docx_converter_with_ocr import DocxConverterWithOCR
 from ._pptx_converter_with_ocr import PptxConverterWithOCR
@@ -25,10 +31,15 @@ def register_converters(markitdown: MarkItDown, **kwargs: Any) -> None:
     converters (which have priority 0.0), effectively replacing them when
     the plugin is enabled.
 
+    OCR service can be configured in three ways (in order of priority):
+    1. Explicit kwargs: llm_client, llm_model, llm_prompt
+    2. Environment variables: MARKITDOWN_OCR_API_KEY, MARKITDOWN_OCR_API_BASE, MARKITDOWN_OCR_MODEL
+    3. No OCR service (text-only extraction)
+
     Args:
         markitdown: MarkItDown instance to register converters with
         **kwargs: Additional keyword arguments that may include:
-            - llm_client: OpenAI-compatible client for LLM-based OCR (required for OCR to work)
+            - llm_client: OpenAI-compatible client for LLM-based OCR
             - llm_model: Model name (e.g., 'gpt-4o')
             - llm_prompt: Custom prompt for text extraction
     """
@@ -39,12 +50,21 @@ def register_converters(markitdown: MarkItDown, **kwargs: Any) -> None:
     llm_prompt = kwargs.get("llm_prompt")
 
     ocr_service: LLMVisionOCRService | None = None
+
+    # Priority 1: Use explicit kwargs if provided
     if llm_client and llm_model:
         ocr_service = LLMVisionOCRService(
             client=llm_client,
             model=llm_model,
             default_prompt=llm_prompt,
         )
+    # Priority 2: Try to create from environment variables
+    elif os.environ.get(OCR_API_KEY_ENV) and os.environ.get(OCR_MODEL_ENV):
+        try:
+            ocr_service = LLMVisionOCRService.from_env(default_prompt=llm_prompt)
+        except Exception:
+            # If environment config is incomplete or invalid, proceed without OCR
+            pass
 
     # Register converters with priority -1.0 (before built-ins at 0.0)
     # This effectively "replaces" the built-in converters when plugin is installed


### PR DESCRIPTION
feat: Add environment variable configuration for OCR service and image resize

- Add MARKITDOWN_OCR_API_KEY, MARKITDOWN_OCR_API_BASE, MARKITDOWN_OCR_MODEL env vars
- Add MARKITDOWN_MAX_IMAGE_DIMENSION env var for image resize control
- Add LLMVisionOCRService.from_env() class method to create service from env
- Update plugin to auto-configure OCR service from environment variables
- Add image resize logic to reduce LLM Vision API load (default max 1500px)
- Add design documentation for the resize feature
