### PR TITLE
fix: preserve underline formatting in DOCX to Markdown conversion

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -75,7 +75,16 @@ class DocxConverter(HtmlConverter):
                 _dependency_exc_info[2]
             )
 
-        style_map = kwargs.get("style_map", None)
+        # Default style map preserves underline formatting via HTML <u> tags,
+        # since Markdown has no native underline syntax. User-supplied style_map
+        # is appended so its rules take precedence over the defaults.
+        default_style_map = "u => u"
+        user_style_map = kwargs.get("style_map", None)
+        style_map = (
+            default_style_map + "\n" + user_style_map
+            if user_style_map
+            else default_style_map
+        )
         pre_process_stream = pre_process_docx(file_stream)
         return self._html_converter.convert_string(
             mammoth.convert_to_html(pre_process_stream, style_map=style_map).value,

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -122,5 +122,15 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             return "[x] " if el.has_attr("checked") else "[ ] "
         return ""
 
+    def convert_u(
+        self,
+        el: Any,
+        text: str,
+        convert_as_inline: Optional[bool] = False,
+        **kwargs,
+    ) -> str:
+        """Preserve underline formatting using HTML <u> tags (Markdown has no underline syntax)."""
+        return "<u>%s</u>" % text
+
     def convert_soup(self, soup: Any) -> str:
         return super().convert_soup(soup)  # type: ignore


### PR DESCRIPTION
## Summary

Closes #35

Underlined text in `.docx` files was silently dropped during conversion. Two things were missing:

- **Mammoth** was not configured to emit `<u>` HTML tags for underlined runs (it requires an explicit `style_map` rule)
- **`_CustomMarkdownify`** had no `convert_u` handler, so even if `<u>` tags arrived they would have been stripped

## Changes

- `_docx_converter.py`: Set `u => u` as the default Mammoth `style_map` so underlined runs are emitted as `<u>` elements. Any user-supplied `style_map` is appended and takes precedence.
- `_markdownify.py`: Add `convert_u` to `_CustomMarkdownify` that renders `<u>text</u>` inline HTML — the only way to express underline in CommonMark.

## Test plan

- [ ] Convert a `.docx` file containing underlined text and verify the output contains `<u>...</u>` wrapping the underlined spans
- [ ] Verify bold and italic text still convert correctly (`**bold**`, `*italic*`)
- [ ] Verify passing a custom `style_map` kwarg still works and takes precedence over the default
- [ ] Run the existing test suite: `hatch test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)