### PR TITLE
refactor: replace print() with logging in YouTubeConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -8,7 +8,8 @@ from urllib.parse import parse_qs, urlparse, unquote
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
-logger = logging.getLogger(__name__) 
+
+logger = logging.getLogger(__name__)
 # Optional YouTube transcription support
 try:
     # Suppress some warnings on library import
@@ -113,7 +114,7 @@ class YouTubeConverter(DocumentConverter):
                             metadata["description"] = str(attrdesc.get("content", ""))
                     break
         except Exception as e:
-            logger.warning(f"Error extracting description: {e}")          
+            logger.warning(f"Error extracting description: {e}")
             pass
 
         # Start preparing the page

--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -2,12 +2,13 @@ import json
 import time
 import re
 import bs4
+import logging
 from typing import Any, BinaryIO, Dict, List, Union
 from urllib.parse import parse_qs, urlparse, unquote
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
-
+logger = logging.getLogger(__name__) 
 # Optional YouTube transcription support
 try:
     # Suppress some warnings on library import
@@ -112,7 +113,7 @@ class YouTubeConverter(DocumentConverter):
                             metadata["description"] = str(attrdesc.get("content", ""))
                     break
         except Exception as e:
-            print(f"Error extracting description: {e}")
+            logger.warning(f"Error extracting description: {e}")          
             pass
 
         # Start preparing the page
@@ -176,7 +177,7 @@ class YouTubeConverter(DocumentConverter):
                 except Exception as e:
                     # No transcript available
                     if len(languages) == 1:
-                        print(f"Error fetching transcript: {e}")
+                        logger.warning(f"Error fetching transcript: {e}")
                     else:
                         # Translate transcript into first kwarg
                         transcript = (
@@ -230,7 +231,7 @@ class YouTubeConverter(DocumentConverter):
             try:
                 return operation()  # Attempt the operation
             except Exception as e:
-                print(f"Attempt {attempt + 1} failed: {e}")
+                logger.warning(f"Attempt {attempt + 1} failed: {e}")
                 if attempt < retries - 1:
                     time.sleep(delay)  # Wait before retrying
                 attempt += 1

--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -76,8 +76,12 @@ class YouTubeConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Parse the stream
-        encoding = "utf-8" if stream_info.charset is None else stream_info.charset
-        soup = bs4.BeautifulSoup(file_stream, "html.parser", from_encoding=encoding)
+        encoding = (
+            "utf-8" if stream_info.charset is None else stream_info.charset
+        )
+        soup = bs4.BeautifulSoup(
+            file_stream, "html.parser", from_encoding=encoding
+        )
 
         # Read the meta tags
         metadata: Dict[str, str] = {}
@@ -109,9 +113,13 @@ class YouTubeConverter(DocumentConverter):
                     match = re.search(r"var ytInitialData = ({.*?});", content)
                     if match:
                         data = json.loads(match.group(1))
-                        attrdesc = self._findKey(data, "attributedDescriptionBodyText")
+                        attrdesc = self._findKey(
+                            data, "attributedDescriptionBodyText"
+                        )
                         if attrdesc and isinstance(attrdesc, dict):
-                            metadata["description"] = str(attrdesc.get("content", ""))
+                            metadata["description"] = str(
+                                attrdesc.get("content", "")
+                            )
                     break
         except Exception as e:
             logger.warning(f"Error extracting description: {e}")
@@ -186,7 +194,9 @@ class YouTubeConverter(DocumentConverter):
                             .translate(youtube_transcript_languages[0])
                             .fetch()
                         )
-                        transcript_text = " ".join([part.text for part in transcript])
+                        transcript_text = " ".join(
+                            [part.text for part in transcript]
+                        )
             if transcript_text:
                 webpage_text += f"\n### Transcript\n{transcript_text}\n"
 
@@ -210,7 +220,9 @@ class YouTubeConverter(DocumentConverter):
                 return metadata[k]
         return default
 
-    def _findKey(self, json: Any, key: str) -> Union[str, None]:  # TODO: Fix json type
+    def _findKey(
+        self, json: Any, key: str
+    ) -> Union[str, None]:  # TODO: Fix json type
         """Recursively search for a key in nested dictionary/list structures."""
         if isinstance(json, list):
             for elm in json:


### PR DESCRIPTION
Problem: YouTubeConverter used print() for error messages instead of 
the standard logging module, bypassing the app's logging configuration.

Solution: Added import logging and a module-level logger, then replaced 
all print() calls with logger.warning().