### PR TITLE
fix: update youtube-transcript-api version constraint to >=1.2.3

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -45,7 +45,7 @@ all = [
   "olefile",
   "pydub",
   "SpeechRecognition",
-  "youtube-transcript-api~=1.0.0",
+  "youtube-transcript-api>=1.2.3",
   "azure-ai-documentintelligence",
   "azure-identity",
 ]
@@ -56,7 +56,7 @@ xls = ["pandas", "xlrd"]
 pdf = ["pdfminer.six>=20251230", "pdfplumber>=0.11.9"]
 outlook = ["olefile"]
 audio-transcription = ["pydub", "SpeechRecognition"]
-youtube-transcription = ["youtube-transcript-api"]
+youtube-transcription = ["youtube-transcript-api>=1.2.3"]
 az-doc-intel = ["azure-ai-documentintelligence", "azure-identity"]
 
 [project.urls]


### PR DESCRIPTION
## Problem

The version constraint `youtube-transcript-api~=1.0.0` (i.e. `>=1.0.0, <1.1.0`) can never be satisfied because **no 1.0.x release exists on PyPI**. The package jumped from `0.6.2` directly to `1.2.3`.

This causes `pip install -e "packages/markitdown[all]"` to fail with:

```
ERROR: Could not find a version that satisfies the requirement youtube-transcript-api~=1.0.0
```

Additionally, all versions `<=1.2.2` require `Python <3.14`, so on Python 3.14+ even if a matching version existed, it would not be installable.

## Fix

- Changed `[all]` optional dep: `youtube-transcript-api~=1.0.0` → `youtube-transcript-api>=1.2.3`
- Changed `[youtube-transcription]` optional dep: `youtube-transcript-api` → `youtube-transcript-api>=1.2.3` (added explicit minimum for consistency)

## Verification

- ✅ `pip install -e "packages/markitdown[all]"` succeeds with the updated constraint
- ✅ `MarkItDown` initializes correctly
- ✅ YouTube transcript capability is functional (`IS_YOUTUBE_TRANSCRIPT_CAPABLE = True`)
- ✅ API compatibility verified: `YouTubeTranscriptApi()`, `.list()`, `.fetch()`, `.find_transcript()`, `.translate()` all exist in v1.2.4