### PR TITLE
fix(csv): escape pipes and newlines in CSV cells

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -54,23 +54,29 @@ class CsvConverter(DocumentConverter):
         if not rows:
             return DocumentConverterResult(markdown="")
 
+        def escape_cell(value: str) -> str:
+            # Escape pipes and collapse newlines so a single cell can't break
+            # the surrounding markdown table layout.
+            return value.replace("\\", "\\\\").replace("|", "\\|").replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+
         # Create markdown table
         markdown_table = []
+        header = [escape_cell(c) for c in rows[0]]
 
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        markdown_table.append("| " + " | ".join(header) + " |")
 
         # Add separator row
-        markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
+        markdown_table.append("| " + " | ".join(["---"] * len(header)) + " |")
 
         # Add data rows
         for row in rows[1:]:
             # Make sure row has the same number of columns as header
-            while len(row) < len(rows[0]):
+            while len(row) < len(header):
                 row.append("")
             # Truncate if row has more columns than header
-            row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+            row = row[: len(header)]
+            markdown_table.append("| " + " | ".join(escape_cell(c) for c in row) + " |")
 
         result = "\n".join(markdown_table)
 


### PR DESCRIPTION

**Repo:** microsoft/markitdown (⭐ 113363)
**Type:** bugfix
**Files changed:** 1
**Lines:** +11/-5

## What
The CSV converter builds a GitHub-flavored markdown table by joining raw CSV cell values with ` | `. When a cell contains an unescaped `|` character or an embedded newline (both legal in quoted CSV fields), the emitted markdown table breaks: columns shift, rows split, and downstream markdown renderers misalign the table. This change introduces an `escape_cell` helper that escapes backslashes and pipes, and collapses CR/LF sequences to spaces, before the values are joined into the table.

## Why
CSV files frequently contain free-text cells with punctuation or multi-line values (addresses, descriptions, log entries). Producing malformed markdown for them is a correctness bug in a lossy direction — users won't notice until they render or parse the markdown downstream. The fix is local to the converter, handles header and data rows symmetrically, and follows the standard markdown table escaping convention (`\|`).

## Testing
- Manual: a single-column CSV with a value `a|b` previously produced `| a|b |` (2 visible columns); now produces `| a\|b |` (1 column, as intended).
- A cell containing `"line1\nline2"` previously split the row in two; it now renders as `line1 line2` on a single row.
- No existing tests reference CSV pipe/newline escaping, so behavior for well-formed CSVs without these characters is unchanged.

## Risk
Low — change is confined to one converter's output formatting; escaping is the markdown-standard convention and only activates on characters that otherwise corrupt the table.
