### PR TITLE
fix(wikipedia): accept mobile (m.wikipedia.org) URLs

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
@@ -34,7 +34,7 @@ class WikipediaConverter(DocumentConverter):
         mimetype = (stream_info.mimetype or "").lower()
         extension = (stream_info.extension or "").lower()
 
-        if not re.search(r"^https?:\/\/[a-zA-Z]{2,3}\.wikipedia.org\/", url):
+        if not re.search(r"^https?:\/\/[a-zA-Z]{2,3}(\.m)?\.wikipedia.org\/", url):
             # Not a Wikipedia URL
             return False
 


### PR DESCRIPTION
## Summary

`WikipediaConverter.accepts()` rejected mobile Wikipedia URLs
(e.g. `https://en.m.wikipedia.org/wiki/Foo`) because its regex required
the language subdomain (2-3 letters) to be **immediately** followed by
`.wikipedia.org`. Mobile URLs have an extra `.m` segment between the
language code and `.wikipedia.org`, so they fell through to the
generic `HtmlConverter`, producing noisy navigation/footer markdown
instead of the clean main-content extraction `WikipediaConverter`
provides.

## What changed

One-line regex change in `_wikipedia_converter.py`:

```diff
- if not re.search(r"^https?:\/\/[a-zA-Z]{2,3}\.wikipedia.org\/", url):
+ if not re.search(r"^https?:\/\/[a-zA-Z]{2,3}(\.m)?\.wikipedia.org\/", url):
```

The optional `(\.m)?` allows mobile subdomains while preserving:
- The `^https?:` anchor
- Rejection of non-Wikipedia hosts like `wikipedia.com`
- Rejection of arbitrary subdomains like `xyz.example.com`

## How to test

```python
import re
pat = r"^https?:\/\/[a-zA-Z]{2,3}(\.m)?\.wikipedia.org\/"

# Should match
assert re.search(pat, "https://en.wikipedia.org/wiki/X")
assert re.search(pat, "https://en.m.wikipedia.org/wiki/X")
assert re.search(pat, "https://de.m.wikipedia.org/wiki/X")
assert re.search(pat, "https://fr.m.wikipedia.org/wiki/X")

# Should not match
assert not re.search(pat, "https://wikipedia.com/x")
assert not re.search(pat, "https://en.example.org/x")
```

## Why this is small + safe

- Single line of production code changed
- The change is purely additive: every previously-accepted URL is still
  accepted (the new group `(\.m)?` is optional)
- No behavior change for the `convert()` path
- No new dependencies

## Notes

This is orthogonal to PR #1723's hyphenated-language-code fix
(`be-tarask`, `zh-classical`, etc.) - mobile URLs are a separate gap
not covered by that PR's regex `[a-zA-Z0-9-]+\.wikipedia.org` because
the `.m.` segment still has to fit between the language code and
`.wikipedia.org`. The two fixes can compose if both are merged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>