### PR TITLE
Fix multiple converter bugs: RSS crash, PPTX text loss, CSV pipes, Wikipedia regex, ExifTool encoding

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -57,8 +57,13 @@ class CsvConverter(DocumentConverter):
         # Create markdown table
         markdown_table = []
 
+        def escape_pipe(cell: str) -> str:
+            return cell.replace("|", "\\|")
+
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        markdown_table.append(
+            "| " + " | ".join(escape_pipe(cell) for cell in rows[0]) + " |"
+        )
 
         # Add separator row
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
@@ -70,7 +75,9 @@ class CsvConverter(DocumentConverter):
                 row.append("")
             # Truncate if row has more columns than header
             row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+            markdown_table.append(
+                "| " + " | ".join(escape_pipe(cell) for cell in row) + " |"
+            )
 
         result = "\n".join(markdown_table)
 

--- a/packages/markitdown/src/markitdown/converters/_exiftool.py
+++ b/packages/markitdown/src/markitdown/converters/_exiftool.py
@@ -1,5 +1,4 @@
 import json
-import locale
 import subprocess
 from typing import Any, BinaryIO, Union
 
@@ -45,8 +44,6 @@ def exiftool_metadata(
             text=False,
         ).stdout
 
-        return json.loads(
-            output.decode(locale.getpreferredencoding(False)),
-        )[0]
+        return json.loads(output.decode("utf-8"))[0]
     finally:
         file_stream.seek(cur_pos)

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -160,7 +160,7 @@ class PptxConverter(DocumentConverter):
                     md_content += self._convert_chart_to_markdown(shape.chart)
 
                 # Text areas
-                elif shape.has_text_frame:
+                if shape.has_text_frame:
                     if shape == title:
                         md_content += "# " + shape.text.lstrip() + "\n"
                     else:

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -143,8 +143,9 @@ class RssConverter(DocumentConverter):
         channel_title = self._get_data_by_tag_name(channel, "title")
         channel_description = self._get_data_by_tag_name(channel, "description")
         items = channel.getElementsByTagName("item")
+        md_text = ""
         if channel_title:
-            md_text = f"# {channel_title}\n"
+            md_text += f"# {channel_title}\n"
         if channel_description:
             md_text += f"{channel_description}\n"
         for item in items:

--- a/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
@@ -34,7 +34,7 @@ class WikipediaConverter(DocumentConverter):
         mimetype = (stream_info.mimetype or "").lower()
         extension = (stream_info.extension or "").lower()
 
-        if not re.search(r"^https?:\/\/[a-zA-Z]{2,3}\.wikipedia.org\/", url):
+        if not re.search(r"^https?:\/\/[a-zA-Z0-9-]+\.wikipedia\.org\/", url):
             # Not a Wikipedia URL
             return False
 

