### PR TITLE
docs: correct image converter description in README (EXIF + LLM, not OCR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MarkItDown currently supports the conversion from:
 - PowerPoint
 - Word
 - Excel
-- Images (EXIF metadata and OCR)
+- Images (EXIF metadata and LLM-based description)
 - Audio (EXIF metadata and speech transcription)
 - HTML
 - Text-based formats (CSV, JSON, XML)


### PR DESCRIPTION
## What

The supported-formats list in README.md claims:

> - Images (EXIF metadata and OCR)

But the built-in `ImageConverter` does **not** perform OCR. Per the converter's own docstring:

> Converts images to markdown via extraction of metadata (if `exiftool` is installed), and description via a multimodal LLM (if an `llm_client` is configured).

OCR is only available through the separate **Azure Document Intelligence** converter (`[az-doc-intel]` optional dependency), which is already documented in its own section of the README.

## Why

This one-word misstatement has caused recurring user confusion. Recent examples:

- #1601 — "OCR is not working"
- #1344 — "OCR Fallback Not Working"
- #1170 — "text in the images in a pdf is not recognizable"
- #255  — "Please add the option to use GPT models for OCR"

Users install `markitdown[all]`, feed a JPEG, and expect OCR output — but what they get is EXIF-only (no LLM client configured) or an LLM-generated description (not OCR).

## Change

One line in `README.md`:

```diff
- - Images (EXIF metadata and OCR)
+ - Images (EXIF metadata and LLM-based description)
```

This matches `ImageConverter`'s own docstring and the pattern used elsewhere in the list (e.g. "Audio (EXIF metadata and speech transcription)" — conditional, documented).

## Related

Aware of #1608 — overlapping intent (clarify OCR availability), but that PR points users at a `markitdown-ocr` plugin that is not in this repo. This change is minimal and factual: describe what the in-tree converter actually does. Happy to defer if maintainers prefer #1608's framing, or to fold this into a broader docs rewrite.