### PR TITLE
fix: Update Docker image references to mcp/markitdown

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -37,19 +37,24 @@ markitdown-mcp --http --host 127.0.0.1 --port 3001
 
 ## Running in Docker
 
-To run `markitdown-mcp` in Docker, build the Docker image using the provided Dockerfile:
+The `markitdown-mcp` Docker image is available on Docker Hub as `mcp/markitdown`:
 ```bash
-docker build -t markitdown-mcp:latest .
+docker pull mcp/markitdown
 ```
 
-And run it using:
+Run it using:
 ```bash
-docker run -it --rm markitdown-mcp:latest
+docker run -it --rm mcp/markitdown
 ```
 This will be sufficient for remote URIs. To access local files, you need to mount the local directory into the container. For example, if you want to access files in `/home/user/data`, you can run:
 
 ```bash
-docker run -it --rm -v /home/user/data:/workdir markitdown-mcp:latest
+docker run -it --rm -v /home/user/data:/workdir mcp/markitdown
+```
+
+Alternatively, you can build the Docker image locally using the provided Dockerfile:
+```bash
+docker build -t mcp/markitdown .
 ```
 
 Once mounted, all files under data will be accessible under `/workdir` in the container. For example, if you have a file `example.txt` in `/home/user/data`, it will be accessible in the container at `/workdir/example.txt`.
@@ -71,7 +76,7 @@ Edit it to include the following JSON entry:
         "run",
         "--rm",
         "-i",
-        "markitdown-mcp:latest"
+        "mcp/markitdown"
       ]
     }
   }
@@ -91,7 +96,7 @@ If you want to mount a directory, adjust it accordingly:
 	"-i",
 	"-v",
 	"/home/user/data:/workdir",
-	"markitdown-mcp:latest"
+	"mcp/markitdown"
       ]
     }
   }

--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -37,12 +37,12 @@ markitdown-mcp --http --host 127.0.0.1 --port 3001
 
 ## Running in Docker
 
-The `markitdown-mcp` Docker image is available on Docker Hub as `mcp/markitdown`:
+To run `markitdown-mcp` in Docker, build the Docker image using the provided Dockerfile:
 ```bash
-docker pull mcp/markitdown
+docker build -t mcp/markitdown .
 ```
 
-Run it using:
+And run it using:
 ```bash
 docker run -it --rm mcp/markitdown
 ```
@@ -52,12 +52,12 @@ This will be sufficient for remote URIs. To access local files, you need to moun
 docker run -it --rm -v /home/user/data:/workdir mcp/markitdown
 ```
 
-Alternatively, you can build the Docker image locally using the provided Dockerfile:
-```bash
-docker build -t mcp/markitdown .
-```
-
 Once mounted, all files under data will be accessible under `/workdir` in the container. For example, if you have a file `example.txt` in `/home/user/data`, it will be accessible in the container at `/workdir/example.txt`.
+
+Alternatively, you can pull the published Docker image directly from Docker Hub:
+```bash
+docker pull mcp/markitdown
+```
 
 ## Accessing from Claude Desktop
 


### PR DESCRIPTION
Noticed the [published image](https://hub.docker.com/r/mcp/markitdown) follows a different format, so thought it would be a good idea to align it, can also close if not relevant.