--- a/packages/markitdown/tests/test_bug_fixes.py
+++ b/packages/markitdown/tests/test_bug_fixes.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for specific bug fixes."""
+import io
+import os
+import tempfile
+
+import pytest
+
+from markitdown import MarkItDown, StreamInfo
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+
+class TestRssNoTitleBug:
+    """Test fix for: RSS converter crashes with NameError when feed has no channel title."""
+
+    def test_rss_no_channel_title(self):
+        """An RSS feed with no <title> in <channel> should not crash."""
+        rss_no_title = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <description>A feed without a title</description>
+    <item>
+      <title>Item Title</title>
+      <description>Item description</description>
+    </item>
+  </channel>
+</rss>"""
+        markitdown = MarkItDown()
+        result = markitdown.convert_stream(
+            io.BytesIO(rss_no_title.encode("utf-8")),
+            file_extension=".rss",
+        )
+        assert "Item Title" in result.text_content
+        assert "Item description" in result.text_content
+
+    def test_rss_no_channel_title_or_description(self):
+        """An RSS feed with no title or description should still work."""
+        rss_minimal = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Only Item</title>
+    </item>
+  </channel>
+</rss>"""
+        markitdown = MarkItDown()
+        result = markitdown.convert_stream(
+            io.BytesIO(rss_minimal.encode("utf-8")),
+            file_extension=".rss",
+        )
+        assert "Only Item" in result.text_content
+
+
+class TestCsvPipeEscape:
+    """Test fix for: CSV converter doesn't escape pipe characters in cell values."""
+
+    def test_csv_pipe_in_cell(self):
+        """CSV cells containing | should be escaped in markdown output."""
+        csv_with_pipe = "Name,Description\nTest,hello | world\n"
+        markitdown = MarkItDown()
+        result = markitdown.convert_stream(
+            io.BytesIO(csv_with_pipe.encode("utf-8")),
+            file_extension=".csv",
+            mimetype="text/csv",
+        )
+        # The pipe inside the cell should be escaped
+        assert "hello \\| world" in result.text_content
+        # Header should be unaffected
+        assert "| Name | Description |" in result.text_content
+
+
+class TestWikipediaLanguageSubdomains:
+    """Test fix for: Wikipedia converter rejects valid language subdomains."""
+
+    def test_wikipedia_standard_subdomain(self):
+        """Standard 2-letter language codes should still work."""
+        from markitdown.converters._wikipedia_converter import WikipediaConverter
+
+        converter = WikipediaConverter()
+        stream_info = StreamInfo(
+            mimetype="text/html",
+            extension=".html",
+            url="https://en.wikipedia.org/wiki/Test",
+        )
+        assert converter.accepts(io.BytesIO(b""), stream_info)
+
+    def test_wikipedia_hyphenated_subdomain(self):
+        """Hyphenated language codes like be-tarask should be accepted."""
+        from markitdown.converters._wikipedia_converter import WikipediaConverter
+
+        converter = WikipediaConverter()
+        stream_info = StreamInfo(
+            mimetype="text/html",
+            extension=".html",
+            url="https://be-tarask.wikipedia.org/wiki/Test",
+        )
+        assert converter.accepts(io.BytesIO(b""), stream_info)
+
+    def test_wikipedia_multi_char_subdomain(self):
+        """Long language codes like zh-classical should be accepted."""
+        from markitdown.converters._wikipedia_converter import WikipediaConverter
+
+        converter = WikipediaConverter()
+        stream_info = StreamInfo(
+            mimetype="text/html",
+            extension=".html",
+            url="https://zh-classical.wikipedia.org/wiki/Test",
+        )
+        assert converter.accepts(io.BytesIO(b""), stream_info)
+
+    def test_wikipedia_numeric_subdomain(self):
+        """Numeric language codes should be accepted."""
+        from markitdown.converters._wikipedia_converter import WikipediaConverter
+
+        converter = WikipediaConverter()
+        stream_info = StreamInfo(
+            mimetype="text/html",
+            extension=".html",
+            url="https://roa-rup.wikipedia.org/wiki/Test",
+        )
+        assert converter.accepts(io.BytesIO(b""), stream_info)
+
+
+if __name__ == "__main__":
+    for test in [
+        TestRssNoTitleBug().test_rss_no_channel_title,
+        TestRssNoTitleBug().test_rss_no_channel_title_or_description,
+        TestCsvPipeEscape().test_csv_pipe_in_cell,
+        TestWikipediaLanguageSubdomains().test_wikipedia_standard_subdomain,
+        TestWikipediaLanguageSubdomains().test_wikipedia_hyphenated_subdomain,
+        TestWikipediaLanguageSubdomains().test_wikipedia_multi_char_subdomain,
+        TestWikipediaLanguageSubdomains().test_wikipedia_numeric_subdomain,
+    ]:
+        print(f"Running {test.__name__}...", end="")
+        test()
+        print("OK")
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

This PR fixes 5 bugs found across multiple converters:

1. **RSS converter crash** (`_rss_converter.py`): `NameError` when an RSS feed has no `<title>` element in `<channel>`. `md_text` was never initialized before the conditional assignment, causing a crash when `channel_title` is `None`. Fixed by initializing `md_text = ""` and using `+=` consistently.

2. **PPTX text frame loss** (`_pptx_converter.py`): `elif shape.has_text_frame` after `if shape.has_chart` caused text content to be silently dropped for shapes that have both a chart and a text frame. Changed `elif` to `if` so both chart and text content are extracted.

3. **CSV malformed tables** (`_csv_converter.py`): Pipe characters (`|`) in CSV cell values were not escaped, producing broken markdown tables with extra columns. Added `escape_pipe()` helper to escape `|` as `\|`.

4. **Wikipedia language subdomain regex** (`_wikipedia_converter.py`): The regex `[a-zA-Z]{2,3}` rejected valid Wikipedia subdomains with hyphenated or multi-character language codes (e.g., `be-tarask`, `zh-classical`, `roa-rup`, `map-bms`). Changed to `[a-zA-Z0-9-]+` to match all valid Wikipedia language subdomains.

5. **ExifTool encoding** (`_exiftool.py`): Used `locale.getpreferredencoding(False)` to decode ExifTool JSON output, which can fail on non-UTF-8 systems (e.g., Windows with `cp1252`). Since ExifTool always outputs UTF-8 JSON, hardcoded `"utf-8"` and removed unused `locale` import.

## Test plan

- [x] All 159 existing test vectors pass
- [x] 7 new tests added in `test_bug_fixes.py` covering:
  - RSS feed with no channel title
  - RSS feed with no title or description
  - CSV with pipe characters in cells
  - Wikipedia standard subdomains (en)
  - Wikipedia hyphenated subdomains (be-tarask)
  - Wikipedia multi-character subdomains (zh-classical)
  - Wikipedia numeric subdomains (roa-rup)
- [x] Total: 203 tests passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)