### PR TITLE
Add EML email converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ MarkItDown currently supports the conversion from:
 - Audio (EXIF metadata and speech transcription)
 - HTML
 - Text-based formats (CSV, JSON, XML)
+- Email messages (EML, MSG)
 - ZIP files (iterates over contents)
 - Youtube URLs
 - EPubs

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -34,6 +34,7 @@ from .converters import (
     PptxConverter,
     ImageConverter,
     AudioConverter,
+    EmlConverter,
     OutlookMsgConverter,
     ZipConverter,
     EpubConverter,
@@ -199,6 +200,7 @@ class MarkItDown:
             self.register_converter(ImageConverter())
             self.register_converter(IpynbConverter())
             self.register_converter(PdfConverter())
+            self.register_converter(EmlConverter())
             self.register_converter(OutlookMsgConverter())
             self.register_converter(EpubConverter())
             self.register_converter(CsvConverter())

--- a/packages/markitdown/src/markitdown/converters/__init__.py
+++ b/packages/markitdown/src/markitdown/converters/__init__.py
@@ -15,6 +15,7 @@ from ._xlsx_converter import XlsxConverter, XlsConverter
 from ._pptx_converter import PptxConverter
 from ._image_converter import ImageConverter
 from ._audio_converter import AudioConverter
+from ._eml_converter import EmlConverter
 from ._outlook_msg_converter import OutlookMsgConverter
 from ._zip_converter import ZipConverter
 from ._doc_intel_converter import (
@@ -39,6 +40,7 @@ __all__ = [
     "PptxConverter",
     "ImageConverter",
     "AudioConverter",
+    "EmlConverter",
     "OutlookMsgConverter",
     "ZipConverter",
     "DocumentIntelligenceConverter",

--- a/packages/markitdown/src/markitdown/converters/_eml_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_eml_converter.py
@@ -1,0 +1,151 @@
+from email import policy
+from email.message import EmailMessage, Message
+from email.parser import BytesParser
+from typing import Any, BinaryIO, Iterable, Optional
+
+from .._base_converter import DocumentConverter, DocumentConverterResult
+from .._stream_info import StreamInfo
+from ._html_converter import HtmlConverter
+
+ACCEPTED_MIME_TYPE_PREFIXES = [
+    "message/rfc822",
+]
+
+ACCEPTED_FILE_EXTENSIONS = [
+    ".eml",
+]
+
+
+class EmlConverter(DocumentConverter):
+    """Converts RFC 822 / MIME email messages to Markdown."""
+
+    def accepts(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,
+    ) -> bool:
+        mimetype = (stream_info.mimetype or "").lower()
+        extension = (stream_info.extension or "").lower()
+
+        if extension in ACCEPTED_FILE_EXTENSIONS:
+            return True
+
+        for prefix in ACCEPTED_MIME_TYPE_PREFIXES:
+            if mimetype.startswith(prefix):
+                return True
+
+        cur_pos = file_stream.tell()
+        try:
+            headers = BytesParser(policy=policy.default).parse(
+                file_stream, headersonly=True
+            )
+            return self._looks_like_email(headers)
+        except Exception:
+            return False
+        finally:
+            file_stream.seek(cur_pos)
+
+    def convert(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,
+    ) -> DocumentConverterResult:
+        message = BytesParser(policy=policy.default).parse(file_stream)
+        subject = self._header_value(message, "Subject")
+
+        lines = ["# Email Message", ""]
+
+        headers = [
+            ("From", self._header_value(message, "From")),
+            ("To", self._header_value(message, "To")),
+            ("Cc", self._header_value(message, "Cc")),
+            ("Bcc", self._header_value(message, "Bcc")),
+            ("Date", self._header_value(message, "Date")),
+            ("Subject", subject),
+        ]
+
+        for key, value in headers:
+            if value:
+                lines.append(f"**{key}:** {value}")
+
+        body = self._extract_body(message)
+        attachments = self._extract_attachment_names(message)
+
+        if body:
+            lines.extend(["", "## Content", "", body.strip()])
+
+        if attachments:
+            lines.extend(["", "## Attachments", ""])
+            lines.extend([f"- {name}" for name in attachments])
+
+        return DocumentConverterResult(
+            markdown="\n".join(lines).strip(),
+            title=subject,
+        )
+
+    def _looks_like_email(self, message: Message) -> bool:
+        if not message.keys():
+            return False
+
+        has_sender = message.get("From") is not None
+        has_recipient = any(message.get(header) is not None for header in ["To", "Cc"])
+        has_subject = message.get("Subject") is not None
+
+        return has_sender and (has_recipient or has_subject)
+
+    def _header_value(self, message: Message, name: str) -> Optional[str]:
+        value = message.get(name)
+        return None if value is None else str(value).strip()
+
+    def _extract_body(self, message: Message) -> str:
+        plain_parts = list(self._iter_body_parts(message, "text/plain"))
+        if plain_parts:
+            return "\n\n".join(plain_parts)
+
+        html_parts = list(self._iter_body_parts(message, "text/html"))
+        if not html_parts:
+            return ""
+
+        html = "\n\n".join(html_parts)
+        result = HtmlConverter().convert_string(html)
+        return result.markdown
+
+    def _iter_body_parts(self, message: Message, content_type: str) -> Iterable[str]:
+        if message.is_multipart():
+            for part in message.walk():
+                if part.is_multipart():
+                    continue
+                if part.get_content_disposition() == "attachment":
+                    continue
+                if part.get_content_type() == content_type:
+                    yield self._get_part_content(part)
+        elif message.get_content_type() == content_type:
+            yield self._get_part_content(message)
+
+    def _get_part_content(self, part: Message) -> str:
+        if isinstance(part, EmailMessage):
+            content = part.get_content()
+            return content if isinstance(content, str) else str(content)
+
+        payload = part.get_payload(decode=True)
+        if payload is None:
+            content = part.get_payload()
+            return content if isinstance(content, str) else str(content)
+
+        charset = part.get_content_charset() or "utf-8"
+        return payload.decode(charset, errors="replace")
+
+    def _extract_attachment_names(self, message: Message) -> list[str]:
+        if not message.is_multipart():
+            return []
+
+        attachments: list[str] = []
+        for part in message.walk():
+            if part.get_content_disposition() == "attachment":
+                filename = part.get_filename()
+                if filename:
+                    attachments.append(filename)
+
+        return attachments

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -88,6 +88,25 @@ GENERAL_TEST_VECTORS = [
         must_not_include=[],
     ),
     FileTestVector(
+        filename="test.eml",
+        mimetype="message/rfc822",
+        charset="utf-8",
+        url=None,
+        must_include=[
+            "# Email Message",
+            "**From:** Test Sender <test.sender@example.com>",
+            "**To:** Test Recipient <test.recipient@example.com>",
+            "**Subject:** Test EML Message",
+            "## Content",
+            "This is the body of the test EML message.",
+            "It has multiple lines.",
+        ],
+        must_not_include=[
+            "Content-Type:",
+            "MIME-Version:",
+        ],
+    ),
+    FileTestVector(
         filename="test.pdf",
         mimetype="application/pdf",
         charset=None,

--- a/packages/markitdown/tests/test_files/test.eml
+++ b/packages/markitdown/tests/test_files/test.eml
@@ -1,0 +1,9 @@
+From: Test Sender <test.sender@example.com>
+To: Test Recipient <test.recipient@example.com>
+Date: Fri, 15 May 2026 10:00:00 -0700
+Subject: Test EML Message
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+This is the body of the test EML message.
+It has multiple lines.


### PR DESCRIPTION
## Summary
- add built-in support for converting RFC 822 / MIME .eml email messages
- extract common email headers, plain-text or HTML body content, and attachment filenames
- add a fixture and vector coverage for EML conversion

Fixes #89.

## Tests
- `.\.venv\Scripts\python -m pytest packages\markitdown\tests\test_module_vectors.py -q`