### PR TITLE
docs: fix sample plugin comment typo

### DIFF
--- a/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
+++ b/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
@@ -60,7 +60,7 @@ class RtfConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,
     ) -> DocumentConverterResult:
-        # Read the file stream into an str using hte provided charset encoding, or using the system default
+        # Read the file stream into an str using the provided charset encoding, or using the system default
         encoding = stream_info.charset or locale.getpreferredencoding()
         stream_data = file_stream.read().decode(encoding)
 


### PR DESCRIPTION
## Summary\n- Fix a small typo in the sample plugin charset decoding comment\n- No runtime behavior changes\n\n## Validation\n- git diff --check\n- Targeted content assertion confirmed "hte provided charset encoding" is gone and "the provided charset encoding" is present