### PR TITLE
feat: add include_comments option to DocxConverter

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -110,6 +110,12 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "--include-comments",
+        action="store_true",
+        help="Include Word comment references in output.",
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
@@ -191,10 +197,14 @@ def main():
             sys.stdin.buffer,
             stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
+            include_comments=args.include_comments,
         )
     else:
         result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
+            args.filename,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+            include_comments=args.include_comments,
         )
 
     _handle_output(args, result)

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -75,7 +75,13 @@ class DocxConverter(HtmlConverter):
                 _dependency_exc_info[2]
             )
 
-        style_map = kwargs.get("style_map", None)
+        style_map = kwargs.pop("style_map", None)
+        include_comments = kwargs.pop("include_comments", False)
+
+        if include_comments:
+            comment_style = "comment-reference => sup"
+            style_map = (style_map + "\n" + comment_style) if style_map else comment_style
+
         pre_process_stream = pre_process_docx(file_stream)
         return self._html_converter.convert_string(
             mammoth.convert_to_html(pre_process_stream, style_map=style_map).value,


### PR DESCRIPTION
## Summary

- Adds opt-in `include_comments` parameter to `DocxConverter.convert()` (default `False`, backwards-compatible)
- When `True`, Word comment reference marks in the document body are rendered as superscript anchors using mammoth's `style_map` mechanism (`comment-reference => sup`)
- Adds `--include-comments` CLI flag for use with file and stdin conversion

## Usage

**Python API:**
```python
from markitdown import MarkItDown

md = MarkItDown()
result = md.convert("document.docx", include_comments=True)
```

**CLI:**
```bash
markitdown --include-comments document.docx
# or via stdin
markitdown --include-comments < document.docx
```

## Test plan

- [ ] Existing `test_docx_comments` passes (verified via `hatch test` — 175 passed, 1 skipped)
- [ ] Default behavior unchanged: `include_comments=False` produces identical output to previous behavior
- [ ] `include_comments=True` renders comment reference marks as superscript anchors in the output
- [ ] `--include-comments` CLI flag correctly toggles the feature for both file and stdin paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)