### PR TITLE
docs: add note about ffmpeg dependency and RuntimeWarning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ MarkItDown currently supports the conversion from:
 - Excel
 - Images (EXIF metadata and OCR)
 - Audio (EXIF metadata and speech transcription)
+  - *Note: Audio conversion requires `ffmpeg` or `avconv` to be installed on your system. If not installed, you may see a `RuntimeWarning`.*
 - HTML
 - Text-based formats (CSV, JSON, XML)
 - ZIP files (iterates over contents)


### PR DESCRIPTION
**Subject:** docs: add note about `ffmpeg` dependency and `RuntimeWarning`

**Description:**
## What does this PR do?
This PR updates the `README.md` to clarify the system requirements for Audio transcription. 

Currently, `markitdown` triggers a `RuntimeWarning: Couldn't find ffmpeg or avconv...` when users run conversions on systems without `ffmpeg` installed (since `pydub` attempts to look for it). Adding a brief note about this dependency saves new users from confusion when they see this warning text in the terminal during general CLI usage.

## Changes
- Updated the list of supported formats in the `README.md` under the "Audio" section to mention `ffmpeg`/`avconv` prerequisites.
- Mentioned the `RuntimeWarning` directly so it can be easily found via search.

## Checklist
- [x] I have read the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [LICENSE](LICENSE) agreements.
- [x] I have run the `pre-commit` hooks locally to ensure formatting and linting pass.
- [x] Existing `tests` run successfully.
- [x] This is a documentation-only change; no new Python dependencies or code logic were introduced.