### PR TITLE
fix: OCR scanned pages when mixed with text pages

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
@@ -280,6 +280,13 @@ class PdfConverterWithOCR(DocumentConverter):
                             text_content = page.extract_text() or ""
                             if text_content.strip():
                                 markdown_content.append(text_content.strip())
+                            else:
+                                # Scanned page with no image objects or text layer:
+                                # render the whole page and OCR it, so it doesn't
+                                # silently vanish from the output.
+                                page_ocr = self._ocr_page(page, ocr_service)
+                                if page_ocr:
+                                    markdown_content.append(page_ocr)
                     else:
                         # No OCR, just extract text
                         text_content = page.extract_text() or ""
@@ -336,6 +343,27 @@ class PdfConverterWithOCR(DocumentConverter):
         images.sort(key=lambda x: x["y_pos"])
 
         return images
+
+    def _ocr_page(self, page: Any, ocr_service: LLMVisionOCRService) -> str:
+        """
+        Render a single pdfplumber page to PNG and run OCR on it.
+
+        Returns a formatted OCR block, a 'no text' marker if OCR is empty,
+        or an error marker if rendering/OCR raises.
+        """
+        try:
+            page_img = page.to_image(resolution=300)
+            img_stream = io.BytesIO()
+            page_img.original.save(img_stream, format="PNG")
+            img_stream.seek(0)
+
+            ocr_result = ocr_service.extract_text(img_stream)
+            text = (ocr_result.text or "").strip()
+            if text:
+                return f"*[Image OCR]\n{text}\n[End OCR]*"
+            return "*[No text could be extracted from this page]*"
+        except Exception as e:
+            return f"*[Error processing page {page.page_number}: {str(e)}]*"
 
     def _ocr_full_pages(
         self, pdf_bytes: io.BytesIO, ocr_service: LLMVisionOCRService

--- a/packages/markitdown-ocr/tests/ocr_test_data/pdf_text_then_blank.pdf
+++ b/packages/markitdown-ocr/tests/ocr_test_data/pdf_text_then_blank.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260422131200-04'00') /Creator (anonymous) /Keywords () /ModDate (D:20260422131200-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 2 /Kids [ 3 0 R 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 132
+>>
+stream
+Gap@E0a`Ou'L[:DnOb%BpdMD'grf1p@+hUo5pQ46O.VEQ$j1Db7];L2b-4./]UU*%3[.;OTEDl>WL%tcf#\Z<OLrhf(n7-AiO`8um7BEWpVGi.Ipe,U#<JX!s+]kFd[hH<~>endstream
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 59
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_PP$O!3^,C5Q~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000061 00000 n 
+0000000092 00000 n 
+0000000199 00000 n 
+0000000392 00000 n 
+0000000585 00000 n 
+0000000653 00000 n 
+0000000914 00000 n 
+0000000979 00000 n 
+0000001201 00000 n 
+trailer
+<<
+/ID 
+[<eb8881dfad71505b489b1d3b511a4d19><eb8881dfad71505b489b1d3b511a4d19>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 10
+>>
+startxref
+1349
+%%EOF

--- a/packages/markitdown-ocr/tests/test_pdf_converter.py
+++ b/packages/markitdown-ocr/tests/test_pdf_converter.py
@@ -190,6 +190,22 @@ def test_pdf_scanned_report(svc: MockOCRService) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Mixed text + scanned pages: a page with neither image objects nor a text
+# layer must still be OCR'd inline rather than silently dropped.
+# Regression test for microsoft/markitdown#1791.
+# ---------------------------------------------------------------------------
+
+
+def test_pdf_text_then_blank_page_is_ocred(svc: MockOCRService) -> None:
+    expected = (
+        "## Page 1\n\n\n"
+        "First page content, extracted as text.\n\n\n"
+        f"## Page 2\n\n\n{_OCR_BLOCK}"
+    )
+    assert _convert("pdf_text_then_blank.pdf", svc) == expected
+
+
+# ---------------------------------------------------------------------------
 # Scanned PDF fallback path (pdfplumber finds no text → full-page OCR)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes Microsoft/markitdown#1791

- When a multi-page PDF mixed selectable text with scanned pages, the converter only emitted content for pages that had either an image object or an extractable text layer. A scanned page with neither (no `page.images`, no `page.extract_text()`) silently fell through, and the whole-document `_ocr_full_pages` fallback only runs when every page is empty. So pages 2..N just disappeared.

- This adds a small `_ocr_page` helper that renders a single pdfplumber page to PNG and runs the configured OCR service on it, and calls it from the per-page loop when the page yields nothing the existing branches can use. The output format matches what `_ocr_full_pages` already emits, so existing snapshot tests are unaffected.

Test: new `pdf_text_then_blank.pdf` fixture (~1.7 KB, page 1 has selectable text, page 2 is blank) plus a snapshot test that asserts both pages survive the round-trip.
