### PR TITLE
fix(uri): decode percent-encoded Unicode file URIs

### DIFF
--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -2,7 +2,7 @@ import base64
 import os
 from typing import Tuple, Dict
 from urllib.request import url2pathname
-from urllib.parse import urlparse, unquote_to_bytes
+from urllib.parse import urlparse, unquote, unquote_to_bytes
 
 
 def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
@@ -12,7 +12,8 @@ def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
         raise ValueError(f"Not a file URL: {file_uri}")
 
     netloc = parsed.netloc if parsed.netloc else None
-    path = os.path.abspath(url2pathname(parsed.path))
+    decoded_path = unquote(parsed.path)
+    path = os.path.abspath(url2pathname(decoded_path))
     return netloc, path
 
 

--- a/packages/markitdown/tests/test_uri_utils.py
+++ b/packages/markitdown/tests/test_uri_utils.py
@@ -1,0 +1,13 @@
+from markitdown._uri_utils import file_uri_to_path
+
+
+def test_file_uri_to_path_decodes_percent_encoded_space() -> None:
+    _, path = file_uri_to_path("file:///path/to/my%20file.txt")
+    assert "my file.txt" in path
+    assert "%20" not in path
+
+
+def test_file_uri_to_path_decodes_percent_encoded_unicode() -> None:
+    _, path = file_uri_to_path("file:///path/to/%E6%B5%8B%E8%AF%95.txt")
+    assert "娴嬭瘯.txt" in path
+    assert "%E6%B5%8B%E8%AF%95" not in path


### PR DESCRIPTION
## Summary
- fixes #1738 by decoding `parsed.path` with `unquote()` before `url2pathname()`
- ensures percent-encoded Unicode file URIs resolve to valid local paths
- adds regression tests for percent-encoded space and Unicode path decoding

## Validation
- `$env:PYTHONPATH='packages/markitdown/src'; python -m pytest packages/markitdown/tests/test_uri_utils.py -q`