### PR TITLE
fix: write UTF-8 to stdout.buffer to avoid UnicodeEncodeError on non-UTF-8 systems

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -212,7 +212,13 @@ def _handle_output(args, result: DocumentConverterResult):
         # in the markdown output, and also handles the case where
         # sys.stdout.encoding is None (e.g. when stdout is a raw pipe).
         if hasattr(sys.stdout, "buffer"):
-            sys.stdout.buffer.write(result.markdown.encode("utf-8"))
+            data = result.markdown.encode("utf-8")
+            # `print()` (used in the fallback branch and previously here) appends
+            # a trailing newline, so preserve that behavior to keep output
+            # parity for downstream tools that expect a final newline.
+            if not data.endswith(b"\n"):
+                data += b"\n"
+            sys.stdout.buffer.write(data)
             sys.stdout.buffer.flush()
         else:
             encoding = sys.stdout.encoding or "utf-8"

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -206,12 +206,19 @@ def _handle_output(args, result: DocumentConverterResult):
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(result.markdown)
     else:
-        # Handle stdout encoding errors more gracefully
-        print(
-            result.markdown.encode(sys.stdout.encoding, errors="replace").decode(
-                sys.stdout.encoding
+        # Write UTF-8 directly to the underlying binary buffer when available.
+        # This avoids UnicodeEncodeError on systems whose locale encoding
+        # (e.g. GBK on Chinese Windows) cannot represent all Unicode characters
+        # in the markdown output, and also handles the case where
+        # sys.stdout.encoding is None (e.g. when stdout is a raw pipe).
+        if hasattr(sys.stdout, "buffer"):
+            sys.stdout.buffer.write(result.markdown.encode("utf-8"))
+            sys.stdout.buffer.flush()
+        else:
+            encoding = sys.stdout.encoding or "utf-8"
+            print(
+                result.markdown.encode(encoding, errors="replace").decode(encoding)
             )
-        )
 
 
 def _exit_with_error(message: str):


### PR DESCRIPTION
Fixes #1788

## Problem

On Windows systems with a non-UTF-8 locale (e.g. GBK on Chinese Windows), running:

```
markitdown file.pdf > output.md
```

raises a `UnicodeEncodeError`:

```
UnicodeEncodeError: 'gbk' codec can't encode character '\u2022' in position 140: illegal multibyte sequence
```

The previous approach of encoding to `sys.stdout.encoding` with `errors='replace'` had two remaining issues:

1. `sys.stdout.encoding` can be `None` when stdout is a raw pipe, causing a `TypeError` instead of a graceful failure.
2. Characters are silently replaced with `'?'` (lossy output), which is undesirable when redirecting to a file.

## Solution

Write UTF-8 encoded bytes directly to `sys.stdout.buffer` when available. This produces lossless UTF-8 output regardless of the system locale encoding, consistent with the behavior of the `-o`/`--output` flag (which already writes UTF-8 explicitly).

A safe fallback handles the rare case where `stdout.buffer` is not available (e.g. some embedded or wrapped stdout objects), using the locale encoding with `errors='replace'` and guarding against `None` encoding.

## Testing

- Verified the fix handles the `sys.stdout.encoding is None` case without raising `TypeError`
- Verified lossless UTF-8 output when redirecting (`> file.md`) on systems with non-UTF-8 locale encoding