### PR TITLE
fix(youtube): support short YouTube URLs in converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -53,8 +53,8 @@ class YouTubeConverter(DocumentConverter):
         url = unquote(url)
         url = url.replace(r"\?", "?").replace(r"\=", "=")
 
-        if not url.startswith("https://www.youtube.com/watch?"):
-            # Not a YouTube URL
+        if self._extract_video_id(url) is None:
+            # Not a supported YouTube URL
             return False
 
         if extension in ACCEPTED_FILE_EXTENSIONS:
@@ -147,10 +147,8 @@ class YouTubeConverter(DocumentConverter):
         if IS_YOUTUBE_TRANSCRIPT_CAPABLE:
             ytt_api = YouTubeTranscriptApi()
             transcript_text = ""
-            parsed_url = urlparse(stream_info.url)  # type: ignore
-            params = parse_qs(parsed_url.query)  # type: ignore
-            if "v" in params and params["v"][0]:
-                video_id = str(params["v"][0])
+            video_id = self._extract_video_id(stream_info.url or "")
+            if video_id:
                 transcript_list = ytt_api.list(video_id)
                 languages = ["en"]
                 for transcript in transcript_list:
@@ -195,6 +193,25 @@ class YouTubeConverter(DocumentConverter):
             markdown=webpage_text,
             title=title,
         )
+
+    def _extract_video_id(self, url: str) -> Union[str, None]:
+        parsed_url = urlparse(url)
+        host = parsed_url.netloc.lower()
+        path = parsed_url.path.strip("/")
+
+        if host in {"youtu.be", "www.youtu.be"}:
+            return path.split("/", 1)[0] if path else None
+
+        if host in {"youtube.com", "www.youtube.com", "m.youtube.com"}:
+            if path == "watch":
+                params = parse_qs(parsed_url.query)
+                video_id = params.get("v", [None])[0]
+                return str(video_id) if video_id else None
+            if path.startswith("shorts/") or path.startswith("embed/"):
+                video_id = path.split("/", 1)[1]
+                return video_id.split("/", 1)[0] if video_id else None
+
+        return None
 
     def _get(
         self,

--- a/packages/markitdown/tests/test_youtube_converter.py
+++ b/packages/markitdown/tests/test_youtube_converter.py
@@ -1,0 +1,35 @@
+import io
+
+from markitdown import StreamInfo
+from markitdown.converters._youtube_converter import YouTubeConverter
+
+
+def _stream_info(url: str) -> StreamInfo:
+    return StreamInfo(url=url, mimetype="text/html", extension=".html")
+
+
+def test_accepts_youtube_short_urls() -> None:
+    converter = YouTubeConverter()
+
+    assert converter.accepts(io.BytesIO(b""), _stream_info("https://youtu.be/dQw4w9WgXcQ"))
+    assert converter.accepts(
+        io.BytesIO(b""), _stream_info("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+    )
+    assert converter.accepts(
+        io.BytesIO(b""), _stream_info("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    )
+
+
+def test_extract_video_id_from_supported_youtube_urls() -> None:
+    converter = YouTubeConverter()
+
+    assert (
+        converter._extract_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        == "dQw4w9WgXcQ"
+    )
+    assert converter._extract_video_id("https://youtu.be/dQw4w9WgXcQ?t=42") == "dQw4w9WgXcQ"
+    assert (
+        converter._extract_video_id("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+        == "dQw4w9WgXcQ"
+    )
+    assert converter._extract_video_id("https://example.com/watch?v=dQw4w9WgXcQ") is None


### PR DESCRIPTION
## Summary
- fixes #1730 by accepting `youtu.be` and `/shorts/` URL patterns in `YouTubeConverter.accepts()`
- adds unified video-id extraction logic used by transcript fetching
- adds regression tests for accepts() and ID extraction

## Validation
- `$env:PYTHONPATH='packages/markitdown/src'; python -m pytest packages/markitdown/tests/test_youtube_converter.py -q`