### PR TITLE
fix: handle case-mismatched zip entry names in .docx files

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -1,3 +1,4 @@
+import struct
 import zipfile
 from io import BytesIO
 from typing import BinaryIO
@@ -115,6 +116,49 @@ def _pre_process_math(content: bytes) -> bytes:
     return str(soup).encode()
 
 
+def _fix_zip_name_casing(input_docx: BinaryIO) -> BinaryIO:
+    """
+    Fixes case mismatches between zip central directory and local file headers.
+
+    Some .docx files produced by certain tools have inconsistent casing between the zip
+    central directory (e.g. ``customXml/item2.xml``) and local file headers
+    (e.g. ``customXML/item2.xml``).  Python's ``zipfile`` module strictly validates this
+    and raises ``BadZipFile``.  The central directory is authoritative per the zip spec,
+    so this function patches any mismatched local headers in memory before the zip is
+    opened for real.  Only entries whose names differ solely in case (and therefore have
+    the same byte length) are touched.
+
+    Args:
+        input_docx (BinaryIO): A binary input stream representing the DOCX file.
+
+    Returns:
+        BinaryIO: A patched ``BytesIO`` if any entries were fixed, otherwise the original
+        stream rewound to the start.
+    """
+    input_docx.seek(0)
+    raw = bytearray(input_docx.read())
+    patched = False
+    try:
+        with zipfile.ZipFile(BytesIO(bytes(raw)), mode="r") as zf:
+            for info in zf.infolist():
+                offset = info.header_offset
+                if raw[offset : offset + 4] != b"PK\x03\x04":
+                    continue
+                fname_len = struct.unpack_from("<H", raw, offset + 26)[0]
+                local_name = bytes(raw[offset + 30 : offset + 30 + fname_len])
+                central_name = info.filename.encode("utf-8")
+                if local_name != central_name and len(local_name) == len(central_name):
+                    raw[offset + 30 : offset + 30 + fname_len] = central_name
+                    patched = True
+    except zipfile.BadZipFile:
+        input_docx.seek(0)
+        return input_docx
+    if patched:
+        return BytesIO(bytes(raw))
+    input_docx.seek(0)
+    return input_docx
+
+
 def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
     """
     Pre-processes a DOCX file with provided steps.
@@ -129,6 +173,7 @@ def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
     Returns:
         BinaryIO: A binary output stream representing the processed DOCX file.
     """
+    input_docx = _fix_zip_name_casing(input_docx)
     output_docx = BytesIO()
     # The files that need to be pre-processed from .docx
     pre_process_enable_files = [

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -274,6 +274,55 @@ def test_docx_equations() -> None:
     assert block_equations, "No block equations found in the document."
 
 
+def test_fix_zip_name_casing() -> None:
+    """Test that _fix_zip_name_casing patches local file headers with case-mismatched names.
+
+    Some .docx files produced by certain tools have inconsistent casing between the zip
+    central directory and local file headers (e.g. 'customXml/item2.xml' in the central
+    directory vs 'customXML/item2.xml' in the local header). This causes Python's zipfile
+    module to raise BadZipFile. The fix patches the local headers to match the central
+    directory before the zip is opened for real processing. See issue #1812.
+    """
+    import struct
+    import zipfile
+    from io import BytesIO
+
+    from markitdown.converter_utils.docx.pre_process import _fix_zip_name_casing
+
+    # Build a valid zip in memory with two entries
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, mode="w") as zf:
+        zf.writestr("customXml/item1.xml", b"<root/>")
+        zf.writestr("customXml/item2.xml", b"<root/>")
+    raw = bytearray(buf.getvalue())
+
+    # Patch the local file header of the second entry to use 'customXML' (capital L)
+    # so it mismatches the central directory entry 'customXml/item2.xml'.
+    # In a zip file the local file headers come before the central directory, so the
+    # FIRST occurrence of 'customXml/item2.xml' in the raw bytes is the local header
+    # we want to corrupt; the SECOND occurrence is the central directory entry which
+    # we intentionally leave unchanged (it remains authoritative).
+    target_local = b"customXml/item2.xml"
+    replacement_local = b"customXML/item2.xml"
+    idx = raw.find(target_local)
+    assert idx != -1, "Test setup: could not find target local header in zip bytes"
+    raw[idx : idx + len(target_local)] = replacement_local
+
+    # Verify the raw zip now raises BadZipFile when we try to read the patched entry
+    with zipfile.ZipFile(BytesIO(bytes(raw)), mode="r") as zf:
+        zf.read("customXml/item1.xml")  # this one is fine
+        with pytest.raises(zipfile.BadZipFile):
+            zf.read("customXml/item2.xml")  # this raises due to local header mismatch
+
+    # Apply the fix
+    fixed = _fix_zip_name_casing(BytesIO(bytes(raw)))
+
+    # After fixing, both entries should be readable without error
+    with zipfile.ZipFile(fixed, mode="r") as zf:
+        assert zf.read("customXml/item1.xml") == b"<root/>"
+        assert zf.read("customXml/item2.xml") == b"<root/>"
+
+
 def test_input_as_strings() -> None:
     markitdown = MarkItDown()
 


### PR DESCRIPTION
Fixes #1812

## Problem

Some `.docx` files produced by certain tools (e.g. legal document systems) have inconsistent casing between the zip central directory and local file headers — for example, the central directory lists `customXml/item2.xml` but the local file header contains `customXML/item2.xml`. This is technically a violation of the zip spec, but is produced by certain versions of Microsoft Word and third-party tools.

Python's `zipfile` module strictly validates this match and raises `BadZipFile`:

```
markitdown._exceptions.FileConversionException: File conversion failed after 1 attempts:
 - DocxConverter threw BadZipFile with message: File name in directory 'customXml/item2.xml' and header b'customXML/item2.xml' differ.
```

## Solution

Add `_fix_zip_name_casing()` to `converter_utils/docx/pre_process.py`. This function:

1. Reads the raw zip bytes into a `bytearray`
2. Opens the zip using `zipfile.ZipFile` (which reads the central directory first — this succeeds even with mismatched local headers)
3. For each central directory entry, finds the corresponding local file header at `header_offset`
4. If the local filename differs from the central directory filename only in case (same byte length), patches the local header bytes in-place
5. Returns a patched `BytesIO` if any headers were fixed, otherwise returns the original stream unchanged

The central directory is authoritative per the zip spec. The patch is safe: it only applies to case-only differences (same byte length in ASCII paths), so no offset recalculation is needed.

`pre_process_docx()` now calls `_fix_zip_name_casing()` as its first step, before opening the zip for math pre-processing.

## Testing

Added `test_fix_zip_name_casing()` in `test_module_misc.py` that:
- Builds a valid two-entry zip in memory
- Deliberately corrupts the local file header of one entry to introduce a case mismatch
- Asserts that reading the corrupted entry raises `BadZipFile` (reproduces the bug)
- Applies `_fix_zip_name_casing()` and asserts both entries are now readable without error