### PR TITLE
feat: extract PDF metadata (title, author, dates) into markdown output

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -492,6 +492,59 @@ def _extract_tables_from_words(page: Any) -> list[list[list[str]]]:
     return [table_rows]
 
 
+def _parse_pdf_date(date_str: str) -> str:
+    """Parse a PDF date string (D:YYYYMMDDHHmmSS...) into YYYY-MM-DD format."""
+    if not isinstance(date_str, str) or not date_str.startswith("D:"):
+        return date_str
+    raw = date_str[2:]  # Strip "D:"
+    try:
+        year = raw[0:4]
+        month = raw[4:6] if len(raw) >= 6 else "01"
+        day = raw[6:8] if len(raw) >= 8 else "01"
+        return f"{year}-{month}-{day}"
+    except Exception:
+        return date_str
+
+
+def _extract_pdf_metadata(metadata: dict[str, Any]) -> str:
+    """Format a pdfplumber metadata dict as a markdown Document Properties section.
+
+    Returns an empty string if no relevant fields are present.
+    """
+    field_map = [
+        ("Title", "Title"),
+        ("Author", "Author"),
+        ("Subject", "Subject"),
+        ("Keywords", "Keywords"),
+        ("Creator", "Creator"),
+        ("Producer", "Producer"),
+        ("CreationDate", "Created"),
+        ("ModDate", "Modified"),
+    ]
+
+    lines: list[str] = []
+    for pdf_key, label in field_map:
+        value = metadata.get(pdf_key, "")
+        if not value:
+            continue
+        if isinstance(value, bytes):
+            try:
+                value = value.decode("utf-8", errors="replace")
+            except Exception:
+                continue
+        value = str(value).strip()
+        if not value:
+            continue
+        if pdf_key in ("CreationDate", "ModDate"):
+            value = _parse_pdf_date(value)
+        lines.append(f"- **{label}:** {value}")
+
+    if not lines:
+        return ""
+
+    return "## Document Properties\n\n" + "\n".join(lines) + "\n\n"
+
+
 class PdfConverter(DocumentConverter):
     """
     Converts PDFs to Markdown.
@@ -548,8 +601,11 @@ class PdfConverter(DocumentConverter):
             markdown_chunks: list[str] = []
             form_page_count = 0
             plain_page_indices: list[int] = []
+            metadata_str = ""
 
             with pdfplumber.open(pdf_bytes) as pdf:
+                metadata_str = _extract_pdf_metadata(pdf.metadata or {})
+
                 for page_idx, page in enumerate(pdf.pages):
                     page_content = _extract_form_content_from_words(page)
 
@@ -575,6 +631,7 @@ class PdfConverter(DocumentConverter):
 
         except Exception:
             # Fallback if pdfplumber fails
+            metadata_str = ""
             pdf_bytes.seek(0)
             markdown = pdfminer.high_level.extract_text(pdf_bytes)
 
@@ -585,5 +642,8 @@ class PdfConverter(DocumentConverter):
 
         # Post-process to merge MasterFormat-style partial numbering with following text
         markdown = _merge_partial_numbering_lines(markdown)
+
+        if metadata_str:
+            markdown = metadata_str + markdown
 
         return DocumentConverterResult(markdown=markdown)

--- a/packages/markitdown/tests/test_pdf_metadata.py
+++ b/packages/markitdown/tests/test_pdf_metadata.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for PDF metadata extraction in PdfConverter.
+
+Verifies that:
+- PDF metadata fields (title, author, dates, etc.) appear in the output
+- PDF date strings are parsed into YYYY-MM-DD format
+- Missing or empty metadata fields are silently skipped
+- Documents with no metadata produce no metadata section
+"""
+
+import io
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from markitdown.converters._pdf_converter import _parse_pdf_date, _extract_pdf_metadata
+from markitdown import MarkItDown, StreamInfo
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestParsePdfDate:
+    def test_full_date_string(self):
+        assert _parse_pdf_date("D:20230615120000+00'00'") == "2023-06-15"
+
+    def test_date_only(self):
+        assert _parse_pdf_date("D:20210101") == "2021-01-01"
+
+    def test_year_and_month(self):
+        # Day defaults to "01" when not present
+        assert _parse_pdf_date("D:202306") == "2023-06-01"
+
+    def test_no_d_prefix_returned_as_is(self):
+        assert _parse_pdf_date("20230615") == "20230615"
+
+    def test_empty_string(self):
+        assert _parse_pdf_date("") == ""
+
+    def test_non_string_returns_as_is(self):
+        assert _parse_pdf_date(None) is None  # type: ignore[arg-type]
+
+
+class TestExtractPdfMetadata:
+    def test_full_metadata(self):
+        meta = {
+            "Title": "Annual Report 2023",
+            "Author": "Jane Smith",
+            "Subject": "Finance",
+            "Keywords": "finance, annual",
+            "Creator": "Microsoft Word",
+            "Producer": "Adobe PDF Library",
+            "CreationDate": "D:20230615",
+            "ModDate": "D:20230620",
+        }
+        result = _extract_pdf_metadata(meta)
+        assert "## Document Properties" in result
+        assert "**Title:** Annual Report 2023" in result
+        assert "**Author:** Jane Smith" in result
+        assert "**Subject:** Finance" in result
+        assert "**Keywords:** finance, annual" in result
+        assert "**Creator:** Microsoft Word" in result
+        assert "**Producer:** Adobe PDF Library" in result
+        assert "**Created:** 2023-06-15" in result
+        assert "**Modified:** 2023-06-20" in result
+
+    def test_empty_metadata_returns_empty_string(self):
+        assert _extract_pdf_metadata({}) == ""
+
+    def test_all_empty_values_returns_empty_string(self):
+        assert _extract_pdf_metadata({"Title": "", "Author": ""}) == ""
+
+    def test_partial_metadata(self):
+        result = _extract_pdf_metadata({"Title": "My Doc", "Author": "Bob"})
+        assert "**Title:** My Doc" in result
+        assert "**Author:** Bob" in result
+        assert "Subject" not in result
+
+    def test_bytes_values_decoded(self):
+        result = _extract_pdf_metadata({"Title": b"Bytes Title"})
+        assert "**Title:** Bytes Title" in result
+
+    def test_dates_are_parsed(self):
+        result = _extract_pdf_metadata({"CreationDate": "D:20220101"})
+        assert "**Created:** 2022-01-01" in result
+        assert "D:" not in result
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via MarkItDown.convert_stream
+# ---------------------------------------------------------------------------
+
+
+def _mock_pdfplumber_open(metadata: dict, pages=None):
+    """Return a pdfplumber.open mock with the given metadata and optional pages."""
+    if pages is None:
+        page = MagicMock()
+        page.width = 612
+        page.close = MagicMock()
+        page.extract_words.return_value = []
+        page.extract_text.return_value = "Sample text content."
+        pages = [page]
+
+    def mock_open(stream):
+        mock_pdf = MagicMock()
+        mock_pdf.pages = pages
+        mock_pdf.metadata = metadata
+        mock_pdf.__enter__ = MagicMock(return_value=mock_pdf)
+        mock_pdf.__exit__ = MagicMock(return_value=False)
+        return mock_pdf
+
+    return mock_open
+
+
+class TestPdfMetadataInOutput:
+    def test_title_and_author_appear_in_output(self):
+        metadata = {"Title": "Test Document", "Author": "Alice"}
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open(metadata)
+            mock_pdfminer.high_level.extract_text.return_value = "Body text here."
+
+            md = MarkItDown()
+            result = md.convert_stream(
+                io.BytesIO(b"fake pdf"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        assert "## Document Properties" in result.text_content
+        assert "**Title:** Test Document" in result.text_content
+        assert "**Author:** Alice" in result.text_content
+
+    def test_creation_date_parsed(self):
+        metadata = {"CreationDate": "D:20240301"}
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open(metadata)
+            mock_pdfminer.high_level.extract_text.return_value = "Body."
+
+            md = MarkItDown()
+            result = md.convert_stream(
+                io.BytesIO(b"fake pdf"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        assert "**Created:** 2024-03-01" in result.text_content
+
+    def test_no_metadata_section_when_empty(self):
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open({})
+            mock_pdfminer.high_level.extract_text.return_value = "Just text."
+
+            md = MarkItDown()
+            result = md.convert_stream(
+                io.BytesIO(b"fake pdf"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        assert "## Document Properties" not in result.text_content
+
+    def test_metadata_precedes_body_text(self):
+        metadata = {"Title": "First"}
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open(metadata)
+            mock_pdfminer.high_level.extract_text.return_value = "Body content."
+
+            md = MarkItDown()
+            result = md.convert_stream(
+                io.BytesIO(b"fake pdf"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        content = result.text_content
+        meta_pos = content.find("## Document Properties")
+        body_pos = content.find("Body content.")
+        assert meta_pos < body_pos, "Metadata section should appear before body text"


### PR DESCRIPTION
## Summary

Closes #1664.

PDF files often carry useful metadata - title, author, subject, keywords, creator, producer, and creation/modification dates - but the current PdfConverter silently discards it. This PR surfaces that information as a **Document Properties** section at the top of the converted markdown.

### What changed

- Added  to convert PDF date strings () to readable  format
- Added  to format the pdfplumber metadata dict as a markdown section
- Wired both into  — metadata is prepended to the output when present, skipped entirely when absent or empty
- Added  with 16 tests covering unit helpers and end-to-end output via mocks

### Example output

For a PDF with title and author set:



### Design decisions

- Only fields that are present and non-empty are emitted — no blank lines for missing fields
- Uses 's  dict (already imported); no new dependencies
- Falls back gracefully: if pdfplumber raises, metadata is skipped and pdfminer handles the text as before
