### PR TITLE
feat: Add batch conversion API and CLI support

### DIFF
--- a/docs/superpowers/plans/2026-04-23-batch-parallelization.md
+++ b/docs/superpowers/plans/2026-04-23-batch-parallelization.md
@@ -1,0 +1,756 @@
+# Batch Parallelization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add parallel batch conversion to the `markitdown` library (`convert_batch()`) and CLI (multi-file arguments).
+
+**Architecture:** A new `BatchConversionResult` dataclass pairs each result with its source. `convert_batch()` submits all conversions to a `ThreadPoolExecutor` and yields results in completion order via `as_completed()`. The CLI multi-file path calls `convert_batch()` and routes output to stdout or `--output-dir`.
+
+**Tech Stack:** Python 3.10+, `concurrent.futures.ThreadPoolExecutor`, `concurrent.futures.as_completed`, `dataclasses`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `packages/markitdown/src/markitdown/_base_converter.py` | Add `BatchConversionResult` dataclass |
+| `packages/markitdown/src/markitdown/_markitdown.py` | Add `convert_batch()` method |
+| `packages/markitdown/src/markitdown/__init__.py` | Export `BatchConversionResult` |
+| `packages/markitdown/src/markitdown/__main__.py` | Multi-file CLI: `nargs="*"`, `--workers`, `--fail-fast`, `--output-dir` |
+| `packages/markitdown/tests/test_batch.py` | New test file for library batch API |
+| `packages/markitdown/tests/test_cli_misc.py` | Extend with CLI batch tests |
+
+---
+
+## Task 1: Add `BatchConversionResult` dataclass
+
+**Files:**
+- Modify: `packages/markitdown/src/markitdown/_base_converter.py`
+- Create: `packages/markitdown/tests/test_batch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/markitdown/tests/test_batch.py`:
+
+```python
+import pytest
+from markitdown._base_converter import BatchConversionResult, DocumentConverterResult
+
+
+def test_batch_result_success_true():
+    r = BatchConversionResult(
+        source="test.txt",
+        result=DocumentConverterResult(markdown="# Hello"),
+    )
+    assert r.success is True
+    assert r.result is not None
+    assert r.error is None
+
+
+def test_batch_result_success_false():
+    r = BatchConversionResult(source="test.txt", error=ValueError("oops"))
+    assert r.success is False
+    assert r.result is None
+    assert r.error is not None
+
+
+def test_batch_result_defaults():
+    r = BatchConversionResult(source="test.txt")
+    assert r.result is None
+    assert r.error is None
+    assert r.success is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+cd packages/markitdown
+pytest tests/test_batch.py -v
+```
+
+Expected: `ImportError` — `BatchConversionResult` does not exist yet.
+
+- [ ] **Step 3: Add `BatchConversionResult` to `_base_converter.py`**
+
+Add the following imports at the top of `packages/markitdown/src/markitdown/_base_converter.py`:
+
+```python
+from dataclasses import dataclass, field
+```
+
+Add this class **after** `DocumentConverterResult` and **before** `DocumentConverter`:
+
+```python
+@dataclass
+class BatchConversionResult:
+    """Result of a single conversion within a convert_batch() call."""
+
+    source: Any  # The original input passed to convert_batch()
+    result: Optional["DocumentConverterResult"] = None
+    error: Optional[Exception] = None
+
+    @property
+    def success(self) -> bool:
+        return self.error is None
+```
+
+The existing `from typing import Any, BinaryIO, Optional` import already covers `Any` and `Optional`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+cd packages/markitdown
+pytest tests/test_batch.py -v
+```
+
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markitdown/src/markitdown/_base_converter.py packages/markitdown/tests/test_batch.py
+git commit -m "feat: add BatchConversionResult dataclass"
+```
+
+---
+
+## Task 2: Add `convert_batch()` to `MarkItDown`
+
+**Files:**
+- Modify: `packages/markitdown/src/markitdown/_markitdown.py`
+- Modify: `packages/markitdown/tests/test_batch.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/markitdown/tests/test_batch.py`:
+
+```python
+import os
+import concurrent.futures
+from markitdown import MarkItDown, BatchConversionResult, DocumentConverterResult
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+
+def test_convert_batch_basic():
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "test.pdf"),
+        os.path.join(TEST_FILES_DIR, "test.pptx"),
+    ]
+    results = list(md.convert_batch(sources))
+    assert len(results) == 3
+    assert all(isinstance(r, BatchConversionResult) for r in results)
+    assert all(r.success for r in results)
+    assert all(isinstance(r.result, DocumentConverterResult) for r in results)
+    assert {r.source for r in results} == set(sources)
+
+
+def test_convert_batch_on_error_collect():
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "nonexistent_file_xyz.docx"),
+    ]
+    results = list(md.convert_batch(sources, on_error="collect"))
+    assert len(results) == 2
+    successful = [r for r in results if r.success]
+    failed = [r for r in results if not r.success]
+    assert len(successful) == 1
+    assert len(failed) == 1
+    assert failed[0].error is not None
+
+
+def test_convert_batch_on_error_raise():
+    md = MarkItDown()
+    sources = [os.path.join(TEST_FILES_DIR, "nonexistent_file_xyz.docx")]
+    with pytest.raises(Exception):
+        list(md.convert_batch(sources, on_error="raise"))
+
+
+def test_convert_batch_invalid_on_error():
+    md = MarkItDown()
+    with pytest.raises(ValueError, match="on_error"):
+        list(md.convert_batch([], on_error="bad_value"))
+
+
+def test_convert_batch_empty():
+    md = MarkItDown()
+    results = list(md.convert_batch([]))
+    assert results == []
+
+
+def test_convert_batch_custom_executor():
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "test.pdf"),
+    ]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(md.convert_batch(sources, executor=executor))
+    assert len(results) == 2
+    assert all(r.success for r in results)
+
+
+def test_convert_batch_workers_param():
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "test.pdf"),
+    ]
+    results = list(md.convert_batch(sources, workers=1))
+    assert len(results) == 2
+    assert all(r.success for r in results)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd packages/markitdown
+pytest tests/test_batch.py -v
+```
+
+Expected: `AttributeError` — `MarkItDown` has no `convert_batch`.
+
+- [ ] **Step 3: Add imports to `_markitdown.py`**
+
+At the top of `packages/markitdown/src/markitdown/_markitdown.py`, add to the existing imports:
+
+```python
+import concurrent.futures
+from typing import Any, List, Dict, Optional, Union, BinaryIO, Iterator, Iterable
+```
+
+(Replace the existing `from typing import Any, List, Dict, Optional, Union, BinaryIO` line — just add `Iterator, Iterable` to it.)
+
+Also add to the `_base_converter` import line:
+
+```python
+from ._base_converter import DocumentConverter, DocumentConverterResult, BatchConversionResult
+```
+
+- [ ] **Step 4: Add `convert_batch()` method to `MarkItDown`**
+
+Add this method to the `MarkItDown` class in `_markitdown.py`, after the `convert()` method (around line 300):
+
+```python
+def convert_batch(
+    self,
+    sources: Iterable[Union[str, Path, BinaryIO, "requests.Response"]],
+    *,
+    on_error: str = "collect",
+    workers: Optional[int] = None,
+    executor: Optional[concurrent.futures.Executor] = None,
+    **kwargs: Any,
+) -> Iterator[BatchConversionResult]:
+    """Convert multiple sources concurrently.
+
+    Yields BatchConversionResult instances in completion order.
+
+    Args:
+        sources: Iterable of inputs accepted by convert().
+        on_error: "collect" wraps errors and continues; "raise" re-raises the first error.
+        workers: Thread count when no executor is provided. Defaults to min(32, cpu_count+4).
+        executor: If provided, used directly; caller owns its lifecycle.
+        **kwargs: Passed through to each convert() call.
+    """
+    if on_error not in ("collect", "raise"):
+        raise ValueError(f"on_error must be 'collect' or 'raise', got {on_error!r}")
+
+    own_executor = executor is None
+    _executor = executor or concurrent.futures.ThreadPoolExecutor(
+        max_workers=workers or min(32, (os.cpu_count() or 1) + 4)
+    )
+
+    try:
+        future_to_source = {
+            _executor.submit(self.convert, source, **kwargs): source
+            for source in sources
+        }
+
+        for future in concurrent.futures.as_completed(future_to_source):
+            source = future_to_source[future]
+            exc = future.exception()
+            if exc is not None:
+                if on_error == "raise":
+                    for f in future_to_source:
+                        f.cancel()
+                    raise exc
+                yield BatchConversionResult(source=source, error=exc)
+            else:
+                yield BatchConversionResult(source=source, result=future.result())
+    finally:
+        if own_executor:
+            _executor.shutdown(wait=False, cancel_futures=True)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cd packages/markitdown
+pytest tests/test_batch.py -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/markitdown/src/markitdown/_markitdown.py packages/markitdown/tests/test_batch.py
+git commit -m "feat: add convert_batch() method to MarkItDown"
+```
+
+---
+
+## Task 3: Export `BatchConversionResult` from `__init__.py`
+
+**Files:**
+- Modify: `packages/markitdown/src/markitdown/__init__.py`
+- Modify: `packages/markitdown/tests/test_batch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/markitdown/tests/test_batch.py`:
+
+```python
+def test_batch_result_public_import():
+    from markitdown import BatchConversionResult as BCR
+    assert BCR is BatchConversionResult
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+cd packages/markitdown
+pytest tests/test_batch.py::test_batch_result_public_import -v
+```
+
+Expected: `ImportError` — `BatchConversionResult` not in `markitdown.__init__`.
+
+- [ ] **Step 3: Update `__init__.py`**
+
+In `packages/markitdown/src/markitdown/__init__.py`:
+
+Change:
+```python
+from ._base_converter import DocumentConverterResult, DocumentConverter
+```
+To:
+```python
+from ._base_converter import DocumentConverterResult, DocumentConverter, BatchConversionResult
+```
+
+Add `"BatchConversionResult"` to the `__all__` list:
+```python
+__all__ = [
+    "__version__",
+    "MarkItDown",
+    "DocumentConverter",
+    "DocumentConverterResult",
+    "BatchConversionResult",
+    "MarkItDownException",
+    "MissingDependencyException",
+    "FailedConversionAttempt",
+    "FileConversionException",
+    "UnsupportedFormatException",
+    "StreamInfo",
+    "PRIORITY_SPECIFIC_FILE_FORMAT",
+    "PRIORITY_GENERIC_FILE_FORMAT",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+cd packages/markitdown
+pytest tests/test_batch.py -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markitdown/src/markitdown/__init__.py packages/markitdown/tests/test_batch.py
+git commit -m "feat: export BatchConversionResult from public API"
+```
+
+---
+
+## Task 4: Update CLI for multi-file batch support
+
+**Files:**
+- Modify: `packages/markitdown/src/markitdown/__main__.py`
+- Modify: `packages/markitdown/tests/test_cli_misc.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/markitdown/tests/test_cli_misc.py`:
+
+```python
+import os
+import tempfile
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+
+def test_cli_multi_file_stdout():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "test.docx"),
+            os.path.join(TEST_FILES_DIR, "test.pdf"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    assert "--- " in result.stdout
+
+
+def test_cli_multi_file_output_dir():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        result = subprocess.run(
+            [
+                "python", "-m", "markitdown",
+                os.path.join(TEST_FILES_DIR, "test.docx"),
+                os.path.join(TEST_FILES_DIR, "test.pdf"),
+                "--output-dir", tmp_dir,
+            ],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"CLI failed: {result.stderr}"
+        assert os.path.exists(os.path.join(tmp_dir, "test.docx.md"))
+        assert os.path.exists(os.path.join(tmp_dir, "test.pdf.md"))
+
+
+def test_cli_multi_file_fail_fast():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "nonexistent_xyz.pdf"),
+            "--fail-fast",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_cli_multi_file_collect_errors():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "test.docx"),
+            os.path.join(TEST_FILES_DIR, "nonexistent_xyz.pdf"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "Error" in result.stderr
+
+
+def test_cli_workers_flag():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "test.docx"),
+            os.path.join(TEST_FILES_DIR, "test.pdf"),
+            "--workers", "2",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd packages/markitdown
+pytest tests/test_cli_misc.py -v
+```
+
+Expected: The new tests FAIL — `--output-dir`, `--workers`, `--fail-fast` are unknown flags; `filename` only accepts one value.
+
+- [ ] **Step 3: Update `__main__.py`**
+
+Replace the entire `main()` function in `packages/markitdown/src/markitdown/__main__.py` with:
+
+```python
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert various file formats to markdown.",
+        prog="markitdown",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        usage=dedent(
+            """
+            SYNTAX:
+
+                markitdown <OPTIONAL: FILENAME [FILENAME ...]>
+                If FILENAME is empty, markitdown reads from stdin.
+
+            EXAMPLES:
+
+                markitdown example.pdf
+
+                markitdown file1.pdf file2.docx file3.html
+
+                cat example.pdf | markitdown
+
+                markitdown example.pdf -o example.md
+
+                markitdown file1.pdf file2.docx --output-dir ./output/
+            """
+        ).strip(),
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="show the version number and exit",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file name. Only valid for single-file conversion.",
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        help="Output directory for batch conversion. Each file is written to <dir>/<filename>.md.",
+    )
+
+    parser.add_argument(
+        "-x",
+        "--extension",
+        help="Provide a hint about the file extension (e.g., when reading from stdin).",
+    )
+
+    parser.add_argument(
+        "-m",
+        "--mime-type",
+        help="Provide a hint about the file's MIME type.",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--charset",
+        help="Provide a hint about the file's charset (e.g, UTF-8).",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--use-docintel",
+        action="store_true",
+        help="Use Document Intelligence to extract text instead of offline conversion.",
+    )
+
+    parser.add_argument(
+        "-e",
+        "--endpoint",
+        type=str,
+        help="Document Intelligence Endpoint.",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--use-plugins",
+        action="store_true",
+        help="Use 3rd-party plugins to convert files.",
+    )
+
+    parser.add_argument(
+        "--list-plugins",
+        action="store_true",
+        help="List installed 3rd-party plugins.",
+    )
+
+    parser.add_argument(
+        "--keep-data-uris",
+        action="store_true",
+        help="Keep data URIs in the output.",
+    )
+
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help="Number of parallel threads for batch conversion.",
+    )
+
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Abort batch conversion on the first error (default: collect errors and continue).",
+    )
+
+    parser.add_argument("filename", nargs="*")
+    args = parser.parse_args()
+
+    # Parse the extension hint
+    extension_hint = args.extension
+    if extension_hint is not None:
+        extension_hint = extension_hint.strip().lower()
+        if len(extension_hint) > 0:
+            if not extension_hint.startswith("."):
+                extension_hint = "." + extension_hint
+        else:
+            extension_hint = None
+
+    # Parse the mime type
+    mime_type_hint = args.mime_type
+    if mime_type_hint is not None:
+        mime_type_hint = mime_type_hint.strip()
+        if len(mime_type_hint) > 0:
+            if mime_type_hint.count("/") != 1:
+                _exit_with_error(f"Invalid MIME type: {mime_type_hint}")
+        else:
+            mime_type_hint = None
+
+    # Parse the charset
+    charset_hint = args.charset
+    if charset_hint is not None:
+        charset_hint = charset_hint.strip()
+        if len(charset_hint) > 0:
+            try:
+                charset_hint = codecs.lookup(charset_hint).name
+            except LookupError:
+                _exit_with_error(f"Invalid charset: {charset_hint}")
+        else:
+            charset_hint = None
+
+    stream_info = None
+    if (
+        extension_hint is not None
+        or mime_type_hint is not None
+        or charset_hint is not None
+    ):
+        stream_info = StreamInfo(
+            extension=extension_hint, mimetype=mime_type_hint, charset=charset_hint
+        )
+
+    if args.list_plugins:
+        print("Installed MarkItDown 3rd-party Plugins:\n")
+        plugin_entry_points = list(entry_points(group="markitdown.plugin"))
+        if len(plugin_entry_points) == 0:
+            print("  * No 3rd-party plugins installed.")
+            print(
+                "\nFind plugins by searching for the hashtag #markitdown-plugin on GitHub.\n"
+            )
+        else:
+            for entry_point in plugin_entry_points:
+                print(f"  * {entry_point.name:<16}\t(package: {entry_point.value})")
+            print(
+                "\nUse the -p (or --use-plugins) option to enable 3rd-party plugins.\n"
+            )
+        sys.exit(0)
+
+    if args.use_docintel:
+        if args.endpoint is None:
+            _exit_with_error(
+                "Document Intelligence Endpoint is required when using Document Intelligence."
+            )
+        elif not args.filename:
+            _exit_with_error("Filename is required when using Document Intelligence.")
+        markitdown = MarkItDown(
+            enable_plugins=args.use_plugins, docintel_endpoint=args.endpoint
+        )
+    else:
+        markitdown = MarkItDown(enable_plugins=args.use_plugins)
+
+    # Stdin mode
+    if not args.filename:
+        result = markitdown.convert_stream(
+            sys.stdin.buffer,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+        )
+        _handle_output(args, result)
+        return
+
+    # Single-file mode (preserves original behaviour exactly)
+    if len(args.filename) == 1 and args.output_dir is None:
+        result = markitdown.convert(
+            args.filename[0],
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+        )
+        _handle_output(args, result)
+        return
+
+    # Batch mode
+    on_error = "raise" if args.fail_fast else "collect"
+    exit_code = 0
+    try:
+        for batch_result in markitdown.convert_batch(
+            args.filename,
+            on_error=on_error,
+            workers=args.workers,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+        ):
+            if not batch_result.success:
+                print(
+                    f"Error converting {batch_result.source}: {batch_result.error}",
+                    file=sys.stderr,
+                )
+                exit_code = 1
+            elif args.output_dir:
+                os.makedirs(args.output_dir, exist_ok=True)
+                source_name = os.path.basename(str(batch_result.source))
+                out_path = os.path.join(args.output_dir, source_name + ".md")
+                with open(out_path, "w", encoding="utf-8") as f:
+                    f.write(batch_result.result.markdown)
+                print(f"Converted: {batch_result.source} -> {out_path}", file=sys.stderr)
+            else:
+                print(f"\n--- {batch_result.source} ---\n")
+                print(
+                    batch_result.result.markdown.encode(
+                        sys.stdout.encoding, errors="replace"
+                    ).decode(sys.stdout.encoding)
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        exit_code = 1
+
+    sys.exit(exit_code)
+```
+
+Note: also add `import os` at the top of `__main__.py` if it's not already there. Check first with `grep "^import os" packages/markitdown/src/markitdown/__main__.py`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd packages/markitdown
+pytest tests/test_cli_misc.py -v
+```
+
+Expected: All tests PASS (including the original `test_version` and `test_invalid_flag`).
+
+- [ ] **Step 5: Run the full test suite**
+
+```
+cd packages/markitdown
+pytest tests/ -v --ignore=tests/test_docintel_html.py
+```
+
+Expected: All tests PASS (docintel tests require credentials, skip them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/markitdown/src/markitdown/__main__.py packages/markitdown/tests/test_cli_misc.py
+git commit -m "feat: add batch CLI support with --workers, --fail-fast, --output-dir"
+```
+
+---
+
+## Done
+
+The full batch parallelization feature is complete:
+- `BatchConversionResult` in public API
+- `MarkItDown.convert_batch()` with pluggable executor
+- CLI accepts multiple files with `--workers`, `--fail-fast`, `--output-dir`

