### PR TITLE
Fix text handling in PPTX converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -162,9 +162,9 @@ class PptxConverter(DocumentConverter):
                 # Text areas
                 elif shape.has_text_frame:
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\n"
+                        md_content += "# " + (shape.text or "").lstrip() + "\n"
                     else:
-                        md_content += shape.text + "\n"
+                        md_content += (shape.text or "") + "\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -194,7 +194,7 @@ class PptxConverter(DocumentConverter):
                 md_content += "\n\n### Notes:\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
+                    md_content += (notes_frame.text or "")
                 md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())


### PR DESCRIPTION
fix: handle None text in PptxConverter to prevent TypeError

Fixes #1808

When PowerPoint slides contain None text values (from malformed shapes or third-party-generated PPTX files), PptxConverter would crash with: "TypeError: can only concatenate str (not 'NoneType') to str"

Updated three lines to safely handle None values using the `or ""` pattern:
- Line 165: Title text concatenation
- Line 167: Shape text concatenation  
- Line 197: Notes frame text concatenation

This ensures that a single malformed shape no longer fails the entire file conversion.