### PR TITLE
Escape CSV cells in Markdown tables

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -12,6 +12,15 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ACCEPTED_FILE_EXTENSIONS = [".csv"]
 
 
+def _escape_markdown_table_cell(value: str) -> str:
+    return (
+        value.replace("|", "\\|")
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\n", "<br>")
+    )
+
+
 class CsvConverter(DocumentConverter):
     """
     Converts CSV files to Markdown tables.
@@ -58,7 +67,11 @@ class CsvConverter(DocumentConverter):
         markdown_table = []
 
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        markdown_table.append(
+            "| "
+            + " | ".join(_escape_markdown_table_cell(cell) for cell in rows[0])
+            + " |"
+        )
 
         # Add separator row
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
@@ -70,7 +83,11 @@ class CsvConverter(DocumentConverter):
                 row.append("")
             # Truncate if row has more columns than header
             row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+            markdown_table.append(
+                "| "
+                + " | ".join(_escape_markdown_table_cell(cell) for cell in row)
+                + " |"
+            )
 
         result = "\n".join(markdown_table)
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -14,6 +14,7 @@ from markitdown import (
     FileConversionException,
     StreamInfo,
 )
+from markitdown.converters._csv_converter import CsvConverter
 
 # This file contains module tests that are not directly tested by the FileTestVectors.
 # This includes things like helper functions and runtime conversion options
@@ -250,6 +251,19 @@ def test_file_uris() -> None:
     netloc, path = file_uri_to_path(file_uri)
     assert netloc is None
     assert path == "/path/to/file.txt"
+
+
+def test_csv_converter_escapes_markdown_table_cells() -> None:
+    csv_content = 'name,notes\nAda,"uses A|B\nnext line"\n'
+
+    result = CsvConverter().convert(
+        io.BytesIO(csv_content.encode("utf-8")),
+        StreamInfo(extension=".csv", charset="utf-8"),
+    )
+
+    assert result.markdown == (
+        "| name | notes |\n| --- | --- |\n| Ada | uses A\\|B<br>next line |"
+    )
 
 
 def test_docx_comments() -> None:


### PR DESCRIPTION
## Summary
- escape pipe characters in CSV cells before rendering Markdown tables
- normalize embedded newlines in CSV cells to `<br>` so a quoted multiline field stays within one table row
- add a focused regression test for pipe and multiline cell content

## Tests
- uv run --project packages/markitdown --with pytest python -m pytest packages/markitdown/tests/test_module_misc.py::test_csv_converter_escapes_markdown_table_cells packages/markitdown/tests/test_module_vectors.py::test_convert_stream_with_hints -q
- uv run --project packages/markitdown --with ruff ruff format --check packages/markitdown/src/markitdown/converters/_csv_converter.py packages/markitdown/tests/test_module_misc.py
- uv run --project packages/markitdown --with ruff ruff check packages/markitdown/src/markitdown/converters/_csv_converter.py packages/markitdown/tests/test_module_misc.py
- uv run --project packages/markitdown --with mypy python -m mypy --ignore-missing-imports packages/markitdown/src/markitdown/converters/_csv_converter.py packages/markitdown/tests/test_module_misc.py