--- a/docs/superpowers/specs/2026-04-23-batch-parallelization-design.md
+++ b/docs/superpowers/specs/2026-04-23-batch-parallelization-design.md
@@ -1,0 +1,127 @@
+# Batch Parallelization Design
+
+**Date:** 2026-04-23
+**Scope:** Add parallel batch conversion to the `markitdown` library and CLI.
+
+---
+
+## Goals
+
+- Convert multiple local files concurrently from both the library API and CLI.
+- Return results in arrival order (completion order, not input order).
+- Let callers choose between fail-fast and collect-and-continue error handling.
+- Default to `ThreadPoolExecutor`; allow callers to plug in any `concurrent.futures.Executor`.
+
+## Out of Scope
+
+- Parallelism _within_ a single document.
+- Async / `asyncio` interface.
+- Remote URL batch fetching (future work).
+
+---
+
+## Library API
+
+### New dataclass: `BatchConversionResult`
+
+Added to `_base_converter.py` alongside the existing `DocumentConverterResult`.
+
+```python
+from dataclasses import dataclass
+from typing import Optional, Union
+from pathlib import Path
+
+@dataclass
+class BatchConversionResult:
+    source: Union[str, Path]                  # original input value
+    result: Optional[DocumentConverterResult] = None
+    error: Optional[Exception] = None
+
+    @property
+    def success(self) -> bool:
+        return self.error is None
+```
+
+### New method: `MarkItDown.convert_batch()`
+
+```python
+def convert_batch(
+    self,
+    sources: Iterable[Union[str, Path, BinaryIO, requests.Response]],
+    *,
+    on_error: Literal["raise", "collect"] = "collect",
+    workers: Optional[int] = None,
+    executor: Optional[concurrent.futures.Executor] = None,
+    **kwargs,
+) -> Iterator[BatchConversionResult]:
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `sources` | required | Any iterable of inputs accepted by `convert()` |
+| `on_error` | `"collect"` | `"collect"` wraps errors and continues; `"raise"` re-raises the first error |
+| `workers` | `min(32, cpu_count + 4)` | Thread count when no `executor` is provided |
+| `executor` | `None` | If provided, used directly; caller owns its lifecycle |
+| `**kwargs` | — | Passed through to each `convert()` call |
+
+**Behaviour:**
+
+- Yields `BatchConversionResult` instances in **completion order** via `concurrent.futures.as_completed()`.
+- When `on_error="collect"`: exceptions are caught per-future and wrapped in `BatchConversionResult(source=..., error=...)`.
+- When `on_error="raise"`: first exception is re-raised; remaining futures are cancelled.
+- When `executor` is `None`: a `ThreadPoolExecutor(max_workers=workers)` is created internally and shut down after all futures resolve.
+- When `executor` is provided: `convert_batch()` submits work to it but does **not** call `shutdown()`.
+
+**Note on `ProcessPoolExecutor`:** Passing a `ProcessPoolExecutor` is unsupported — `MarkItDown` is not reliably picklable. No helper or workaround is provided.
+
+---
+
+## CLI Changes
+
+### Updated argument: `filename`
+
+Changed from `nargs="?"` to `nargs="*"`. Stdin mode activates when no filenames are given (unchanged).
+
+### New flags
+
+| Flag | Description |
+|---|---|
+| `--workers N` | Number of parallel threads (default: library default) |
+| `--fail-fast` | Exit on first conversion error (default: collect and continue) |
+| `--output-dir DIR` | Write each result to `<DIR>/<stem>.md` instead of stdout |
+
+### Output rules
+
+| Scenario | Behaviour |
+|---|---|
+| Single file, no `--output-dir` | Unchanged: stdout or `-o file` |
+| Multiple files, no `--output-dir` | Results printed to stdout in arrival order, each preceded by `--- <source> ---` |
+| Multiple files, `--output-dir` | Each result written to `<DIR>/<original_filename>.md` (e.g., `report.pdf` → `report.pdf.md`) to avoid collisions; progress lines printed to stderr |
+| Error in collect mode | Error message printed to stderr; processing continues |
+| Error in fail-fast mode | Error printed to stderr; exit code 1 |
+
+---
+
+## Thread Safety
+
+| Shared state | Assessment |
+|---|---|
+| `self._converters` | Read-only after construction. Safe. |
+| `self._requests_session` | `requests.Session` is documented thread-safe. Safe. |
+| `self._magika` | ONNX inference is safe for concurrent reads. Safe. |
+| Individual converters | All stateless per-call; no mutable instance state. Safe. |
+
+No locks are required.
+
+---
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `packages/markitdown/src/markitdown/_base_converter.py` | Add `BatchConversionResult` dataclass |
+| `packages/markitdown/src/markitdown/_markitdown.py` | Add `convert_batch()` method; export `BatchConversionResult` |
+| `packages/markitdown/src/markitdown/__init__.py` | Export `BatchConversionResult` |
+| `packages/markitdown/src/markitdown/__main__.py` | Multi-file CLI: `nargs="*"`, `--workers`, `--fail-fast`, `--output-dir` |

--- a/packages/markitdown/src/markitdown/__init__.py
+++ b/packages/markitdown/src/markitdown/__init__.py
@@ -8,7 +8,7 @@ from ._markitdown import (
     PRIORITY_SPECIFIC_FILE_FORMAT,
     PRIORITY_GENERIC_FILE_FORMAT,
 )
-from ._base_converter import DocumentConverterResult, DocumentConverter
+from ._base_converter import DocumentConverterResult, DocumentConverter, BatchConversionResult
 from ._stream_info import StreamInfo
 from ._exceptions import (
     MarkItDownException,
@@ -23,6 +23,7 @@ __all__ = [
     "MarkItDown",
     "DocumentConverter",
     "DocumentConverterResult",
+    "BatchConversionResult",
     "MarkItDownException",
     "MissingDependencyException",
     "FailedConversionAttempt",

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -217,6 +217,12 @@ def main():
         return
 
     # Batch mode
+    if args.output:
+        _exit_with_error("--output is only valid for single-file conversion.")
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+
     on_error = "raise" if args.fail_fast else "collect"
     exit_code = 0
     try:
@@ -233,14 +239,13 @@ def main():
                     file=sys.stderr,
                 )
                 exit_code = 1
-            elif args.output_dir:
-                os.makedirs(args.output_dir, exist_ok=True)
+            elif args.output_dir and batch_result.result is not None:
                 source_name = os.path.basename(str(batch_result.source))
                 out_path = os.path.join(args.output_dir, source_name + ".md")
                 with open(out_path, "w", encoding="utf-8") as f:
                     f.write(batch_result.result.markdown)
                 print(f"Converted: {batch_result.source} -> {out_path}", file=sys.stderr)
-            else:
+            elif batch_result.result is not None:
                 print(f"\n--- {batch_result.source} ---\n")
                 print(
                     batch_result.result.markdown.encode(

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 import argparse
+import os
 import sys
 import codecs
 from textwrap import dedent
@@ -19,28 +20,20 @@ def main():
             """
             SYNTAX:
 
-                markitdown <OPTIONAL: FILENAME>
+                markitdown <OPTIONAL: FILENAME [FILENAME ...]>
                 If FILENAME is empty, markitdown reads from stdin.
 
-            EXAMPLE:
+            EXAMPLES:
 
                 markitdown example.pdf
 
-                OR
+                markitdown file1.pdf file2.docx file3.html
 
                 cat example.pdf | markitdown
 
-                OR
-
-                markitdown < example.pdf
-
-                OR to save to a file use
-
                 markitdown example.pdf -o example.md
 
-                OR
-
-                markitdown example.pdf > example.md
+                markitdown file1.pdf file2.docx --output-dir ./output/
             """
         ).strip(),
     )
@@ -56,7 +49,12 @@ def main():
     parser.add_argument(
         "-o",
         "--output",
-        help="Output file name. If not provided, output is written to stdout.",
+        help="Output file name. Only valid for single-file conversion.",
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        help="Output directory for batch conversion. Each file is written to <dir>/<filename>.md.",
     )
 
     parser.add_argument(
@@ -110,7 +108,20 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
-    parser.add_argument("filename", nargs="?")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help="Number of parallel threads for batch conversion.",
+    )
+
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Abort batch conversion on the first error (default: collect errors and continue).",
+    )
+
+    parser.add_argument("filename", nargs="*")
     args = parser.parse_args()
 
     # Parse the extension hint
@@ -156,7 +167,6 @@ def main():
         )
 
     if args.list_plugins:
-        # List installed plugins, then exit
         print("Installed MarkItDown 3rd-party Plugins:\n")
         plugin_entry_points = list(entry_points(group="markitdown.plugin"))
         if len(plugin_entry_points) == 0:
@@ -177,7 +187,7 @@ def main():
             _exit_with_error(
                 "Document Intelligence Endpoint is required when using Document Intelligence."
             )
-        elif args.filename is None:
+        elif not args.filename:
             _exit_with_error("Filename is required when using Document Intelligence.")
 
         markitdown = MarkItDown(
@@ -186,18 +196,62 @@ def main():
     else:
         markitdown = MarkItDown(enable_plugins=args.use_plugins)
 
-    if args.filename is None:
+    # Stdin mode
+    if not args.filename:
         result = markitdown.convert_stream(
             sys.stdin.buffer,
             stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
         )
-    else:
-        result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
-        )
+        _handle_output(args, result)
+        return
 
-    _handle_output(args, result)
+    # Single-file mode (preserves original behaviour exactly)
+    if len(args.filename) == 1 and args.output_dir is None:
+        result = markitdown.convert(
+            args.filename[0],
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+        )
+        _handle_output(args, result)
+        return
+
+    # Batch mode
+    on_error = "raise" if args.fail_fast else "collect"
+    exit_code = 0
+    try:
+        for batch_result in markitdown.convert_batch(
+            args.filename,
+            on_error=on_error,
+            workers=args.workers,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+        ):
+            if not batch_result.success:
+                print(
+                    f"Error converting {batch_result.source}: {batch_result.error}",
+                    file=sys.stderr,
+                )
+                exit_code = 1
+            elif args.output_dir:
+                os.makedirs(args.output_dir, exist_ok=True)
+                source_name = os.path.basename(str(batch_result.source))
+                out_path = os.path.join(args.output_dir, source_name + ".md")
+                with open(out_path, "w", encoding="utf-8") as f:
+                    f.write(batch_result.result.markdown)
+                print(f"Converted: {batch_result.source} -> {out_path}", file=sys.stderr)
+            else:
+                print(f"\n--- {batch_result.source} ---\n")
+                print(
+                    batch_result.result.markdown.encode(
+                        sys.stdout.encoding, errors="replace"
+                    ).decode(sys.stdout.encoding)
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        exit_code = 1
+
+    sys.exit(exit_code)
 
 
 def _handle_output(args, result: DocumentConverterResult):

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, BinaryIO, Optional
 from ._stream_info import StreamInfo
 
@@ -37,6 +38,19 @@ class DocumentConverterResult:
     def __str__(self) -> str:
         """Return the converted Markdown text."""
         return self.markdown
+
+
+@dataclass
+class BatchConversionResult:
+    """Result of a single conversion within a convert_batch() call."""
+
+    source: Any  # The original input passed to convert_batch()
+    result: Optional["DocumentConverterResult"] = None
+    error: Optional[Exception] = None
+
+    @property
+    def success(self) -> bool:
+        return self.error is None
 
 
 class DocumentConverter:

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any, BinaryIO, Optional
 from ._stream_info import StreamInfo
 
@@ -40,13 +39,23 @@ class DocumentConverterResult:
         return self.markdown
 
 
-@dataclass
 class BatchConversionResult:
-    """Result of a single conversion within a convert_batch() call."""
+    """Result of a single conversion within a convert_batch() call.
 
-    source: Any  # The original input passed to convert_batch()
-    result: Optional["DocumentConverterResult"] = None
-    error: Optional[Exception] = None
+    Note: `success` returns True when no error is set. `result` may still be
+    None if `success` is True and no conversion output was produced.
+    """
+
+    def __init__(
+        self,
+        source: Any,
+        *,
+        result: Optional["DocumentConverterResult"] = None,
+        error: Optional[Exception] = None,
+    ):
+        self.source = source
+        self.result = result
+        self.error = error
 
     @property
     def success(self) -> bool:

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -312,7 +312,9 @@ class MarkItDown:
         """Convert multiple sources concurrently, yielding results in completion order.
 
         Args:
-            sources: Iterable of inputs accepted by convert().
+            sources: Iterable of inputs accepted by convert(). Consumed eagerly —
+                all sources are submitted to the thread pool before any result is
+                yielded. Not safe with infinite iterables.
             on_error: "collect" wraps errors and continues; "raise" re-raises the first error.
             workers: Thread count when no executor is provided. Defaults to min(32, cpu_count+4).
             executor: If provided, used directly; caller owns its lifecycle.
@@ -342,8 +344,6 @@ class MarkItDown:
                 exc = future.exception()
                 if exc is not None:
                     if on_error == "raise":
-                        for f in future_to_source:
-                            f.cancel()
                         raise exc
                     yield BatchConversionResult(source=source, error=exc)
                 else:

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import mimetypes
 import os
 import re
@@ -7,7 +8,7 @@ import traceback
 import io
 from dataclasses import dataclass
 from importlib.metadata import entry_points
-from typing import Any, List, Dict, Optional, Union, BinaryIO
+from typing import Any, List, Dict, Optional, Union, BinaryIO, Iterator, Iterable
 from pathlib import Path
 from urllib.parse import urlparse
 from warnings import warn
@@ -41,7 +42,7 @@ from .converters import (
     CsvConverter,
 )
 
-from ._base_converter import DocumentConverter, DocumentConverterResult
+from ._base_converter import DocumentConverter, DocumentConverterResult, BatchConversionResult
 
 from ._exceptions import (
     FileConversionException,
@@ -298,6 +299,55 @@ class MarkItDown:
             raise TypeError(
                 f"Invalid source type: {type(source)}. Expected str, requests.Response, BinaryIO."
             )
+
+    def convert_batch(
+        self,
+        sources: Iterable[Union[str, Path, BinaryIO, "requests.Response"]],
+        *,
+        on_error: str = "collect",
+        workers: Optional[int] = None,
+        executor: Optional[concurrent.futures.Executor] = None,
+        **kwargs: Any,
+    ) -> Iterator[BatchConversionResult]:
+        """Convert multiple sources concurrently, yielding results in completion order.
+
+        Args:
+            sources: Iterable of inputs accepted by convert().
+            on_error: "collect" wraps errors and continues; "raise" re-raises the first error.
+            workers: Thread count when no executor is provided. Defaults to min(32, cpu_count+4).
+            executor: If provided, used directly; caller owns its lifecycle.
+            **kwargs: Passed through to each convert() call.
+
+        Note: Passing a ProcessPoolExecutor is unsupported — MarkItDown is not reliably picklable.
+        """
+        if on_error not in ("collect", "raise"):
+            raise ValueError(f"on_error must be 'collect' or 'raise', got {on_error!r}")
+
+        own_executor = executor is None
+        _executor = executor or concurrent.futures.ThreadPoolExecutor(
+            max_workers=workers or min(32, (os.cpu_count() or 1) + 4)
+        )
+
+        try:
+            future_to_source = {
+                _executor.submit(self.convert, source, **kwargs): source
+                for source in sources
+            }
+
+            for future in concurrent.futures.as_completed(future_to_source):
+                source = future_to_source[future]
+                exc = future.exception()
+                if exc is not None:
+                    if on_error == "raise":
+                        for f in future_to_source:
+                            f.cancel()
+                        raise exc
+                    yield BatchConversionResult(source=source, error=exc)
+                else:
+                    yield BatchConversionResult(source=source, result=future.result())
+        finally:
+            if own_executor:
+                _executor.shutdown(wait=False, cancel_futures=True)
 
     def convert_local(
         self,

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -323,9 +323,12 @@ class MarkItDown:
         if on_error not in ("collect", "raise"):
             raise ValueError(f"on_error must be 'collect' or 'raise', got {on_error!r}")
 
+        if executor is not None and workers is not None:
+            warn("workers is ignored when an executor is provided", stacklevel=2)
+
         own_executor = executor is None
         _executor = executor or concurrent.futures.ThreadPoolExecutor(
-            max_workers=workers or min(32, (os.cpu_count() or 1) + 4)
+            max_workers=workers if workers is not None else min(32, (os.cpu_count() or 1) + 4)
         )
 
         try:
@@ -347,7 +350,7 @@ class MarkItDown:
                     yield BatchConversionResult(source=source, result=future.result())
         finally:
             if own_executor:
-                _executor.shutdown(wait=False, cancel_futures=True)
+                _executor.shutdown(wait=True, cancel_futures=True)
 
     def convert_local(
         self,

--- a/packages/markitdown/tests/test_batch.py
+++ b/packages/markitdown/tests/test_batch.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3 -m pytest
 # NOTE: importing from private module until Task 3 exports BatchConversionResult publicly
+import os
+import concurrent.futures
 from markitdown._base_converter import BatchConversionResult, DocumentConverterResult
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
 
 def test_batch_result_success_true():
@@ -25,12 +29,6 @@ def test_batch_result_defaults():
     assert r.result is None
     assert r.error is None
     assert r.success is True
-
-
-import os
-import concurrent.futures
-
-TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
 
 def test_convert_batch_basic():

--- a/packages/markitdown/tests/test_batch.py
+++ b/packages/markitdown/tests/test_batch.py
@@ -66,7 +66,6 @@ def test_convert_batch_on_error_collect():
 
 
 def test_convert_batch_on_error_raise():
-    import pytest
     from markitdown import MarkItDown
     md = MarkItDown()
     sources = [os.path.join(TEST_FILES_DIR, "nonexistent_file_xyz.docx")]

--- a/packages/markitdown/tests/test_batch.py
+++ b/packages/markitdown/tests/test_batch.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3 -m pytest
-# NOTE: importing from private module until Task 3 exports BatchConversionResult publicly
 import os
 import concurrent.futures
-from markitdown._base_converter import BatchConversionResult, DocumentConverterResult
+from markitdown._base_converter import DocumentConverterResult
+from markitdown import BatchConversionResult
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
@@ -117,3 +117,8 @@ def test_convert_batch_workers_param():
     results = list(md.convert_batch(sources, workers=1))
     assert len(results) == 2
     assert all(r.success for r in results)
+
+
+def test_batch_result_public_import():
+    from markitdown import BatchConversionResult as BCR
+    assert BCR is BatchConversionResult

--- a/packages/markitdown/tests/test_batch.py
+++ b/packages/markitdown/tests/test_batch.py
@@ -1,0 +1,26 @@
+import pytest
+from markitdown._base_converter import BatchConversionResult, DocumentConverterResult
+
+
+def test_batch_result_success_true():
+    r = BatchConversionResult(
+        source="test.txt",
+        result=DocumentConverterResult(markdown="# Hello"),
+    )
+    assert r.success is True
+    assert r.result is not None
+    assert r.error is None
+
+
+def test_batch_result_success_false():
+    r = BatchConversionResult(source="test.txt", error=ValueError("oops"))
+    assert r.success is False
+    assert r.result is None
+    assert r.error is not None
+
+
+def test_batch_result_defaults():
+    r = BatchConversionResult(source="test.txt")
+    assert r.result is None
+    assert r.error is None
+    assert r.success is True

--- a/packages/markitdown/tests/test_batch.py
+++ b/packages/markitdown/tests/test_batch.py
@@ -1,4 +1,5 @@
-import pytest
+#!/usr/bin/env python3 -m pytest
+# NOTE: importing from private module until Task 3 exports BatchConversionResult publicly
 from markitdown._base_converter import BatchConversionResult, DocumentConverterResult
 
 

--- a/packages/markitdown/tests/test_batch.py
+++ b/packages/markitdown/tests/test_batch.py
@@ -25,3 +25,98 @@ def test_batch_result_defaults():
     assert r.result is None
     assert r.error is None
     assert r.success is True
+
+
+import os
+import concurrent.futures
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+
+def test_convert_batch_basic():
+    from markitdown import MarkItDown
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "test.pdf"),
+        os.path.join(TEST_FILES_DIR, "test.pptx"),
+    ]
+    results = list(md.convert_batch(sources))
+    assert len(results) == 3
+    assert all(isinstance(r, BatchConversionResult) for r in results)
+    assert all(r.success for r in results)
+    assert all(isinstance(r.result, DocumentConverterResult) for r in results)
+    assert {r.source for r in results} == set(sources)
+
+
+def test_convert_batch_on_error_collect():
+    from markitdown import MarkItDown
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "nonexistent_file_xyz.docx"),
+    ]
+    results = list(md.convert_batch(sources, on_error="collect"))
+    assert len(results) == 2
+    successful = [r for r in results if r.success]
+    failed = [r for r in results if not r.success]
+    assert len(successful) == 1
+    assert len(failed) == 1
+    assert failed[0].error is not None
+
+
+def test_convert_batch_on_error_raise():
+    import pytest
+    from markitdown import MarkItDown
+    md = MarkItDown()
+    sources = [os.path.join(TEST_FILES_DIR, "nonexistent_file_xyz.docx")]
+    raised = False
+    try:
+        list(md.convert_batch(sources, on_error="raise"))
+    except Exception:
+        raised = True
+    assert raised, "Expected an exception to be raised"
+
+
+def test_convert_batch_invalid_on_error():
+    from markitdown import MarkItDown
+    md = MarkItDown()
+    raised = False
+    try:
+        list(md.convert_batch([], on_error="bad_value"))
+    except ValueError as e:
+        raised = True
+        assert "on_error" in str(e)
+    assert raised, "Expected ValueError"
+
+
+def test_convert_batch_empty():
+    from markitdown import MarkItDown
+    md = MarkItDown()
+    results = list(md.convert_batch([]))
+    assert results == []
+
+
+def test_convert_batch_custom_executor():
+    from markitdown import MarkItDown
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "test.pdf"),
+    ]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(md.convert_batch(sources, executor=executor))
+    assert len(results) == 2
+    assert all(r.success for r in results)
+
+
+def test_convert_batch_workers_param():
+    from markitdown import MarkItDown
+    md = MarkItDown()
+    sources = [
+        os.path.join(TEST_FILES_DIR, "test.docx"),
+        os.path.join(TEST_FILES_DIR, "test.pdf"),
+    ]
+    results = list(md.convert_batch(sources, workers=1))
+    assert len(results) == 2
+    assert all(r.success for r in results)

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3 -m pytest
+import os
 import subprocess
+import tempfile
 from markitdown import __version__
 
 # This file contains CLI tests that are not directly tested by the FileTestVectors.
 # This includes things like help messages, version numbers, and invalid flags.
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
 
 def test_version() -> None:
@@ -25,6 +29,78 @@ def test_invalid_flag() -> None:
         "unrecognized arguments" in result.stderr
     ), "Expected 'unrecognized arguments' to appear in STDERR"
     assert "SYNTAX" in result.stderr, "Expected 'SYNTAX' to appear in STDERR"
+
+
+def test_cli_multi_file_stdout():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "test.docx"),
+            os.path.join(TEST_FILES_DIR, "test.pdf"),
+        ],
+        capture_output=True, text=True,
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    assert "--- " in result.stdout
+
+
+def test_cli_multi_file_output_dir():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        result = subprocess.run(
+            [
+                "python", "-m", "markitdown",
+                os.path.join(TEST_FILES_DIR, "test.docx"),
+                os.path.join(TEST_FILES_DIR, "test.pdf"),
+                "--output-dir", tmp_dir,
+            ],
+            capture_output=True, text=True,
+            cwd=os.path.join(os.path.dirname(__file__), ".."),
+        )
+        assert result.returncode == 0, f"CLI failed: {result.stderr}"
+        assert os.path.exists(os.path.join(tmp_dir, "test.docx.md"))
+        assert os.path.exists(os.path.join(tmp_dir, "test.pdf.md"))
+
+
+def test_cli_multi_file_fail_fast():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "nonexistent_xyz.pdf"),
+            "--fail-fast",
+        ],
+        capture_output=True, text=True,
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+    )
+    assert result.returncode == 1
+
+
+def test_cli_multi_file_collect_errors():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "test.docx"),
+            os.path.join(TEST_FILES_DIR, "nonexistent_xyz.pdf"),
+        ],
+        capture_output=True, text=True,
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+    )
+    assert result.returncode == 1
+    assert "Error" in result.stderr
+
+
+def test_cli_workers_flag():
+    result = subprocess.run(
+        [
+            "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "test.docx"),
+            os.path.join(TEST_FILES_DIR, "test.pdf"),
+            "--workers", "2",
+        ],
+        capture_output=True, text=True,
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+    )
+    assert result.returncode == 0
 
 
 if __name__ == "__main__":

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -66,6 +66,7 @@ def test_cli_multi_file_fail_fast():
     result = subprocess.run(
         [
             "python", "-m", "markitdown",
+            os.path.join(TEST_FILES_DIR, "test.docx"),
             os.path.join(TEST_FILES_DIR, "nonexistent_xyz.pdf"),
             "--fail-fast",
         ],


### PR DESCRIPTION
Adds `convert_batch()` to the `MarkItDown` class and corresponding CLI flags for converting multiple files concurrently.

### Library API

A new `convert_batch()` method on `MarkItDown` accepts an iterable of sources and yields `BatchConversionResult` objects in completion order:

```python
from markitdown import MarkItDown, BatchConversionResult

