### PR TITLE
docs: fix MCP package display name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Built by AutoGen Team](https://img.shields.io/badge/Built%20by-AutoGen%20Team-blue)](https://github.com/microsoft/autogen)
 
 > [!TIP]
-> MarkItDown now offers an MCP (Model Context Protocol) server for integration with LLM applications like Claude Desktop. See [markitdown-mcp](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) for more information.
+> MarkItDown now offers an MCP (Model Context Protocol) server for integration with LLM applications like Claude Desktop. See [markitdown_mcp](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) for more information.
 
 > [!IMPORTANT]
 > Breaking changes between 0.0.1 to 0.1.0:


### PR DESCRIPTION
## Summary
- fixes #1749 by changing the README display text from \markitdown-mcp\ to \markitdown_mcp\`n- keeps the existing package path link unchanged (\packages/markitdown-mcp\)

## Validation
- docs-only change