### PR TITLE
fix(youtube): support short YouTube URLs in converter

### DIFF
--- a/packages/markitdown/tests/test_youtube_converter.py
+++ b/packages/markitdown/tests/test_youtube_converter.py
@@ -1,0 +1,35 @@
+import io
+
+from markitdown import StreamInfo
+from markitdown.converters._youtube_converter import YouTubeConverter
+
+
+def _stream_info(url: str) -> StreamInfo:
+    return StreamInfo(url=url, mimetype="text/html", extension=".html")
+
+
+def test_accepts_youtube_short_urls() -> None:
+    converter = YouTubeConverter()
+
+    assert converter.accepts(io.BytesIO(b""), _stream_info("https://youtu.be/dQw4w9WgXcQ"))
+    assert converter.accepts(
+        io.BytesIO(b""), _stream_info("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+    )
+    assert converter.accepts(
+        io.BytesIO(b""), _stream_info("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    )
+
+
+def test_extract_video_id_from_supported_youtube_urls() -> None:
+    converter = YouTubeConverter()
+
+    assert (
+        converter._extract_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        == "dQw4w9WgXcQ"
+    )
+    assert converter._extract_video_id("https://youtu.be/dQw4w9WgXcQ?t=42") == "dQw4w9WgXcQ"
+    assert (
+        converter._extract_video_id("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+        == "dQw4w9WgXcQ"
+    )
+    assert converter._extract_video_id("https://example.com/watch?v=dQw4w9WgXcQ") is None


### PR DESCRIPTION
## Summary
- fixes #1730 by accepting `youtu.be` and `/shorts/` URL patterns in `YouTubeConverter.accepts()`
- adds unified video-id extraction logic used by transcript fetching
- adds regression tests for accepts() and ID extraction

## Validation
- `$env:PYTHONPATH='packages/markitdown/src'; python -m pytest packages/markitdown/tests/test_youtube_converter.py -q`