### PR TITLE
fix: RSS feed metadata leakage and PPTX table pipe escaping

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -219,10 +219,14 @@ class PptxConverter(DocumentConverter):
         for row in table.rows:
             html_table += "<tr>"
             for cell in row.cells:
+                # Escape cell text: html.escape handles <, >, &, etc.
+                # Pipe characters (|) are also escaped to prevent breaking
+                # the markdown table structure after HTML-to-Markdown conversion.
+                escaped_text = html.escape(cell.text).replace("|", "\|")
                 if first_row:
-                    html_table += "<th>" + html.escape(cell.text) + "</th>"
+                    html_table += "<th>" + escaped_text + "</th>"
                 else:
-                    html_table += "<td>" + html.escape(cell.text) + "</td>"
+                    html_table += "<td>" + escaped_text + "</td>"
             html_table += "</tr>"
             first_row = False
         html_table += "</table></body></html>"

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -104,10 +104,12 @@ class RssConverter(DocumentConverter):
         Returns None if the feed type is not recognized or something goes wrong.
         """
         root = doc.getElementsByTagName("feed")[0]
-        title = self._get_data_by_tag_name(root, "title")
-        subtitle = self._get_data_by_tag_name(root, "subtitle")
+        title = self._get_direct_child_data(root, "title")
+        subtitle = self._get_direct_child_data(root, "subtitle")
         entries = root.getElementsByTagName("entry")
-        md_text = f"# {title}\n"
+        md_text = ""
+        if title:
+            md_text = f"# {title}\n"
         if subtitle:
             md_text += f"{subtitle}\n"
         for entry in entries:
@@ -140,9 +142,10 @@ class RssConverter(DocumentConverter):
         if not channel_list:
             raise ValueError("No channel found in RSS feed")
         channel = channel_list[0]
-        channel_title = self._get_data_by_tag_name(channel, "title")
-        channel_description = self._get_data_by_tag_name(channel, "description")
+        channel_title = self._get_direct_child_data(channel, "title")
+        channel_description = self._get_direct_child_data(channel, "description")
         items = channel.getElementsByTagName("item")
+        md_text = ""
         if channel_title:
             md_text = f"# {channel_title}\n"
         if channel_description:
@@ -189,4 +192,27 @@ class RssConverter(DocumentConverter):
         if fc:
             if hasattr(fc, "data"):
                 return fc.data
+        return None
+
+    def _get_direct_child_data(
+        self, element: Element, tag_name: str
+    ) -> Union[str, None]:
+        """Get data from first *direct* child element with the given tag name.
+
+        Unlike _get_data_by_tag_name which uses getElementsByTagName (recursive
+        descent into all descendants), this method only searches immediate child
+        elements. This prevents item/entry metadata from leaking into
+        channel/feed-level fields.
+
+        Returns None when no such element is found.
+        """
+        for child in element.childNodes:
+            if (
+                child.nodeType == child.ELEMENT_NODE
+                and child.tagName == tag_name
+            ):
+                fc = child.firstChild
+                if fc and hasattr(fc, "data"):
+                    return fc.data
+                return None
         return None


### PR DESCRIPTION
## Summary

Two bugs found and fixed in the converter layer.

### Bug 1: RSS/Atom metadata leakage

`_get_data_by_tag_name()` used `getElementsByTagName()` which recursively searches **all** descendants. When a channel/feed lacked its own `<title>` or `<description>`, the method would return the first matching element from an `<item>`/`<entry>` instead, causing:

- Item titles appearing as the feed title
- Item descriptions appearing as the feed description
- Incorrect `title` in `DocumentConverterResult`

**Fix:** Added `_get_direct_child_data()` that only searches immediate child elements, and used it for channel/feed-level metadata. Also fixed `UnboundLocalError` when `channel_title` is `None` and `channel_description` is not.

### Bug 2: PPTX table pipe escaping

`_convert_table_to_markdown()` used `html.escape()` on cell text, which does not escape pipe characters (`|`). When cell content contained `|`, the resulting markdown table had extra columns.

**Fix:** Added `.replace("|", "\|")` after `html.escape()`.

## Reproduction

**RSS bug:**
```python
from markitdown import MarkItDown
import io

rss = b"""<?xml version="1.0"?>
<rss version="2.0"><channel>
<description>My Channel</description>
<item><title>Item Title</title><description>Item Desc</description></item>
</channel></rss>"""

md = MarkItDown()
result = md.convert_stream(io.BytesIO(rss), file_extension=".rss")
# Before: result.title == "Item Title" (wrong)
# After:  result.title is None (correct)
```

**PPTX bug:**
```python
# PPTX with a table cell containing "|"
# Before: | Alice | Has a | pipe |  (3 columns, broken)
# After:  | Alice | Has a \| pipe |   (2 columns, correct)
```

## Test plan

- [x] All 112 existing tests pass (6 failures are pre-existing missing `outlook` optional dep)
- [x] Manually verified both bugs with reproduction scripts