### PR TITLE
fix: redetect plain-text charset after ASCII-only sniff

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -63,9 +63,19 @@ class PlainTextConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
+        file_bytes = file_stream.read()
+
         if stream_info.charset:
-            text_content = file_stream.read().decode(stream_info.charset)
+            try:
+                text_content = file_bytes.decode(stream_info.charset)
+            except UnicodeDecodeError:
+                # Stream guessing samples only the first chunk of the file, so a late
+                # non-ASCII character can still require a full-file charset detection.
+                charset_match = from_bytes(file_bytes).best()
+                if charset_match is None:
+                    raise
+                text_content = str(charset_match)
         else:
-            text_content = str(from_bytes(file_stream.read()).best())
+            text_content = str(from_bytes(file_bytes).best())
 
         return DocumentConverterResult(markdown=text_content)

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -179,6 +179,18 @@ def test_stream_info_operations() -> None:
     assert updated_stream_info.url == "url.1"
 
 
+def test_convert_text_file_redetects_charset_after_ascii_prefix(tmp_path) -> None:
+    """Late non-ASCII bytes should not fail when the initial stream sniff looks ASCII."""
+
+    file_path = tmp_path / "utf8-after-ascii-prefix.txt"
+    expected_text = ("A" * 4100) + " café\n"
+    file_path.write_bytes(expected_text.encode("utf-8"))
+
+    result = MarkItDown().convert(str(file_path))
+
+    assert result.markdown == expected_text
+
+
 def test_data_uris() -> None:
     # Test basic parsing of data URIs
     data_uri = "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="


### PR DESCRIPTION
## Summary

Fix plain-text conversion when the initial charset sniff only sees ASCII bytes but later bytes require UTF-8 decoding.

## Problem

`MarkItDown().convert()` can guess `charset='ascii'` for `.txt` files whose first 4096 bytes are ASCII-only. `PlainTextConverter.convert()` then decodes the entire file as ASCII and raises `UnicodeDecodeError` once it reaches later non-ASCII bytes.

This reproduces with a text file that starts with 4100 ASCII characters and ends with `café`.

## Fix

When decoding with the guessed charset fails, rerun `charset_normalizer` against the full file bytes and use that result as a fallback.

## Validation

- `PYTHONPATH=packages/markitdown/src uv run --with requests --with markdownify --with beautifulsoup4 --with defusedxml --with charset-normalizer --with magika --with pytest --python 3.12 python -m pytest packages/markitdown/tests/test_module_misc.py -k 'stream_info_operations or redetects_charset_after_ascii_prefix' -q`
- `PYTHONPATH=packages/markitdown/src uv run --with requests --with markdownify --with beautifulsoup4 --with defusedxml --with charset-normalizer --with magika --with pytest --python 3.12 python -m pytest 'packages/markitdown/tests/test_module_vectors.py::test_guess_stream_info[test_vector10]' -q`

Fixes #1505.
