### PR TITLE
fix: quote pip install commands in missing dependency error message

### DIFF
--- a/packages/markitdown/src/markitdown/_exceptions.py
+++ b/packages/markitdown/src/markitdown/_exceptions.py
@@ -2,10 +2,12 @@ from typing import Optional, List, Any
 
 MISSING_DEPENDENCY_MESSAGE = """{converter} recognized the input as a potential {extension} file, but the dependencies needed to read {extension} files have not been installed. To resolve this error, include the optional dependency [{feature}] or [all] when installing MarkItDown. For example:
 
-* pip install markitdown[{feature}]
-* pip install markitdown[all]
-* pip install markitdown[{feature}, ...]
-* etc."""
+* pip install 'markitdown[{feature}]'
+* pip install 'markitdown[all]'
+* pip install 'markitdown[{feature}, ...]'
+* etc.
+
+Note: On zsh (macOS default shell), the square brackets must be quoted (single quotes as shown above) to prevent shell glob expansion."""
 
 
 class MarkItDownException(Exception):

--- a/packages/markitdown/src/markitdown/_exceptions.py
+++ b/packages/markitdown/src/markitdown/_exceptions.py
@@ -2,12 +2,12 @@ from typing import Optional, List, Any
 
 MISSING_DEPENDENCY_MESSAGE = """{converter} recognized the input as a potential {extension} file, but the dependencies needed to read {extension} files have not been installed. To resolve this error, include the optional dependency [{feature}] or [all] when installing MarkItDown. For example:
 
-* pip install 'markitdown[{feature}]'
-* pip install 'markitdown[all]'
-* pip install 'markitdown[{feature}, ...]'
+* pip install "markitdown[{feature}]"
+* pip install "markitdown[all]"
+* pip install "markitdown[{feature}, ...]"
 * etc.
 
-Note: On zsh (macOS default shell), the square brackets must be quoted (single quotes as shown above) to prevent shell glob expansion."""
+Note: On zsh and PowerShell, square brackets are treated as glob/wildcard patterns. The double quotes shown above prevent this on all shells (zsh, bash, fish, PowerShell, cmd.exe)."""
 
 
 class MarkItDownException(Exception):


### PR DESCRIPTION
## Summary

Error messages suggesting `pip install markitdown[pptx]` fail on shells that treat `[...]` as glob/wildcard patterns:
- **zsh** (macOS default since Catalina): `zsh: no matches found: markitdown[pptx]`
- **PowerShell** (Windows): similar glob expansion failure

Wrapped all pip install examples in double quotes — the only quoting style that works correctly across all major shells:

| Shell | Unquoted | Single quotes | Double quotes |
|-------|----------|---------------|---------------|
| zsh | ✗ glob fail | ✓ | ✓ |
| bash | ✓ | ✓ | ✓ |
| fish | ✓ | ✓ | ✓ |
| PowerShell | ✗ glob fail | ✓ | ✓ |
| cmd.exe | ✓ | ✗ literal char | ✓ |

Double quotes are the only option that works on all five.

## Changes

Updated `MISSING_DEPENDENCY_MESSAGE` in `packages/markitdown/src/markitdown/_exceptions.py`:

**Before:**
```
* pip install markitdown[pptx]
* pip install markitdown[all]
```

**After:**
```
* pip install "markitdown[pptx]"
* pip install "markitdown[all]"
```

Also added a short note explaining why quotes are needed.

## Test plan

- [ ] Trigger a `MissingDependencyException` (e.g. convert a .pptx without the `pptx` extra installed) and verify the error message shows double-quoted commands
- [ ] Confirm `pip install "markitdown[pptx]"` works on zsh, PowerShell, and cmd.exe without modification