### PR TITLE
fix: remove unused imports and exception variables

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
@@ -7,7 +7,6 @@ import io
 import sys
 from typing import Any, BinaryIO, Optional
 
-from typing import BinaryIO, Any, Optional
 
 from markitdown.converters import HtmlConverter
 from markitdown import DocumentConverter, DocumentConverterResult, StreamInfo

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -1,6 +1,4 @@
 import sys
-import io
-from warnings import warn
 
 from typing import BinaryIO, Any
 

--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -109,7 +109,7 @@ class ImageConverter(DocumentConverter):
         cur_pos = file_stream.tell()
         try:
             base64_image = base64.b64encode(file_stream.read()).decode("utf-8")
-        except Exception as e:
+        except Exception:
             return None
         finally:
             file_stream.seek(cur_pos)

--- a/packages/markitdown/src/markitdown/converters/_llm_caption.py
+++ b/packages/markitdown/src/markitdown/converters/_llm_caption.py
@@ -21,7 +21,7 @@ def llm_caption(
     cur_pos = file_stream.tell()
     try:
         base64_image = base64.b64encode(file_stream.read()).decode("utf-8")
-    except Exception as e:
+    except Exception:
         return None
     finally:
         file_stream.seek(cur_pos)

--- a/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
@@ -63,7 +63,7 @@ class OutlookMsgConverter(DocumentConverter):
                     "__properties_version1.0" in toc
                     and "__recip_version1.0_#00000000" in toc
                 )
-        except Exception as e:
+        except Exception:
             pass
         finally:
             file_stream.seek(cur_pos)

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -6,7 +6,6 @@ import re
 import html
 
 from typing import BinaryIO, Any
-from operator import attrgetter
 
 from ._html_converter import HtmlConverter
 from ._llm_caption import llm_caption


### PR DESCRIPTION
## Summary
- Remove unused `e` variable in 3 exception handlers (`_image_converter.py`, `_outlook_msg_converter.py`, `_llm_caption.py`) — the exception is caught but `e` is never referenced
- Remove unused imports: `io` and `warn` from `_docx_converter.py`, `attrgetter` from `_pptx_converter.py`
- Remove duplicate `BinaryIO, Any, Optional` import in `_pptx_converter_with_ocr.py`

All fixes are safe removals flagged by [ruff](https://docs.astral.sh/ruff/) (rules F841, F401, F811).

Found by [HUMMBL Arbiter](https://hummbl.io/audit) — deterministic code quality scoring for Python repositories.