### PR TITLE
fix: use HTTPS URL instead of SSH in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ conda activate markitdown
 To install MarkItDown, use pip: `pip install 'markitdown[all]'`. Alternatively, you can install it from the source:
 
 ```bash
-git clone git@github.com:microsoft/markitdown.git
+git clone https://github.com/microsoft/markitdown.git
 cd markitdown
 pip install -e 'packages/markitdown[all]'
 ```


### PR DESCRIPTION
Good day,

Replace SSH clone URL (`git@github.com:microsoft/markitdown.git`) with HTTPS URL (`https://github.com/microsoft/markitdown.git`) for better compatibility with environments that don't have SSH keys configured.

This aligns with the existing issue requesting HTTPS URLs instead of SSH in README install instructions.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof