### PR TITLE
Preserve spaces in positioned PDF text

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -9,6 +9,12 @@ from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 
 # Pattern for MasterFormat-style partial numbering (e.g., ".1", ".2", ".10")
 PARTIAL_NUMBERING_PATTERN = re.compile(r"^\.\d+$")
+LONG_ASCII_WORD_PATTERN = re.compile(r"[A-Za-z]{30,}")
+
+# pdfplumber's default x_tolerance can merge adjacent positioned words in PDFs
+# that omit literal space glyphs. A smaller tolerance preserves those spaces
+# while still allowing table/form detection to operate on word-level positions.
+PDFPLUMBER_TEXT_X_TOLERANCE = 1
 
 
 def _merge_partial_numbering_lines(text: str) -> str:
@@ -55,6 +61,50 @@ def _merge_partial_numbering_lines(text: str) -> str:
             i += 1
 
     return "\n".join(result_lines)
+
+
+def _has_space_starved_text(text: str) -> bool:
+    """
+    Return True when extracted text appears to have lost most word boundaries.
+
+    Some PDFs position words separately instead of storing literal space glyphs.
+    pdfminer can then produce long alphabetic runs such as
+    "NaturalLanguageProcessing" throughout the document. This intentionally
+    uses a conservative threshold so ordinary identifiers/URLs do not trigger
+    a fallback choice by themselves.
+    """
+    ascii_letters = sum(1 for char in text if char.isascii() and char.isalpha())
+    if ascii_letters < 500:
+        return False
+
+    whitespace_ratio = sum(1 for char in text if char.isspace()) / ascii_letters
+    long_word_count = len(LONG_ASCII_WORD_PATTERN.findall(text))
+
+    return whitespace_ratio < 0.03 and long_word_count >= 5
+
+
+def _has_space_starved_words(words: list[dict]) -> bool:
+    alpha_word_count = sum(
+        1
+        for word in words
+        if any(char.isascii() and char.isalpha() for char in word.get("text", ""))
+    )
+    if alpha_word_count < 50:
+        return False
+
+    long_word_count = sum(
+        1 for word in words if LONG_ASCII_WORD_PATTERN.search(word.get("text", ""))
+    )
+
+    return long_word_count >= 5 and long_word_count / alpha_word_count >= 0.025
+
+
+def _select_plain_text_extraction(pdfminer_text: str, pdfplumber_text: str) -> str:
+    """Choose the better plain-text PDF extraction result."""
+    if pdfplumber_text.strip() and _has_space_starved_text(pdfminer_text):
+        return pdfplumber_text
+
+    return pdfminer_text
 
 
 # Load dependencies
@@ -117,7 +167,9 @@ def _to_markdown_table(table: list[list[str]], include_separator: bool = True) -
     return "\n".join(md)
 
 
-def _extract_form_content_from_words(page: Any) -> str | None:
+def _extract_form_content_from_words(
+    page: Any, words: list[dict] | None = None
+) -> str | None:
     """
     Extract form-style content from a PDF page by analyzing word positions.
     This handles borderless forms/tables where words are aligned in columns.
@@ -129,8 +181,12 @@ def _extract_form_content_from_words(page: Any) -> str | None:
     Returns None if the page doesn't appear to be a form-style document,
     indicating that pdfminer should be used instead for better text spacing.
     """
-    words = page.extract_words(keep_blank_chars=True, x_tolerance=3, y_tolerance=3)
+    if words is None:
+        words = page.extract_words(keep_blank_chars=True, x_tolerance=3, y_tolerance=3)
     if not words:
+        return None
+
+    if _has_space_starved_words(words):
         return None
 
     # Group words by their Y position (rows)
@@ -548,10 +604,17 @@ class PdfConverter(DocumentConverter):
             markdown_chunks: list[str] = []
             form_page_count = 0
             plain_page_indices: list[int] = []
+            space_starved_page_count = 0
 
             with pdfplumber.open(pdf_bytes) as pdf:
                 for page_idx, page in enumerate(pdf.pages):
-                    page_content = _extract_form_content_from_words(page)
+                    words = page.extract_words(
+                        keep_blank_chars=True, x_tolerance=3, y_tolerance=3
+                    )
+                    if _has_space_starved_words(words):
+                        space_starved_page_count += 1
+
+                    page_content = _extract_form_content_from_words(page, words=words)
 
                     if page_content is not None:
                         form_page_count += 1
@@ -559,19 +622,33 @@ class PdfConverter(DocumentConverter):
                             markdown_chunks.append(page_content)
                     else:
                         plain_page_indices.append(page_idx)
