### PR TITLE
fix(markitdown-ocr): make PyMuPDF an optional dependency to fix AGPL licensing concern

### DIFF
--- a/packages/markitdown-ocr/README.md
+++ b/packages/markitdown-ocr/README.md
@@ -24,6 +24,28 @@ The plugin uses whatever OpenAI-compatible client you already have. Install one 
 pip install openai
 ```
 
+### Optional: Malformed PDF fallback (PyMuPDF)
+
+`markitdown-ocr` includes a fallback for PDFs that `pdfplumber` cannot open (e.g. truncated or malformed files). This fallback uses [PyMuPDF](https://pymupdf.readthedocs.io/) (`fitz`), which is licensed under **AGPL-3.0**. PyMuPDF is **not installed by default** to avoid imposing AGPL requirements on users who do not need it.
+
+To enable the malformed-PDF fallback:
+
+```bash
+pip install 'markitdown-ocr[pymupdf]'
+```
+
+Or install everything at once:
+
+```bash
+pip install 'markitdown-ocr[all]'
+```
+
+> **License notice:** Including `PyMuPDF` (via the `[pymupdf]` or `[all]` extras) adds an AGPL-3.0
+> dependency to your project. If you distribute software that links PyMuPDF, you must comply with
+> the AGPL — typically by making your application's source code available. See the
+> [PyMuPDF license](https://github.com/pymupdf/PyMuPDF?tab=AGPL-3.0-1-ov-file) for details.
+> If AGPL is incompatible with your project's license, install `markitdown-ocr` without this extra.
+
 ## Usage
 
 ### Command Line
@@ -188,7 +210,9 @@ Contributions are welcome! See the [MarkItDown repository](https://github.com/mi
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+`markitdown-ocr` itself is MIT licensed — see [LICENSE](LICENSE).
+
+**Dependency notice:** The optional `[pymupdf]` extra installs [PyMuPDF](https://github.com/pymupdf/PyMuPDF), which is **AGPL-3.0** licensed. Installing this extra is opt-in. If you do not install it, `markitdown-ocr` operates entirely under MIT-compatible licenses.
 
 ## Changelog
 

--- a/packages/markitdown-ocr/pyproject.toml
+++ b/packages/markitdown-ocr/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "markitdown>=0.1.0",
   "pdfminer.six>=20251230",
   "pdfplumber>=0.11.9",
-  "PyMuPDF>=1.24.0",
   "mammoth~=1.11.0",
   "python-docx",
   "python-pptx",
@@ -39,9 +38,19 @@ dependencies = [
 
 # llm_client is passed in by the user (same as for markitdown image descriptions);
 # install openai or any OpenAI-compatible SDK separately.
+#
+# NOTE: PyMuPDF (fitz) is AGPL-3.0 licensed. Install the [pymupdf] extra only
+# if you need fallback support for malformed PDFs and accept the AGPL terms.
 [project.optional-dependencies]
 llm = [
   "openai>=1.0.0",
+]
+pymupdf = [
+  "PyMuPDF>=1.24.0",
+]
+all = [
+  "openai>=1.0.0",
+  "PyMuPDF>=1.24.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #1675

## Problem

`markitdown-ocr` declared `PyMuPDF>=1.24.0` as a **required** dependency, but PyMuPDF is licensed under **AGPL-3.0**. Since the plugin itself is MIT-licensed, this mismatch was not disclosed anywhere. Any user who installed `markitdown-ocr` silently acquired an AGPL transitive dependency, which can affect the licensing requirements of applications that distribute the software.

PyMuPDF is only used in one place: a fallback path in `_pdf_converter_with_ocr.py` that handles malformed PDFs that `pdfplumber` cannot open (e.g. truncated EOF). This is an edge case, not the primary conversion path.

## Solution

- Move `PyMuPDF` from `dependencies` to an optional `[pymupdf]` extra in `pyproject.toml`
- Add an `[all]` convenience extra that bundles both `[llm]` and `[pymupdf]`
- Add a clear license notice in `README.md` explaining the AGPL implications and showing how to install with or without PyMuPDF

The existing `import fitz` call is already inside a `try/except`, so the fallback path degrades gracefully when PyMuPDF is not installed — no code changes needed.

## Testing

- `pip install markitdown-ocr` installs without PyMuPDF; standard PDF/DOCX/PPTX/XLSX conversion works normally
- `pip install 'markitdown-ocr[pymupdf]'` enables the malformed-PDF fallback
- `pip install 'markitdown-ocr[all]'` pulls in both openai and PyMuPDF extras