### PR TITLE
Fix #1424: add convert_file and convert_directory MCP tools

### DIFF
--- a/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
+++ b/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
@@ -1,6 +1,7 @@
 import contextlib
 import sys
 import os
+from pathlib import Path
 from collections.abc import AsyncIterator
 from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
@@ -21,6 +22,47 @@ mcp = FastMCP("markitdown")
 async def convert_to_markdown(uri: str) -> str:
     """Convert a resource described by an http:, https:, file: or data: URI to markdown"""
     return MarkItDown(enable_plugins=check_plugins_enabled()).convert_uri(uri).markdown
+
+
+@mcp.tool()
+async def convert_file(file_path: str) -> str:
+    """Convert a local file (given as an absolute or relative filesystem path) to markdown.
+
+    This is a convenience wrapper around ``convert_to_markdown`` for callers that already
+    have a plain path rather than a ``file:`` URI. Paths are resolved against the current
+    working directory; non-existent paths raise FileNotFoundError.
+    """
+    resolved = Path(file_path).expanduser().resolve(strict=True)
+    return MarkItDown(enable_plugins=check_plugins_enabled()).convert_local(str(resolved)).markdown
+
+
+@mcp.tool()
+async def convert_directory(dir_path: str, recursive: bool = True) -> dict[str, str]:
+    """Convert every file in a directory to markdown.
+
+    Returns a mapping of ``relative_path`` to converted markdown. Unreadable or
+    unsupported files are skipped silently so a single bad file does not abort
+    the batch; their paths simply don't appear in the result dictionary.
+    ``recursive=True`` descends into sub-directories, ``False`` processes only
+    the immediate directory.
+    """
+    base = Path(dir_path).expanduser().resolve(strict=True)
+    if not base.is_dir():
+        raise NotADirectoryError(f"Not a directory: {base}")
+
+    md = MarkItDown(enable_plugins=check_plugins_enabled())
+    files = base.rglob("*") if recursive else base.iterdir()
+
+    result: dict[str, str] = {}
+    for path in files:
+        if not path.is_file():
+            continue
+        try:
+            result[str(path.relative_to(base))] = md.convert_local(str(path)).markdown
+        except Exception:
+            # Best-effort batch: skip files that fail individually.
+            continue
+    return result
 
 
 def check_plugins_enabled() -> bool:


### PR DESCRIPTION
## Summary

Adds two thin wrapper MCP tools — `convert_file(file_path)` and `convert_directory(dir_path, recursive=True)` — alongside the existing `convert_to_markdown(uri)`. Directly addresses #1424: AI agents tend to skip the current URI-only tool when they already have a plain filesystem path in hand, and end up writing Python glue instead of calling MarkItDown.

## Changes

One file: `packages/markitdown-mcp/src/markitdown_mcp/__main__.py`.

### `convert_file(file_path: str) -> str`

Thin wrapper around `MarkItDown.convert_local()`. Resolves `~` and relative paths against CWD, raises `FileNotFoundError` for missing paths via `Path.resolve(strict=True)`. No library-side change needed.

### `convert_directory(dir_path: str, recursive: bool = True) -> dict[str, str]`

Walks a directory (recursively by default via `Path.rglob`, otherwise `Path.iterdir`) and converts every file it finds, returning a `{relative_path: markdown}` mapping. Files that fail individually are skipped with a `try/except Exception: continue` so a single bad file doesn't abort the batch — mirroring how bulk converters typically behave.

Tool schemas are auto-generated by FastMCP from the Python type hints, so no manual JSON-schema surface is introduced.

## Backwards compatibility

- Fully additive: `convert_to_markdown(uri)` is untouched.
- No new dependencies. Only uses `pathlib.Path` from the stdlib and the already-imported `MarkItDown` class.
- No configuration, environment variable, or breaking-change surface.

## Test plan

Built and installed locally (editable) on Windows with Python 3.13, then ran the new tools via an MCP client (Claude Code):

- [x] `convert_file` on a real `.docx` from a deeply-nested OneDrive/SharePoint path with German umlauts (\`D:\OneDrive\OneDrive - KEGON AG\KEGON\Intern\...\Erfassung-KI-Anwendungsfall-01-Intern-Verzeichnisse.docx\`) — converted cleanly.
- [x] `convert_directory` on the repo's own \`packages/markitdown-mcp/\` (non-recursive) — returned `{'Dockerfile', 'pyproject.toml', 'README.md'}`.
- [x] Agent tool selection: Claude chose `convert_file` autonomously given a plain Windows path (the original \`convert_to_markdown\` would require the agent to URL-escape and prefix `file://` itself — #1424's core complaint).

No unit tests added — the `tests/` directory is present but currently empty; happy to add `pytest` coverage for both new tools if that's desired before merge.

## Notes

- Co-authored with Claude Opus 4.7 (Claude Code).

Closes #1424.