### PR TITLE
fix: guard against None text in PptxConverter shape and notes

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -162,9 +162,9 @@ class PptxConverter(DocumentConverter):
                 # Text areas
                 elif shape.has_text_frame:
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\n"
+                        md_content += "# " + (shape.text or "").lstrip() + "\n"
                     else:
-                        md_content += shape.text + "\n"
+                        md_content += (shape.text or "") + "\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -194,7 +194,7 @@ class PptxConverter(DocumentConverter):
                 md_content += "\n\n### Notes:\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
+                    md_content += (notes_frame.text or "")
                 md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())


### PR DESCRIPTION
## Summary

`PptxConverter.convert()` performs unguarded `+` concatenation on `shape.text` and `notes_frame.text`. When python-pptx yields `None` for a text frame (e.g. an `<a:r>` with no `<a:t>`, or certain third-party-generated decks), the entire file conversion fails with:

```
TypeError: can only concatenate str (not "NoneType") to str
```

### Changes

Apply `(x or "")` pattern to all three concatenation sites in `_pptx_converter.py`:

- **L165**: `shape.text` for title shapes → `(shape.text or "").lstrip()`
- **L167**: `shape.text` for non-title shapes → `(shape.text or "")`
- **L197**: `notes_frame.text` → `(notes_frame.text or "")`

### Why this is safe

`None` text is semantically equivalent to empty string here — a shape with no text content should contribute nothing to the markdown output, not crash the converter. One malformed shape should not fail the entire file.

Fixes #1808