md = MarkItDown()
for result in md.convert_batch(["file1.pdf", "file2.docx", "file3.html"]):
    if result.success:
        print(result.result.markdown)
    else:
        print(f"Failed: {result.source} — {result.error}")
```

Each `BatchConversionResult` has:
- `source` — the original input
- `result` — a `DocumentConverterResult`, or `None` on failure
- `error` — the exception, or `None` on success
- `success` — `True` when no error is set

**Error handling** is configurable via `on_error`:
- `"collect"` (default) — wraps errors and continues
- `"raise"` — re-raises the first error immediately

**Concurrency** uses `ThreadPoolExecutor` (appropriate since heavy converters like pdfminer and lxml release the GIL). A pluggable `executor` parameter lets callers supply their own executor; if omitted, one is created and shut down automatically. The `workers` parameter controls thread count when using the default executor.

`BatchConversionResult` is exported from the top-level `markitdown` package.

### CLI

```bash
# Convert multiple files to stdout (separated by banners)
markitdown file1.pdf file2.docx

# Write each file to an output directory
markitdown file1.pdf file2.docx --output-dir ./output/

# Control parallelism
markitdown file1.pdf file2.docx --workers 4

# Stop on first error instead of collecting all errors
markitdown file1.pdf file2.docx --fail-fast
```

Single-file and stdin modes are unchanged.

### Tests

- `tests/test_batch.py` — unit and integration tests for `BatchConversionResult` and `convert_batch()`
- `tests/test_cli_misc.py` — CLI tests for multi-file stdout, `--output-dir`, `--fail-fast`, `--workers`, and error collection