### PR TITLE
docs(mcp): document SSL_CERT_FILE for corporate proxy setups

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -98,6 +98,28 @@ If you want to mount a directory, adjust it accordingly:
 }
 ```
 
+## Behind a corporate proxy
+
+If you are behind a corporate proxy that performs TLS interception (a "man-in-the-middle" proxy that re-signs HTTPS traffic with an internal CA), `uvx` and `pip` may fail to download `markitdown-mcp` or its dependencies because Python's bundled `certifi` trust store does not include the proxy's CA certificate. The error typically surfaces as an SSL verification failure during package install.
+
+Point Python at a certificate bundle that includes your corporate CA by setting `SSL_CERT_FILE` in the MCP server's `env` block. For example, in `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "markitdown": {
+      "command": "uvx",
+      "args": ["markitdown-mcp"],
+      "env": {
+        "SSL_CERT_FILE": "/Library/Application Support/VPNCLIENT/Agent/data/cacert_combined.pem"
+      }
+    }
+  }
+}
+```
+
+Replace the path with the location of a PEM bundle on your machine that contains your corporate root CA (your IT team can usually provide this). The same `SSL_CERT_FILE` variable works for any client that uses Python's `ssl` module, including `pip` and `uv`.
+
 ## Debugging
 
 To debug the MCP server you can use the `MCP Inspector` tool.


### PR DESCRIPTION
## Summary

Fixes #1444.

Users behind a corporate proxy that performs TLS interception cannot install or run `markitdown-mcp` via `uvx` out of the box. The proxy re-signs HTTPS traffic with an internal CA, and Python's bundled `certifi` trust store does not include that CA, so package downloads fail with an SSL verification error. The fix is well known (point `SSL_CERT_FILE` at a PEM bundle that includes the corporate CA), but the markitdown-mcp README does not mention it, so users hit a dead end before they ever get to use the server.

This PR adds a short "Behind a corporate proxy" subsection to `packages/markitdown-mcp/README.md`. It:

- Explains the failure mode (TLS-intercepting proxy, certifi does not trust the corporate CA, SSL error during install).
- Shows the `mcp.json` snippet from the original issue, with `SSL_CERT_FILE` set in the server's `env` block.
- Notes that the same variable also works for `pip` and `uv`, and that the PEM path will typically come from IT.

The snippet matches the shape the reporter posted in #1444, normalized to the `mcpServers` wrapper used elsewhere in the README so it can be dropped into the same config file as the existing examples.

## Scope

Documentation only. No code or behavior changes.