### PR TITLE
Fix OCR for mixed text and scanned PDF pages

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
@@ -276,10 +276,18 @@ class PdfConverterWithOCR(DocumentConverter):
                                     )
                                     markdown_content.append(img_marker)
                         else:
-                            # No images detected - just extract regular text
+                            # No embedded images detected. If the page also has
+                            # no text layer, OCR just this page instead of
+                            # waiting for the whole-document fallback.
                             text_content = page.extract_text() or ""
                             if text_content.strip():
                                 markdown_content.append(text_content.strip())
+                            else:
+                                ocr_block = self._ocr_single_page(
+                                    page, ocr_service
+                                )
+                                if ocr_block:
+                                    markdown_content.append(ocr_block)
                     else:
                         # No OCR, just extract text
                         text_content = page.extract_text() or ""
@@ -336,6 +344,24 @@ class PdfConverterWithOCR(DocumentConverter):
         images.sort(key=lambda x: x["y_pos"])
 
         return images
+
+    def _ocr_single_page(
+        self, page: Any, ocr_service: LLMVisionOCRService
+    ) -> str:
+        """Render one PDF page and OCR it."""
+        try:
+            page_img = page.to_image(resolution=300)
+            img_stream = io.BytesIO()
+            page_img.original.save(img_stream, format="PNG")
+            img_stream.seek(0)
+
+            ocr_result = ocr_service.extract_text(img_stream)
+            text = (ocr_result.text or "").strip()
+            if not text:
+                return ""
+            return f"*[Image OCR]\n{text}\n[End OCR]*"
+        except Exception:
+            return ""
 
     def _ocr_full_pages(
         self, pdf_bytes: io.BytesIO, ocr_service: LLMVisionOCRService

--- a/packages/markitdown-ocr/tests/test_pdf_converter.py
+++ b/packages/markitdown-ocr/tests/test_pdf_converter.py
@@ -189,6 +189,39 @@ def test_pdf_scanned_report(svc: MockOCRService) -> None:
     assert _convert("pdf_scanned_report.pdf", svc) == expected
 
 
+def test_pdf_mixed_text_and_scanned_pages_ocrs_empty_page(
+    svc: MockOCRService,
+) -> None:
+    converter = PdfConverterWithOCR()
+
+    text_page = MagicMock()
+    text_page.chars = []
+    text_page.extract_text.return_value = "First page text"
+
+    scanned_page = MagicMock()
+    scanned_page.chars = []
+    scanned_page.extract_text.return_value = ""
+    scanned_page.to_image.return_value.original.save.side_effect = (
+        lambda stream, format: stream.write(b"fake-png")
+    )
+
+    mock_pdf = MagicMock()
+    mock_pdf.pages = [text_page, scanned_page]
+    mock_pdf.__enter__.return_value = mock_pdf
+
+    with patch("pdfplumber.open", return_value=mock_pdf), patch.object(
+        converter, "_extract_page_images", return_value=[]
+    ):
+        md = converter.convert(
+            io.BytesIO(b"%PDF-1.7"), StreamInfo(extension=".pdf"), ocr_service=svc
+        ).text_content
+
+    assert "First page text" in md
+    assert "## Page 2" in md
+    assert _OCR_BLOCK in md
+    scanned_page.to_image.assert_called_once_with(resolution=300)
+
+
 # ---------------------------------------------------------------------------
 # Scanned PDF fallback path (pdfplumber finds no text → full-page OCR)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue
Closes #1791

## Root cause
When an OCR-enabled PDF has at least one extractable text page, the converter builds non-empty markdown from that page and never reaches the whole-document scanned-PDF fallback. Later pages that have no embedded image objects and no text layer are left as page headers only.

## Fix
Render and OCR an individual page when OCR is enabled, no embedded images are detected, and the page text layer is empty. This keeps text-layer pages on the existing path while recovering mixed scanned pages.

## Tests
- `uv run --project packages/markitdown-ocr --with-editable packages/markitdown --with pytest python -m pytest packages/markitdown-ocr/tests/test_pdf_converter.py -k 'mixed_text_and_scanned_pages or scanned_report or scanned_fallback_format'`
- Note: running the full `test_pdf_converter.py` file in this local uv environment gives 13/14 passing; the remaining existing `test_pdf_multipage` expectation assumes pdfplumber fails on that fixture, but pdfplumber parses it successfully here before this change.
