### PR TITLE
fix(pptx): handle missing text frames

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -161,10 +161,11 @@ class PptxConverter(DocumentConverter):
 
                 # Text areas
                 elif shape.has_text_frame:
+                    text = shape.text or ""
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\n"
+                        md_content += "# " + text.lstrip() + "\n"
                     else:
-                        md_content += shape.text + "\n"
+                        md_content += text + "\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -194,7 +195,7 @@ class PptxConverter(DocumentConverter):
                 md_content += "\n\n### Notes:\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
+                    md_content += notes_frame.text or ""
                 md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -506,6 +506,25 @@ def test_markitdown_llm_parameters() -> None:
     assert messages[0]["content"][0]["text"] == test_prompt
 
 
+def test_markitdown_pptx_handles_none_text() -> None:
+    import pptx.text.text
+
+    original_text = pptx.text.text.TextFrame.text
+
+    def _patched_text(self):
+        value = original_text.fget(self)
+        return None if value == "World" else value
+
+    try:
+        pptx.text.text.TextFrame.text = property(_patched_text)
+        result = MarkItDown().convert(os.path.join(TEST_FILES_DIR, "test.pptx"))
+    finally:
+        pptx.text.text.TextFrame.text = original_text
+
+    assert "### Notes:" in result.text_content
+    assert "AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation" in result.text_content
+
+
 @pytest.mark.skipif(
     skip_llm,
     reason="do not run llm tests without a key",
@@ -546,6 +565,7 @@ if __name__ == "__main__":
         test_doc_rlink,
         test_markitdown_exiftool,
         test_markitdown_llm_parameters,
+        test_markitdown_pptx_handles_none_text,
         test_markitdown_llm,
     ]:
         print(f"Running {test.__name__}...", end="")


### PR DESCRIPTION
## Summary
- treat `shape.text` and `notes_frame.text` as empty strings when python-pptx returns `None`
- avoid failing the whole PPTX conversion on malformed or third-party-generated decks
- add a regression test that patches a PPTX text frame getter to return `None`

## Verification
- `PYTHONPYCACHEPREFIX=/tmp/pycache-markitdown python3 -m py_compile packages/markitdown/src/markitdown/converters/_pptx_converter.py packages/markitdown/tests/test_module_misc.py`
- targeted `pytest` collection was blocked locally because this environment does not have `onnxruntime`, which is imported through `magika` during test startup

Closes #1808