-                        text = page.extract_text()
+                        text = page.extract_text(
+                            x_tolerance=PDFPLUMBER_TEXT_X_TOLERANCE
+                        )
                         if text and text.strip():
                             markdown_chunks.append(text.strip())
 
                     page.close()  # Free cached page data immediately
 
             # If no pages had form-style content, use pdfminer for
-            # the whole document (better text spacing for prose).
-            if form_page_count == 0:
+            # the whole document when it has good spacing. Some PDFs
+            # encode words by position without literal spaces; in that
+            # case pdfplumber with a tight x_tolerance preserves word
+            # boundaries better.
+            pdfplumber_markdown = "\n\n".join(markdown_chunks).strip()
+            force_plain_text = (
+                space_starved_page_count >= 2
+                and space_starved_page_count > form_page_count
+            )
+
+            if form_page_count == 0 or force_plain_text:
                 pdf_bytes.seek(0)
-                markdown = pdfminer.high_level.extract_text(pdf_bytes)
+                pdfminer_markdown = pdfminer.high_level.extract_text(pdf_bytes)
+                markdown = _select_plain_text_extraction(
+                    pdfminer_markdown, pdfplumber_markdown
+                )
             else:
-                markdown = "\n\n".join(markdown_chunks).strip()
+                markdown = pdfplumber_markdown
 
         except Exception:
             # Fallback if pdfplumber fails

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -67,6 +67,30 @@ def _make_plain_page():
     return page
 
 
+def _make_positioned_plain_page():
+    """Create a mock page that needs tight x_tolerance to preserve spaces."""
+    page = MagicMock()
+    page.width = 612
+    page.close = MagicMock()
+    page.extract_words.return_value = [
+        {
+            "text": "Natural",
+            "x0": 50,
+            "x1": 90,
+            "top": 10,
+            "bottom": 20,
+        },
+    ]
+
+    def extract_text(*args, **kwargs):
+        if kwargs.get("x_tolerance") == 1:
+            return "Natural Language Processing research uses positioned text."
+        return "NaturalLanguageProcessingresearchusespositionedtext."
+
+    page.extract_text.side_effect = extract_text
+    return page
+
+
 def _mock_pdfplumber_open(pages):
     """Return a mock pdfplumber.open that yields the given pages."""
 
@@ -146,6 +170,37 @@ class TestPdfMemoryOptimization:
             "plain-text PDFs should fall back to pdfminer"
         )
         assert result.text_content is not None
+
+    def test_space_starved_pdfminer_output_uses_pdfplumber_text(self):
+        """Use pdfplumber text when pdfminer loses positioned word boundaries."""
+        page = _make_positioned_plain_page()
+        collapsed_text = "\n".join(["NaturalLanguageProcessingResearch"] * 20)
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = collapsed_text
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        page.extract_words.assert_called_with(
+            keep_blank_chars=True,
+            x_tolerance=3,
+            y_tolerance=3,
+        )
+        page.extract_text.assert_called_with(x_tolerance=1)
+        assert "Natural Language Processing" in result.text_content
+        assert "NaturalLanguageProcessingResearch" not in result.text_content
 
     def test_plain_text_pdf_still_closes_all_pages(self):
         """Even for plain-text PDFs, page.close() must be called on every page."""


### PR DESCRIPTION
## Summary
- detect pdfminer output that has lost word boundaries in positioned PDF text and use pdfplumber’s tighter text extraction for those plain-text pages
- avoid treating space-starved prose pages as form/table pages
- add a regression test for the plain-text fallback path

Fixes #120

## Testing
- `UV_CACHE_DIR=/tmp/markitdown-uv-cache uv run --project . --extra pdf --with pytest pytest tests/test_pdf_memory.py::TestPdfMemoryOptimization::test_space_starved_pdfminer_output_uses_pdfplumber_text -q`
- `UV_CACHE_DIR=/tmp/markitdown-uv-cache uv run --project . --extra pdf --with pytest pytest tests/test_pdf_memory.py tests/test_pdf_tables.py tests/test_pdf_masterformat.py -q`
- `UV_CACHE_DIR=/tmp/markitdown-uv-cache GITHUB_ACTIONS=true uv run --project . --all-extras --with pytest --with openai pytest -q`
- `UV_CACHE_DIR=/tmp/markitdown-uv-cache HATCH_ENV_TYPE_VIRTUAL_PATH=/tmp/markitdown-hatch-envs GITHUB_ACTIONS=true uv run --with hatch hatch test`
- `UV_CACHE_DIR=/tmp/markitdown-uv-cache PRE_COMMIT_HOME=/tmp/markitdown-pre-commit uv run --with pre-commit pre-commit run --all-files`
- `git diff --check`