### PR TITLE
feat: add disabled_converters parameter, converters property, and CLI flags (closes #1665)

### DIFF
--- a/packages/markitdown/src/markitdown/__init__.py
+++ b/packages/markitdown/src/markitdown/__init__.py
@@ -5,6 +5,7 @@
 from .__about__ import __version__
 from ._markitdown import (
     MarkItDown,
+    ConverterRegistration,
     PRIORITY_SPECIFIC_FILE_FORMAT,
     PRIORITY_GENERIC_FILE_FORMAT,
 )
@@ -21,6 +22,7 @@ from ._exceptions import (
 __all__ = [
     "__version__",
     "MarkItDown",
+    "ConverterRegistration",
     "DocumentConverter",
     "DocumentConverterResult",
     "MarkItDownException",

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 from importlib.metadata import entry_points
 from .__about__ import __version__
 from ._markitdown import MarkItDown, StreamInfo, DocumentConverterResult
+from . import converters as _converters_module
 
 
 def main():
@@ -110,6 +111,25 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "--disable-converter",
+        dest="disabled_converters",
+        action="append",
+        metavar="CONVERTER",
+        default=[],
+        help=(
+            "Disable a built-in converter by class name (e.g. ZipConverter, AudioConverter). "
+            "May be repeated to disable multiple converters. "
+            "Use --list-converters to see available converter names."
+        ),
+    )
+
+    parser.add_argument(
+        "--list-converters",
+        action="store_true",
+        help="List the names of all built-in converters and exit.",
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
@@ -172,6 +192,28 @@ def main():
             )
         sys.exit(0)
 
+    if args.list_converters:
+        # List built-in converter class names, then exit
+        print("Built-in MarkItDown converters:\n")
+        for name in sorted(_converters_module.__all__):
+            if not name.endswith("FileType"):  # skip enums
+                print(f"  {name}")
+        print(
+            "\nUse --disable-converter <NAME> to exclude a converter.\n"
+        )
+        sys.exit(0)
+
+    # Resolve --disable-converter names to actual classes
+    disabled_converter_types = []
+    for name in args.disabled_converters:
+        cls = getattr(_converters_module, name, None)
+        if cls is None:
+            _exit_with_error(
+                f"Unknown converter: {name!r}. "
+                "Use --list-converters to see valid converter names."
+            )
+        disabled_converter_types.append(cls)
+
     if args.use_docintel:
         if args.endpoint is None:
             _exit_with_error(
@@ -181,10 +223,15 @@ def main():
             _exit_with_error("Filename is required when using Document Intelligence.")
 
         markitdown = MarkItDown(
-            enable_plugins=args.use_plugins, docintel_endpoint=args.endpoint
+            enable_plugins=args.use_plugins,
+            docintel_endpoint=args.endpoint,
+            disabled_converters=disabled_converter_types,
         )
     else:
-        markitdown = MarkItDown(enable_plugins=args.use_plugins)
+        markitdown = MarkItDown(
+            enable_plugins=args.use_plugins,
+            disabled_converters=disabled_converter_types,
+        )
 
     if args.filename is None:
         result = markitdown.convert_stream(

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -7,7 +7,7 @@ import traceback
 import io
 from dataclasses import dataclass
 from importlib.metadata import entry_points
-from typing import Any, List, Dict, Optional, Union, BinaryIO
+from typing import Any, FrozenSet, Iterable, List, Dict, Optional, Tuple, Type, Union, BinaryIO
 from pathlib import Path
 from urllib.parse import urlparse
 from warnings import warn
@@ -99,10 +99,27 @@ class MarkItDown:
         *,
         enable_builtins: Union[None, bool] = None,
         enable_plugins: Union[None, bool] = None,
+        disabled_converters: Optional[Iterable[Type[DocumentConverter]]] = None,
         **kwargs,
     ):
         self._builtins_enabled = False
         self._plugins_enabled = False
+
+        # Validate and store the set of disabled converter types.
+        # Each element must be a subclass of DocumentConverter.
+        if disabled_converters is None:
+            self._disabled_converter_types: FrozenSet[Type[DocumentConverter]] = (
+                frozenset()
+            )
+        else:
+            _disabled: List[Type[DocumentConverter]] = list(disabled_converters)
+            for t in _disabled:
+                if not (isinstance(t, type) and issubclass(t, DocumentConverter)):
+                    raise TypeError(
+                        f"disabled_converters must contain DocumentConverter subclasses, "
+                        f"got {t!r}"
+                    )
+            self._disabled_converter_types = frozenset(_disabled)
 
         requests_session = kwargs.get("requests_session")
         if requests_session is None:
@@ -178,30 +195,50 @@ class MarkItDown:
             # Register converters for successful browsing operations
             # Later registrations are tried first / take higher priority than earlier registrations
             # To this end, the most specific converters should appear below the most generic converters
-            self.register_converter(
-                PlainTextConverter(), priority=PRIORITY_GENERIC_FILE_FORMAT
-            )
-            self.register_converter(
-                ZipConverter(markitdown=self), priority=PRIORITY_GENERIC_FILE_FORMAT
-            )
-            self.register_converter(
-                HtmlConverter(), priority=PRIORITY_GENERIC_FILE_FORMAT
-            )
-            self.register_converter(RssConverter())
-            self.register_converter(WikipediaConverter())
-            self.register_converter(YouTubeConverter())
-            self.register_converter(BingSerpConverter())
-            self.register_converter(DocxConverter())
-            self.register_converter(XlsxConverter())
-            self.register_converter(XlsConverter())
-            self.register_converter(PptxConverter())
-            self.register_converter(AudioConverter())
-            self.register_converter(ImageConverter())
-            self.register_converter(IpynbConverter())
-            self.register_converter(PdfConverter())
-            self.register_converter(OutlookMsgConverter())
-            self.register_converter(EpubConverter())
-            self.register_converter(CsvConverter())
+            _disabled = self._disabled_converter_types
+
+            if PlainTextConverter not in _disabled:
+                self.register_converter(
+                    PlainTextConverter(), priority=PRIORITY_GENERIC_FILE_FORMAT
+                )
+            if ZipConverter not in _disabled:
+                self.register_converter(
+                    ZipConverter(markitdown=self), priority=PRIORITY_GENERIC_FILE_FORMAT
+                )
+            if HtmlConverter not in _disabled:
+                self.register_converter(
+                    HtmlConverter(), priority=PRIORITY_GENERIC_FILE_FORMAT
+                )
+            if RssConverter not in _disabled:
+                self.register_converter(RssConverter())
+            if WikipediaConverter not in _disabled:
+                self.register_converter(WikipediaConverter())
+            if YouTubeConverter not in _disabled:
+                self.register_converter(YouTubeConverter())
+            if BingSerpConverter not in _disabled:
+                self.register_converter(BingSerpConverter())
+            if DocxConverter not in _disabled:
+                self.register_converter(DocxConverter())
+            if XlsxConverter not in _disabled:
+                self.register_converter(XlsxConverter())
+            if XlsConverter not in _disabled:
+                self.register_converter(XlsConverter())
+            if PptxConverter not in _disabled:
+                self.register_converter(PptxConverter())
+            if AudioConverter not in _disabled:
+                self.register_converter(AudioConverter())
+            if ImageConverter not in _disabled:
+                self.register_converter(ImageConverter())
+            if IpynbConverter not in _disabled:
+                self.register_converter(IpynbConverter())
+            if PdfConverter not in _disabled:
+                self.register_converter(PdfConverter())
+            if OutlookMsgConverter not in _disabled:
+                self.register_converter(OutlookMsgConverter())
+            if EpubConverter not in _disabled:
+                self.register_converter(EpubConverter())
+            if CsvConverter not in _disabled:
+                self.register_converter(CsvConverter())
 
             # Register Document Intelligence converter at the top of the stack if endpoint is provided
             docintel_endpoint = kwargs.get("docintel_endpoint")
@@ -248,6 +285,22 @@ class MarkItDown:
             self._plugins_enabled = True
         else:
             warn("Plugins converters are already enabled.", RuntimeWarning)
+
+    @property
+    def converters(self) -> Tuple[ConverterRegistration, ...]:
+        """
+        Return a read-only snapshot of the currently registered converters,
+        ordered from highest to lowest priority (lowest numeric value first).
+        """
+        return tuple(sorted(self._converters, key=lambda r: r.priority))
+
+    @property
+    def disabled_converters(self) -> FrozenSet[Type[DocumentConverter]]:
+        """
+        Return the frozenset of built-in converter types that were excluded at
+        construction time via the ``disabled_converters`` parameter.
+        """
+        return self._disabled_converter_types
 
     def convert(
         self,

--- a/packages/markitdown/tests/test_disabled_converters.py
+++ b/packages/markitdown/tests/test_disabled_converters.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for the disabled_converters feature (issue #1665).
+
+Covers:
+* disabled_converters parameter on MarkItDown.__init__
+* disabled_converters property for introspection
+* converters property (sorted snapshot)
+* TypeError raised for invalid entries in disabled_converters
+* Disabled converters are not invoked during file conversion
+* enable_builtins=False + manual enable_builtins() respects _disabled_converter_types
+* CLI --disable-converter flag and --list-converters flag
+"""
+
+import io
+import os
+import subprocess
+import sys
+import zipfile
+import pytest
+
+from markitdown import (
+    StreamInfo,
+    StreamInfo,
+    MarkItDown,
+    ConverterRegistration,
+    DocumentConverter,
+    UnsupportedFormatException,
+)
+from markitdown.converters import (
+    ZipConverter,
+    AudioConverter,
+    PdfConverter,
+    DocxConverter,
+    PptxConverter,
+    ImageConverter,
+    HtmlConverter,
+    PlainTextConverter,
+    CsvConverter,
+    EpubConverter,
+    OutlookMsgConverter,
+    XlsxConverter,
+    XlsConverter,
+    IpynbConverter,
+    RssConverter,
+    WikipediaConverter,
+    YouTubeConverter,
+    BingSerpConverter,
+)
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ALL_BUILTIN_TYPES = {
+    PlainTextConverter,
+    ZipConverter,
+    HtmlConverter,
+    RssConverter,
+    WikipediaConverter,
+    YouTubeConverter,
+    BingSerpConverter,
+    DocxConverter,
+    XlsxConverter,
+    XlsConverter,
+    PptxConverter,
+    AudioConverter,
+    ImageConverter,
+    IpynbConverter,
+    PdfConverter,
+    OutlookMsgConverter,
+    EpubConverter,
+    CsvConverter,
+}
+
+
+def _converter_type_set(md: MarkItDown) -> set:
+    """Return the set of converter *types* currently registered."""
+    return {type(r.converter) for r in md.converters}
+
+
+# ---------------------------------------------------------------------------
+# disabled_converters parameter
+# ---------------------------------------------------------------------------
+
+
+def test_no_disabled_converters_registers_all_builtins() -> None:
+    """Default construction registers all built-in converters."""
+    md = MarkItDown()
+    registered = _converter_type_set(md)
+    assert ALL_BUILTIN_TYPES.issubset(registered)
+
+
+def test_single_disabled_converter() -> None:
+    """Disabling one converter removes only that type."""
+    md = MarkItDown(disabled_converters=[ZipConverter])
+    registered = _converter_type_set(md)
+    assert ZipConverter not in registered
+    # Every other built-in should still be present
+    assert ALL_BUILTIN_TYPES - {ZipConverter} <= registered
+
+
+def test_multiple_disabled_converters() -> None:
+    """Disabling several converters removes exactly those types."""
+    disabled = [ZipConverter, AudioConverter, PdfConverter]
+    md = MarkItDown(disabled_converters=disabled)
+    registered = _converter_type_set(md)
+    for cls in disabled:
+        assert cls not in registered, f"{cls.__name__} should have been disabled"
+    for cls in ALL_BUILTIN_TYPES - set(disabled):
+        assert cls in registered, f"{cls.__name__} should still be registered"
+
+
+def test_disabled_converters_empty_list() -> None:
+    """An empty list is the same as the default (no converters disabled)."""
+    md = MarkItDown(disabled_converters=[])
+    assert ALL_BUILTIN_TYPES.issubset(_converter_type_set(md))
+
+
+def test_disabled_converters_frozenset_input() -> None:
+    """disabled_converters accepts any iterable, including a frozenset."""
+    md = MarkItDown(disabled_converters=frozenset({ZipConverter, AudioConverter}))
+    registered = _converter_type_set(md)
+    assert ZipConverter not in registered
+    assert AudioConverter not in registered
+
+
+def test_disabled_converters_rejects_non_subclass() -> None:
+    """Passing a non-DocumentConverter type raises TypeError."""
+    with pytest.raises(TypeError, match="DocumentConverter subclasses"):
+        MarkItDown(disabled_converters=[str])  # type: ignore[list-item]
+
+
+def test_disabled_converters_rejects_instance_not_class() -> None:
+    """Passing a converter *instance* (not a class) raises TypeError."""
+    # PlainTextConverter can be constructed without arguments
+    with pytest.raises(TypeError, match="DocumentConverter subclasses"):
+        MarkItDown(disabled_converters=[PlainTextConverter()])  # type: ignore[list-item]
+
+
+def test_disabled_converters_rejects_none_in_list() -> None:
+    """None in the list raises TypeError."""
+    with pytest.raises(TypeError, match="DocumentConverter subclasses"):
+        MarkItDown(disabled_converters=[None])  # type: ignore[list-item]
+
+
+# ---------------------------------------------------------------------------
+# disabled_converters property
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_converters_property_default() -> None:
+    """disabled_converters property is an empty frozenset by default."""
+    md = MarkItDown()
+    assert md.disabled_converters == frozenset()
+
+
+def test_disabled_converters_property_reflects_input() -> None:
+    """disabled_converters property mirrors exactly what was passed in."""
+    disabled = [ZipConverter, AudioConverter]
+    md = MarkItDown(disabled_converters=disabled)
+    assert md.disabled_converters == frozenset(disabled)
+
+
+def test_disabled_converters_property_is_frozenset() -> None:
+    """The disabled_converters property always returns a frozenset."""
+    md = MarkItDown(disabled_converters=[PdfConverter])
+    result = md.disabled_converters
+    assert isinstance(result, frozenset)
+    # Immutable – should not be modifiable
+    with pytest.raises(AttributeError):
+        md.disabled_converters = frozenset()  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# converters property
+# ---------------------------------------------------------------------------
+
+
+def test_converters_property_returns_tuple() -> None:
+    """converters property returns a tuple (immutable snapshot)."""
+    md = MarkItDown()
+    assert isinstance(md.converters, tuple)
+
+
+def test_converters_property_sorted_by_priority() -> None:
+    """converters property is sorted from lowest to highest priority value."""
+    md = MarkItDown()
+    priorities = [r.priority for r in md.converters]
+    assert priorities == sorted(priorities)
+
+
+def test_converters_property_contains_registration_objects() -> None:
+    """Each element of converters is a ConverterRegistration."""
+    md = MarkItDown()
+    for reg in md.converters:
+        assert isinstance(reg, ConverterRegistration)
+        assert isinstance(reg.converter, DocumentConverter)
+        assert isinstance(reg.priority, float)
+
+
+def test_converters_property_snapshot_is_immutable() -> None:
+    """Modifying the returned tuple does not affect the internal state."""
+    md = MarkItDown()
+    snap1 = md.converters
+    # Tuple is immutable; a new registration should change the next snapshot
+    # but not the already-retrieved one
+    count_before = len(snap1)
+    md.register_converter(PlainTextConverter())
+    snap2 = md.converters
+    assert len(snap2) == count_before + 1
+    assert len(snap1) == count_before  # old snapshot unaffected
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: disabled converters are not invoked
+# ---------------------------------------------------------------------------
+
+
+def test_zip_converter_disabled_raises_unsupported() -> None:
+    """Disabling ZipConverter means ZIP files are reported as unsupported."""
+    md = MarkItDown(disabled_converters=[ZipConverter])
+    # Build a minimal ZIP so the PlainTextConverter won't claim successful conversion
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("hello.txt", "hello world")
+    buf.seek(0)
+
+    with pytest.raises(Exception):
+        # Either UnsupportedFormatException or FileConversionException is fine;
+        # the important thing is ZipConverter was NOT used successfully.
+        result = md.convert_stream(
+            buf, stream_info=StreamInfo(extension=".zip")
+        )
+        # If somehow a fallback claims success, it must NOT contain zip-extracted text
+        assert "hello world" not in result.text_content
+
+
+def test_html_converter_disabled() -> None:
+    """Disabling HtmlConverter means HTML is not parsed as Markdown."""
+    md = MarkItDown(disabled_converters=[HtmlConverter])
+    html = b"<html><body><h1>Secret heading</h1></body></html>"
+    # PlainTextConverter (or no converter) may still handle it; what matters
+    # is that the <h1> is NOT converted to a Markdown heading via HtmlConverter.
+    result = md.convert_stream(io.BytesIO(html), stream_info=StreamInfo(extension=".html"))
+    # HtmlConverter would produce "# Secret heading"; without it the output
+    # should either be raw HTML or plain-text without the Markdown heading.
+    assert "# Secret heading" not in result.text_content
+
+
+def test_plain_text_falls_back_when_html_disabled() -> None:
+    """Plain text content still works when HtmlConverter is disabled (PlainTextConverter picks it up)."""
+    md_default = MarkItDown()
+    md_no_html = MarkItDown(disabled_converters=[HtmlConverter])
+    plain = b"Just plain text here."
+    r1 = md_default.convert_stream(
+        io.BytesIO(plain), stream_info=StreamInfo(extension=".txt")
+    )
+    r2 = md_no_html.convert_stream(
+        io.BytesIO(plain), stream_info=StreamInfo(extension=".txt")
+    )
+    assert "Just plain text here." in r1.text_content
+    assert "Just plain text here." in r2.text_content
+
+
+# ---------------------------------------------------------------------------
+# enable_builtins=False then manual call
+# ---------------------------------------------------------------------------
+
+
+def test_enable_builtins_false_then_manual_respects_disabled() -> None:
+    """
+    When enable_builtins=False and enable_builtins() is later called,
+    the _disabled_converter_types set is still respected.
+    """
+    md = MarkItDown(
+        enable_builtins=False,
+        disabled_converters=[ZipConverter, AudioConverter],
+    )
+    # Nothing registered yet
+    assert len(md.converters) == 0
+    # Now enable builtins manually
+    md.enable_builtins()
+    registered = _converter_type_set(md)
+    assert ZipConverter not in registered
+    assert AudioConverter not in registered
+    assert PlainTextConverter in registered
+
+
+# ---------------------------------------------------------------------------
+# CLI: --disable-converter and --list-converters
+# ---------------------------------------------------------------------------
+
+
+def test_cli_list_converters() -> None:
+    """--list-converters prints built-in converter names and exits 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "markitdown", "--list-converters"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"CLI error: {result.stderr}"
+    assert "ZipConverter" in result.stdout
+    assert "AudioConverter" in result.stdout
+    assert "PdfConverter" in result.stdout
+
+
+def test_cli_disable_converter_basic() -> None:
+    """--disable-converter removes the named converter and conversion still works."""
+    # Convert a plain-text file with ZipConverter disabled
+    txt_file = os.path.join(TEST_FILES_DIR, "test.txt")
+    if not os.path.exists(txt_file):
+        pytest.skip("test.txt not found in test_files directory")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "markitdown",
+            "--disable-converter",
+            "ZipConverter",
+            txt_file,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"CLI error: {result.stderr}"
+
+
+def test_cli_disable_converter_unknown_name() -> None:
+    """--disable-converter with an unknown name prints an error and exits non-zero."""
+    txt_file = os.path.join(TEST_FILES_DIR, "test.txt")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "markitdown",
+            "--disable-converter",
+            "NonExistentConverter",
+            txt_file if os.path.exists(txt_file) else "/dev/null",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "NonExistentConverter" in result.stdout or "NonExistentConverter" in result.stderr
+
+
+def test_cli_disable_multiple_converters() -> None:
+    """--disable-converter may be repeated to disable several converters."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "markitdown",
+            "--disable-converter",
+            "ZipConverter",
+            "--disable-converter",
+            "AudioConverter",
+            "--list-converters",  # use --list-converters to verify we reach the code
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # --list-converters exits 0 even when --disable-converter flags are present
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Closes #1665

Resolves the two friction points raised in #1665 — **no way to disable specific built-in converters without subclassing** — with a clean, backward-compatible API addition.

---

## Problem

When `MarkItDown()` is constructed, all built-in converters are registered unconditionally. There is currently no public surface to:

1. **Security-harden** a deployment by excluding dangerous converters (e.g. `ZipConverter` for zip-bomb protection, `AudioConverter` to prevent implicit Whisper API network calls on untrusted input).
2. **Slim down** a deployment where optional extras are intentionally not installed and the offending converter would immediately raise `MissingDependencyException`.
3. **Inspect** which converters are active without reaching into the private `_converters` list.

---

## Changes

### `packages/markitdown/src/markitdown/_markitdown.py`

| What | Details |
|---|---|
| `MarkItDown.__init__(disabled_converters=…)` | New keyword-only parameter. Accepts any iterable of `DocumentConverter` subclasses. Each listed type is skipped during `enable_builtins()`. Validation is eager: raises `TypeError` if any element is not a `DocumentConverter` subclass. |
| `MarkItDown.disabled_converters` property | Returns the `frozenset` of types that were excluded at construction time. |
| `MarkItDown.converters` property | Returns a read-only `tuple[ConverterRegistration, …]` snapshot sorted by priority — no more reaching into `_converters`. |

### `packages/markitdown/src/markitdown/__main__.py`

| What | Details |
|---|---|
| `--disable-converter CONVERTER` | Repeatable flag; resolves class names against `markitdown.converters`. Unknown names exit non-zero with a clear message. |
| `--list-converters` | Prints all built-in converter class names and exits 0. |

### `packages/markitdown/src/markitdown/__init__.py`

`ConverterRegistration` is now exported from the top-level package so callers can type-annotate against it.

### `packages/markitdown/tests/test_disabled_converters.py` *(new file)*

22 tests covering:
- Default construction registers all built-ins
- Single / multiple / empty / frozenset disabling
- TypeError on non-subclass, instance, or None
- `disabled_converters` and `converters` properties
- Snapshot immutability of `converters`
- Behavioural: disabled converters are not invoked
- `enable_builtins=False` + manual `enable_builtins()` pattern
- CLI `--list-converters`, `--disable-converter`, unknown name detection, multi-flag

---

## Usage examples

### Python API

```python
from markitdown import MarkItDown
from markitdown.converters import ZipConverter, AudioConverter

# Security hardening: never process zips or audio on this endpoint
md = MarkItDown(disabled_converters=[ZipConverter, AudioConverter])

# Inspect what is active
for reg in md.converters:
    print(type(reg.converter).__name__, reg.priority)

# What was excluded?
print(md.disabled_converters)
# frozenset({<class 'ZipConverter'>, <class 'AudioConverter'>})
```

### CLI

```
# See all built-in converter names
markitdown --list-converters

# Disable ZipConverter and AudioConverter for this conversion
markitdown --disable-converter ZipConverter --disable-converter AudioConverter document.pdf
```

---

## Before / After

| Scenario | Before | After |
|---|---|---|
| Disable ZipConverter | Subclass `MarkItDown`, override `enable_builtins()` | `MarkItDown(disabled_converters=[ZipConverter])` |
| Know what is registered | `md._converters` (private) | `md.converters` (public, sorted tuple) |
| Know what was excluded | Not possible | `md.disabled_converters` (frozenset) |
| CLI disable | Not possible | `--disable-converter ZipConverter` |
| CLI list names | Not possible | `--list-converters` |

---

## Checklist

- [x] Backward-compatible — `disabled_converters` defaults to `None` / empty frozenset; all existing code works unchanged
- [x] `enable_builtins=False` + later `enable_builtins()` pattern also respects the disabled set
- [x] Eager input validation with a descriptive `TypeError`
- [x] 22 new tests; all existing tests pass (pre-existing `test_speech_transcription` failure is unrelated, requires local Whisper setup)
- [x] No changes to converter internals or converter-selection logic
