### PR TITLE
fix: correct typo in comment from 'legaxy' to 'legacy'

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -580,7 +580,7 @@ class MarkItDown:
                 # Add the list of converters for nested processing
                 _kwargs["_parent_converters"] = self._converters
 
-                # Add legaxy kwargs
+                # Add legacy kwargs
                 if stream_info is not None:
                     if stream_info.extension is not None:
                         _kwargs["file_extension"] = stream_info.extension


### PR DESCRIPTION
Corrected a misspelling in line 583 of packages/markitdown/src/markitdown/_markitdown.py where "legaxy" was written instead of "legacy" in a comment about handling legacy keyword arguments.

Changes Made
File: packages/markitdown/src/markitdown/_markitdown.py
Line: 583
Before: # Add legaxy kwargs
After: # Add legacy kwargs
Type of Change
Bug fix (non-breaking change that fixes an issue)
New feature (non-breaking change that adds functionality)
Breaking change (fix or feature that would cause existing functionality to not work as expected)
Documentation update
Why This Change
While this typo didn't affect functionality, fixing it improves code quality and maintainability by ensuring comments are correctly spelled and professional.

Testing
This change only modifies a comment and requires no additional testing. The functionality remains unchanged.