### PR TITLE
fix: parse charset parameters case-insensitively

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -480,8 +480,9 @@ class MarkItDown:
             parts = response.headers["content-type"].split(";")
             mimetype = parts.pop(0).strip()
             for part in parts:
-                if part.strip().startswith("charset="):
-                    _charset = part.split("=")[1].strip()
+                key, sep, value = part.strip().partition("=")
+                if sep and key.strip().lower() == "charset":
+                    _charset = value.strip()
                     if len(_charset) > 0:
                         charset = _charset
 

--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -43,9 +43,9 @@ def parse_data_uri(uri: str) -> Tuple[str | None, Dict[str, str], bytes]:
         # Handle key=value pairs in the middle
         if "=" in part:
             key, value = part.split("=", 1)
-            attributes[key] = value
+            attributes[key.lower()] = value
         elif len(part) > 0:
-            attributes[part] = ""
+            attributes[part.lower()] = ""
 
     content = base64.b64decode(data) if is_base64 else unquote_to_bytes(data)
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -219,6 +219,13 @@ def test_data_uris() -> None:
     assert attributes["charset"] == "utf-8"
     assert data == b"Hello, World!"
 
+    data_uri = "data:text/plain;Charset=utf-8,Hello%2C%20World%21"
+    mime_type, attributes, data = parse_data_uri(data_uri)
+    assert mime_type == "text/plain"
+    assert len(attributes) == 1
+    assert attributes["charset"] == "utf-8"
+    assert data == b"Hello, World!"
+
 
 def test_file_uris() -> None:
     # Test file URI with an empty host
@@ -250,6 +257,17 @@ def test_file_uris() -> None:
     netloc, path = file_uri_to_path(file_uri)
     assert netloc is None
     assert path == "/path/to/file.txt"
+
+
+def test_response_content_type_charset_is_case_insensitive() -> None:
+    response = MagicMock()
+    response.headers = {"content-type": "text/plain; Charset=UTF-8"}
+    response.url = "https://example.com/test.txt"
+    response.iter_content.return_value = [b"Hello, World!"]
+
+    result = MarkItDown().convert_response(response)
+
+    assert result.text_content == "Hello, World!"
 
 
 def test_docx_comments() -> None:


### PR DESCRIPTION
## Summary

- Treat `charset` parameters case-insensitively when parsing `Content-Type` response headers.
- Normalize data URI parameter names so `Charset=utf-8` is handled the same as `charset=utf-8`.
- Add regression coverage for both paths.

## Why

MIME parameter names are commonly handled case-insensitively, and real HTTP responses may spell charset as `Charset=UTF-8`. MarkItDown already uses the parsed charset as a conversion hint, so preserving it avoids falling back to charset guessing for otherwise explicit inputs.

## Tests

- `uv run --with '.[all]' --with pytest --directory packages/markitdown python -m pytest tests/test_module_misc.py::test_data_uris tests/test_module_misc.py::test_response_content_type_charset_is_case_insensitive -q`
