### PR TITLE
fix(pptx): tolerate missing text frames

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -31,6 +31,10 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ACCEPTED_FILE_EXTENSIONS = [".pptx"]
 
 
+def _safe_text(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
 class PptxConverter(DocumentConverter):
     """
     Converts PPTX files to Markdown. Supports heading, tables and images with alt text.
@@ -161,10 +165,11 @@ class PptxConverter(DocumentConverter):
 
                 # Text areas
                 elif shape.has_text_frame:
+                    text = _safe_text(shape.text)
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\n"
+                        md_content += "# " + text.lstrip() + "\n"
                     else:
-                        md_content += shape.text + "\n"
+                        md_content += text + "\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -194,7 +199,7 @@ class PptxConverter(DocumentConverter):
                 md_content += "\n\n### Notes:\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
+                    md_content += _safe_text(notes_frame.text)
                 md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())
@@ -219,10 +224,11 @@ class PptxConverter(DocumentConverter):
         for row in table.rows:
             html_table += "<tr>"
             for cell in row.cells:
+                text = _safe_text(cell.text)
                 if first_row:
-                    html_table += "<th>" + html.escape(cell.text) + "</th>"
+                    html_table += "<th>" + html.escape(text) + "</th>"
                 else:
-                    html_table += "<td>" + html.escape(cell.text) + "</td>"
+                    html_table += "<td>" + html.escape(text) + "</td>"
             html_table += "</tr>"
             first_row = False
         html_table += "</table></body></html>"
@@ -236,7 +242,7 @@ class PptxConverter(DocumentConverter):
         try:
             md = "\n\n### Chart"
             if chart.has_title:
-                md += f": {chart.chart_title.text_frame.text}"
+                md += f": {_safe_text(chart.chart_title.text_frame.text)}"
             md += "\n\n"
             data = []
             category_names = [c.label for c in chart.plots[0].categories]

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -432,6 +432,21 @@ def test_exceptions() -> None:
     assert type(exc_info.value.attempts[0].converter).__name__ == "PptxConverter"
 
 
+def test_pptx_converter_treats_none_text_as_empty(monkeypatch) -> None:
+    import pptx.text.text
+
+    original_getter = pptx.text.text.TextFrame.text.fget
+
+    def text_or_none(self):
+        text = original_getter(self)
+        return None if text else text
+
+    monkeypatch.setattr(pptx.text.text.TextFrame, "text", property(text_or_none))
+
+    result = MarkItDown().convert(os.path.join(TEST_FILES_DIR, "test.pptx"))
+    assert result.text_content is not None
+
+
 @pytest.mark.skipif(
     skip_exiftool,
     reason="do not run if exiftool is not installed",


### PR DESCRIPTION
## Summary
- Treat missing PPTX text-frame values as empty strings during conversion
- Apply the guard to slide text, notes, table cells, and chart titles
- Add regression coverage for python-pptx returning `None` from `TextFrame.text`

Fixes #1808

## Tests
- PYTHONPATH=packages/markitdown/src /Users/bytedance/MySpace/open-source/markitdown-excel-currency/.venv/bin/python -m pytest packages/markitdown/tests/test_module_misc.py::test_pptx_converter_treats_none_text_as_empty packages/markitdown/tests/test_module_misc.py::test_exceptions
- PYTHONPATH=packages/markitdown/src /Users/bytedance/MySpace/open-source/markitdown-excel-currency/.venv/bin/python -m compileall -q packages/markitdown/src/markitdown/converters/_pptx_converter.py packages/markitdown/tests/test_module_misc.py
- git diff --check
