### PR TITLE
fix: suppress pydub RuntimeWarning when ffmpeg is not installed

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
+++ b/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
@@ -13,6 +13,7 @@ try:
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         warnings.filterwarnings("ignore", category=SyntaxWarning)
+        warnings.filterwarnings("ignore", message=".*ffmpeg.*", category=RuntimeWarning)
         import speech_recognition as sr
         import pydub
 except ImportError:


### PR DESCRIPTION
## Description

When `pydub` is imported on a system without `ffmpeg` or `avconv` in `PATH`, it emits a `RuntimeWarning` at import time — even when no audio conversion is being performed. This affects any user who has the `audio-transcription` extras installed.

The existing `warnings.catch_warnings()` block in `_transcribe_audio.py` already suppresses `DeprecationWarning` and `SyntaxWarning` on import, but `RuntimeWarning` was not covered.

## Fix

Extend the existing filter block with a targeted filter for pydub's ffmpeg warning:

\`\`\`python
warnings.filterwarnings("ignore", message=".*ffmpeg.*", category=RuntimeWarning)
\`\`\`

Using `message=".*ffmpeg.*"` keeps the scope narrow — only the specific "Couldn't find ffmpeg or avconv" warning is silenced, not all `RuntimeWarning`s. If ffmpeg is actually missing when audio conversion is attempted, pydub will raise a proper error at that point anyway.

## Related

Fixes #1685