### PR TITLE
feat: extract embedded PPTX images to a directory

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -110,6 +110,16 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "--extract-images-to",
+        metavar="DIR",
+        default=None,
+        help=(
+            "Extract embedded images (currently supported for PPTX) to the given directory and "
+            "reference them by relative filename in the output. Ignored when --keep-data-uris is set."
+        ),
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
@@ -191,10 +201,14 @@ def main():
             sys.stdin.buffer,
             stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
+            extract_images_to=args.extract_images_to,
         )
     else:
         result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
+            args.filename,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+            extract_images_to=args.extract_images_to,
         )
 
     _handle_output(args, result)

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -5,6 +5,7 @@ import os
 import io
 import re
 import html
+import posixpath
 import warnings
 
 from typing import BinaryIO, Any, Dict, Optional, Set, Tuple
@@ -89,19 +90,28 @@ class PptxConverter(DocumentConverter):
         extract_images_to: Optional[str] = kwargs.get("extract_images_to")
         keep_data_uris: bool = bool(kwargs.get("keep_data_uris", False))
 
-        extract_dir: Optional[str] = None
+        # ``extract_dir_resolved`` is the absolute path used for actual file
+        # I/O (so we can ``os.makedirs`` and ``open`` reliably regardless of
+        # the caller's CWD). ``extract_dir_for_link`` preserves the user's
+        # original input verbatim and is used to build the markdown image
+        # references, so consumers can locate the rendered files relative to
+        # whatever path they passed in (e.g. ``imgs/`` stays relative).
+        extract_dir_resolved: Optional[str] = None
+        extract_dir_for_link: Optional[str] = None
         if extract_images_to and not keep_data_uris:
-            extract_dir = os.path.abspath(extract_images_to)
+            extract_dir_resolved = os.path.abspath(extract_images_to)
+            extract_dir_for_link = extract_images_to
             try:
-                os.makedirs(extract_dir, exist_ok=True)
+                os.makedirs(extract_dir_resolved, exist_ok=True)
             except OSError as exc:
                 warnings.warn(
                     f"Could not create image extraction directory "
-                    f"{extract_dir!r}: {exc}; falling back to placeholder "
+                    f"{extract_dir_resolved!r}: {exc}; falling back to placeholder "
                     f"filenames.",
                     stacklevel=2,
                 )
-                extract_dir = None
+                extract_dir_resolved = None
+                extract_dir_for_link = None
 
         # Track filename uniqueness across the deck and reuse identical images
         # by content hash so duplicate blobs are written to disk only once.
@@ -184,12 +194,12 @@ class PptxConverter(DocumentConverter):
                         content_type = shape.image.content_type or "image/png"
                         b64_string = base64.b64encode(blob).decode("utf-8")
                         md_content += f"\n![{alt_text}](data:{content_type};base64,{b64_string})\n"
-                    elif extract_dir is not None:
+                    elif extract_dir_resolved is not None:
                         # Try to write the image to disk; fall back to the
                         # legacy placeholder if anything goes wrong.
                         try:
                             target_path, ref_name = self._resolve_image_target(
-                                extract_dir,
+                                extract_dir_resolved,
                                 slide_num,
                                 current_shape_idx,
                                 shape,
@@ -197,9 +207,21 @@ class PptxConverter(DocumentConverter):
                                 hash_to_name,
                             )
                             if target_path is not None:
+                                # Write first; only commit dedup/uniqueness
+                                # state to the shared dicts after a
+                                # successful write so a write failure does
+                                # not strand future references on a
+                                # non-existent file.
                                 with open(target_path, "wb") as fh:
                                     fh.write(shape.image.blob)
-                            md_content += f"\n![{alt_text}]({ref_name})\n"
+                                used_names.add(ref_name)
+                                sha1 = getattr(shape.image, "sha1", None)
+                                if sha1:
+                                    hash_to_name[sha1] = ref_name
+                            link = self._build_markdown_link(
+                                extract_dir_for_link, ref_name
+                            )
+                            md_content += f"\n![{alt_text}]({link})\n"
                         except Exception as exc:
                             warnings.warn(
                                 f"Failed to extract embedded PPTX image "
@@ -305,9 +327,14 @@ class PptxConverter(DocumentConverter):
 
         If the image's content hash has been seen before, returns
         ``(None, existing_reference)`` so the caller skips writing and reuses
-        the previous filename. Otherwise allocates a unique filename in
+        the previous filename. Otherwise computes a unique filename in
         ``extract_dir`` and returns the absolute path to write to plus the
         relative filename to embed in the markdown.
+
+        This method does **not** mutate ``used_names`` or ``hash_to_name``.
+        The caller is expected to commit the returned ``ref_name`` to those
+        dicts only after the file has been successfully written, so a write
+        failure does not poison the dedup state for subsequent shapes.
         """
         image = shape.image
 
@@ -316,16 +343,38 @@ class PptxConverter(DocumentConverter):
         if sha1 and sha1 in hash_to_name:
             return None, hash_to_name[sha1]
 
-        # Pick an extension (python-pptx returns a lowercase, dot-less
-        # extension such as ``"png"`` or ``"jpeg"``). Fall back to
-        # ``mimetypes.guess_extension`` based on the content type, then to
-        # ``"bin"`` if nothing else works.
-        ext = (getattr(image, "ext", None) or "").lstrip(".").lower()
+        # Pick an extension. python-pptx normally returns a lowercase
+        # dot-less extension via ``image.ext`` (e.g. ``"png"`` / ``"jpeg"``)
+        # but for image types it does not recognise (SVG, EMF, ICO, ...) it
+        # raises ``ValueError`` instead of returning ``None``. Wrap each
+        # source in its own ``try`` so we can fall through cleanly.
+        ext = ""
+        try:
+            raw_ext = getattr(image, "ext", None)
+        except Exception:
+            raw_ext = None
+        if raw_ext:
+            ext = str(raw_ext).lstrip(".").lower()
+
         if not ext:
-            content_type = getattr(image, "content_type", None) or ""
-            guessed = mimetypes.guess_extension(content_type) if content_type else None
-            if guessed:
-                ext = guessed.lstrip(".").lower()
+            try:
+                content_type = getattr(image, "content_type", None) or ""
+            except Exception:
+                content_type = ""
+            if content_type:
+                guessed = mimetypes.guess_extension(content_type)
+                if guessed:
+                    ext = guessed.lstrip(".").lower()
+
+        if not ext:
+            try:
+                image_filename = getattr(image, "filename", None) or ""
+            except Exception:
+                image_filename = ""
+            if image_filename:
+                _, fname_ext = os.path.splitext(image_filename)
+                ext = fname_ext.lstrip(".").lower()
+
         if not ext:
             ext = "bin"
 
@@ -337,15 +386,40 @@ class PptxConverter(DocumentConverter):
         base_name = f"slide{slide_num:02d}_{shape_idx}_{sanitized}"
         candidate = f"{base_name}.{ext}"
         suffix = 2
-        while candidate in used_names:
+        # Avoid collisions with names this conversion has already allocated
+        # *and* with files that already exist on disk from a previous run or
+        # another caller. ``used_names`` covers in-process allocations (which
+        # also live on disk after we write them); ``os.path.exists`` covers
+        # files we did not put there ourselves so we never silently overwrite
+        # them.
+        while candidate in used_names or os.path.exists(
+            os.path.join(extract_dir, candidate)
+        ):
             candidate = f"{base_name}_{suffix}.{ext}"
             suffix += 1
-        used_names.add(candidate)
-        if sha1:
-            hash_to_name[sha1] = candidate
 
         target_path = os.path.join(extract_dir, candidate)
         return target_path, candidate
+
+    @staticmethod
+    def _build_markdown_link(extract_dir_for_link: Optional[str], filename: str) -> str:
+        """Compose the markdown image reference.
+
+        Joins the user-supplied ``extract_images_to`` value (``imgs/`` or
+        ``/abs/path``) with ``filename`` using forward slashes so the
+        resulting markdown is portable and never contains backslashes on
+        Windows. Falls back to the bare filename when no directory is
+        configured (this branch is mainly defensive — callers only invoke
+        this when extraction is enabled).
+        """
+        if not extract_dir_for_link:
+            return filename
+        # Normalise any backslashes the caller may have used (Windows-style
+        # input) and strip trailing separators before joining.
+        prefix = extract_dir_for_link.replace("\\", "/").rstrip("/")
+        if not prefix:
+            return filename
+        return posixpath.join(prefix, filename)
 
     def _convert_table_to_markdown(self, table, **kwargs):
         # Write the table as HTML, then convert it to Markdown

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -1,11 +1,13 @@
 import sys
 import base64
+import mimetypes
 import os
 import io
 import re
 import html
+import warnings
 
-from typing import BinaryIO, Any
+from typing import BinaryIO, Any, Dict, Optional, Set, Tuple
 from operator import attrgetter
 
 from ._html_converter import HtmlConverter
@@ -78,6 +80,34 @@ class PptxConverter(DocumentConverter):
                 _dependency_exc_info[2]
             )
 
+        # Resolve the optional image extraction directory.
+        # When ``extract_images_to`` is provided (and ``keep_data_uris`` is not
+        # set), embedded images are written to this directory and referenced
+        # by relative filename in the markdown output. When neither option is
+        # set the legacy placeholder behaviour is preserved for backwards
+        # compatibility.
+        extract_images_to: Optional[str] = kwargs.get("extract_images_to")
+        keep_data_uris: bool = bool(kwargs.get("keep_data_uris", False))
+
+        extract_dir: Optional[str] = None
+        if extract_images_to and not keep_data_uris:
+            extract_dir = os.path.abspath(extract_images_to)
+            try:
+                os.makedirs(extract_dir, exist_ok=True)
+            except OSError as exc:
+                warnings.warn(
+                    f"Could not create image extraction directory "
+                    f"{extract_dir!r}: {exc}; falling back to placeholder "
+                    f"filenames.",
+                    stacklevel=2,
+                )
+                extract_dir = None
+
+        # Track filename uniqueness across the deck and reuse identical images
+        # by content hash so duplicate blobs are written to disk only once.
+        used_names: Set[str] = set()
+        hash_to_name: Dict[str, str] = {}
+
         # Perform the conversion
         presentation = pptx.Presentation(file_stream)
         md_content = ""
@@ -89,8 +119,15 @@ class PptxConverter(DocumentConverter):
 
             title = slide.shapes.title
 
+            # Per-slide counter incremented for every visited shape (including
+            # nested group children) so each image gets a stable, monotonic
+            # index for filename construction.
+            shape_counter = [0]
+
             def get_shape_content(shape, **kwargs):
                 nonlocal md_content
+                shape_counter[0] += 1
+                current_shape_idx = shape_counter[0]
                 # Pictures
                 if self._is_picture(shape):
                     # https://github.com/scanny/python-pptx/pull/512#issuecomment-1713100069
@@ -140,14 +177,40 @@ class PptxConverter(DocumentConverter):
                     alt_text = re.sub(r"[\r\n\[\]]", " ", alt_text)
                     alt_text = re.sub(r"\s+", " ", alt_text).strip()
 
-                    # If keep_data_uris is True, use base64 encoding for images
-                    if kwargs.get("keep_data_uris", False):
+                    # If keep_data_uris is True, use base64 encoding for images.
+                    # keep_data_uris takes precedence over extract_images_to.
+                    if keep_data_uris:
                         blob = shape.image.blob
                         content_type = shape.image.content_type or "image/png"
                         b64_string = base64.b64encode(blob).decode("utf-8")
                         md_content += f"\n![{alt_text}](data:{content_type};base64,{b64_string})\n"
+                    elif extract_dir is not None:
+                        # Try to write the image to disk; fall back to the
+                        # legacy placeholder if anything goes wrong.
+                        try:
+                            target_path, ref_name = self._resolve_image_target(
+                                extract_dir,
+                                slide_num,
+                                current_shape_idx,
+                                shape,
+                                used_names,
+                                hash_to_name,
+                            )
+                            if target_path is not None:
+                                with open(target_path, "wb") as fh:
+                                    fh.write(shape.image.blob)
+                            md_content += f"\n![{alt_text}]({ref_name})\n"
+                        except Exception as exc:
+                            warnings.warn(
+                                f"Failed to extract embedded PPTX image "
+                                f"(slide {slide_num}, shape {shape.name!r}): "
+                                f"{exc}; falling back to placeholder filename.",
+                                stacklevel=2,
+                            )
+                            filename = re.sub(r"\W", "", shape.name) + ".jpg"
+                            md_content += "\n![" + alt_text + "](" + filename + ")\n"
                     else:
-                        # A placeholder name
+                        # A placeholder name (legacy behaviour).
                         filename = re.sub(r"\W", "", shape.name) + ".jpg"
                         md_content += "\n![" + alt_text + "](" + filename + ")\n"
 
@@ -211,6 +274,78 @@ class PptxConverter(DocumentConverter):
         if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.TABLE:
             return True
         return False
+
+    def _sanitize_image_basename(self, name: str, fallback: str) -> str:
+        """Return a filesystem-safe basename for an embedded image.
+
+        Keeps Unicode word characters (including CJK) and ``-``; replaces any
+        other character with ``_``. Path separators and ``..`` are scrubbed
+        defensively. When the resulting string is empty, ``fallback`` is used.
+        """
+        cleaned = (name or "").strip()
+        # Defensively strip path separators / parent-directory traversals
+        # before regex sanitisation.
+        cleaned = cleaned.replace("/", "_").replace("\\", "_").replace("..", "_")
+        cleaned = re.sub(r"[^\w\-]", "_", cleaned, flags=re.UNICODE)
+        cleaned = cleaned.strip("._")
+        if not cleaned:
+            cleaned = fallback
+        return cleaned
+
+    def _resolve_image_target(
+        self,
+        extract_dir: str,
+        slide_num: int,
+        shape_idx: int,
+        shape: Any,
+        used_names: Set[str],
+        hash_to_name: Dict[str, str],
+    ) -> Tuple[Optional[str], str]:
+        """Return ``(absolute_path_to_write_or_None, markdown_reference)``.
+
+        If the image's content hash has been seen before, returns
+        ``(None, existing_reference)`` so the caller skips writing and reuses
+        the previous filename. Otherwise allocates a unique filename in
+        ``extract_dir`` and returns the absolute path to write to plus the
+        relative filename to embed in the markdown.
+        """
+        image = shape.image
+
+        # Deduplicate by content hash when available.
+        sha1 = getattr(image, "sha1", None)
+        if sha1 and sha1 in hash_to_name:
+            return None, hash_to_name[sha1]
+
+        # Pick an extension (python-pptx returns a lowercase, dot-less
+        # extension such as ``"png"`` or ``"jpeg"``). Fall back to
+        # ``mimetypes.guess_extension`` based on the content type, then to
+        # ``"bin"`` if nothing else works.
+        ext = (getattr(image, "ext", None) or "").lstrip(".").lower()
+        if not ext:
+            content_type = getattr(image, "content_type", None) or ""
+            guessed = mimetypes.guess_extension(content_type) if content_type else None
+            if guessed:
+                ext = guessed.lstrip(".").lower()
+        if not ext:
+            ext = "bin"
+
+        sanitized = self._sanitize_image_basename(
+            getattr(shape, "name", "") or "",
+            fallback=f"image{shape_idx}",
+        )
+
+        base_name = f"slide{slide_num:02d}_{shape_idx}_{sanitized}"
+        candidate = f"{base_name}.{ext}"
+        suffix = 2
+        while candidate in used_names:
+            candidate = f"{base_name}_{suffix}.{ext}"
+            suffix += 1
+        used_names.add(candidate)
+        if sha1:
+            hash_to_name[sha1] = candidate
+
+        target_path = os.path.join(extract_dir, candidate)
+        return target_path, candidate
 
     def _convert_table_to_markdown(self, table, **kwargs):
         # Write the table as HTML, then convert it to Markdown

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3 -m pytest
+import os
 import subprocess
 from markitdown import __version__
 
 # This file contains CLI tests that are not directly tested by the FileTestVectors.
 # This includes things like help messages, version numbers, and invalid flags.
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
 
 def test_version() -> None:
@@ -25,6 +28,35 @@ def test_invalid_flag() -> None:
         "unrecognized arguments" in result.stderr
     ), "Expected 'unrecognized arguments' to appear in STDERR"
     assert "SYNTAX" in result.stderr, "Expected 'SYNTAX' to appear in STDERR"
+
+
+def test_extract_images_to(tmp_path) -> None:
+    """End-to-end CLI: --extract-images-to should write images to disk and
+    reference them in the markdown printed on stdout."""
+    out_dir = tmp_path / "imgs"
+    pptx_path = os.path.join(TEST_FILES_DIR, "test.pptx")
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "markitdown",
+            "--extract-images-to",
+            str(out_dir),
+            pptx_path,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert result.returncode == 0, f"CLI exited with error: {result.stderr}"
+    assert out_dir.is_dir(), "extraction directory should be created"
+    written = [p for p in out_dir.iterdir() if p.is_file()]
+    assert written, "at least one image should have been extracted"
+    for path in written:
+        assert path.stat().st_size > 0, f"{path} is empty"
+        # The stdout markdown should reference the written filename.
+        assert f"]({path.name})" in result.stdout
 
 
 if __name__ == "__main__":

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -53,10 +53,12 @@ def test_extract_images_to(tmp_path) -> None:
     assert out_dir.is_dir(), "extraction directory should be created"
     written = [p for p in out_dir.iterdir() if p.is_file()]
     assert written, "at least one image should have been extracted"
+    # Markdown links use the user-supplied path joined with the filename
+    # (forward-slash form), matching whatever was passed on the CLI.
+    expected_prefix = str(out_dir).replace("\\", "/")
     for path in written:
         assert path.stat().st_size > 0, f"{path} is empty"
-        # The stdout markdown should reference the written filename.
-        assert f"]({path.name})" in result.stdout
+        assert f"]({expected_prefix}/{path.name})" in result.stdout
 
 
 if __name__ == "__main__":

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -549,44 +549,158 @@ def test_pptx_extract_images_to_dir(tmp_path) -> None:
     for path in written:
         assert path.stat().st_size > 0, f"{path} is empty"
 
-    # The markdown should reference the actual file names that were written,
-    # not the legacy "Picture4.jpg" placeholder.
+    # The markdown should reference the actual file names that were written
+    # joined with the user-supplied extract_images_to path (forward-slash
+    # form), not the legacy "Picture4.jpg" placeholder.
     written_names = {p.name for p in written}
+    expected_prefix = str(out_dir).replace("\\", "/")
     for name in written_names:
+        expected_link = f"{expected_prefix}/{name}"
         assert (
-            f"]({name})" in result.markdown
-        ), f"markdown should reference written file {name}"
+            f"]({expected_link})" in result.markdown
+        ), f"markdown should reference {expected_link}"
     assert "](Picture4.jpg)" not in result.markdown
 
 
-def test_pptx_extract_images_dedup(tmp_path) -> None:
-    """Identical embedded images should be written to disk only once even
-    when referenced multiple times by the markdown."""
-    import hashlib
+def test_pptx_extract_images_to_relative_dir(tmp_path, monkeypatch) -> None:
+    """A relative ``extract_images_to`` should appear verbatim in the
+    markdown output (so consumers can resolve images relative to the
+    rendered markdown), while the files themselves still land in the
+    expected directory on disk."""
+    monkeypatch.chdir(tmp_path)
 
-    out_dir = tmp_path / "imgs"
     markitdown = MarkItDown()
     result = markitdown.convert(
+        os.path.join(TEST_FILES_DIR, "test.pptx"),
+        extract_images_to="imgs",
+    )
+
+    out_dir = tmp_path / "imgs"
+    assert out_dir.is_dir(), "extract directory should be created"
+    written_names = {p.name for p in out_dir.iterdir() if p.is_file()}
+    assert written_names, "at least one image should have been written"
+
+    for name in written_names:
+        assert (
+            f"](imgs/{name})" in result.markdown
+        ), f"markdown should reference imgs/{name} verbatim"
+    # The absolute, resolved path must NOT leak into the markdown.
+    assert str(out_dir) not in result.markdown
+
+
+def test_pptx_extract_images_does_not_overwrite_existing(tmp_path) -> None:
+    """If a file with the would-be target name already exists on disk and
+    was not produced by this conversion, the converter must allocate a
+    new (suffixed) name instead of silently overwriting it."""
+    out_dir = tmp_path / "imgs"
+    out_dir.mkdir()
+
+    # Pre-seed the directory with a sentinel that uses the slide01 prefix
+    # we expect the converter to allocate. The exact filename does not
+    # matter — we just need to guarantee at least one collision.
+    sentinel_payload = b"PRE_EXISTING_DO_NOT_OVERWRITE"
+    pre_existing: list[tuple] = []
+    for entry in out_dir.iterdir():
+        pre_existing.append((entry.name, entry.read_bytes()))
+
+    markitdown = MarkItDown()
+    # Run once to discover what filenames the converter wants to use,
+    # capture them, then re-run with those names pre-populated.
+    first = markitdown.convert(
+        os.path.join(TEST_FILES_DIR, "test.pptx"),
+        extract_images_to=str(out_dir),
+    )
+    discovered = sorted(p.name for p in out_dir.iterdir() if p.is_file())
+    assert discovered, "expected at least one extracted image"
+
+    # Wipe and reseed: pre-create the would-be targets with sentinel bytes.
+    for entry in out_dir.iterdir():
+        entry.unlink()
+    for name in discovered:
+        (out_dir / name).write_bytes(sentinel_payload)
+
+    second = markitdown.convert(
         os.path.join(TEST_FILES_DIR, "test.pptx"),
         extract_images_to=str(out_dir),
     )
 
-    # Build a map of {sha1: [files...]} for everything that landed on disk.
-    digests: dict[str, list[str]] = {}
-    for path in out_dir.iterdir():
-        if not path.is_file():
-            continue
-        sha1 = hashlib.sha1(path.read_bytes()).hexdigest()
-        digests.setdefault(sha1, []).append(path.name)
+    # The sentinel files must still contain the sentinel payload (i.e. were
+    # not overwritten). The new files must have been written under
+    # suffixed names.
+    for name in discovered:
+        assert (
+            out_dir / name
+        ).read_bytes() == sentinel_payload, f"sentinel file {name} was overwritten"
 
-    # No two written files should share the same content.
-    duplicates = {h: names for h, names in digests.items() if len(names) > 1}
-    assert not duplicates, f"duplicate image content written to disk: {duplicates}"
+    # Verify at least one suffixed (_2) variant exists alongside the
+    # originals.
+    final_names = {p.name for p in out_dir.iterdir() if p.is_file()}
+    assert any(
+        "_2." in n for n in final_names
+    ), f"expected suffixed filenames among {final_names}"
 
-    # Sanity-check that the markdown actually reuses each written name at
-    # least once. (A duplicate reference would point to the same file.)
-    for name in digests.values():
-        assert f"]({name[0]})" in result.markdown
+    # Markdown should reference the suffixed paths.
+    expected_prefix = str(out_dir).replace("\\", "/")
+    suffixed = [n for n in final_names if "_2." in n]
+    assert any(
+        f"]({expected_prefix}/{n})" in second.markdown for n in suffixed
+    ), "markdown should reference at least one suffixed filename"
+
+
+def test_pptx_extract_images_dedup(tmp_path) -> None:
+    """Identical embedded images should be written to disk only once even
+    when referenced multiple times by the markdown.
+
+    We programmatically build a deck that embeds the same image on three
+    different slides — the existing ``test.pptx`` fixture happens not to
+    contain duplicate blobs, so without this synthetic fixture the
+    deduplication path would not actually exercise.
+    """
+    import hashlib
+
+    pytest.importorskip("pptx")
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    # Use a real image from the test corpus so python-pptx accepts it.
+    src_image = os.path.join(TEST_FILES_DIR, "test.jpg")
+    assert os.path.exists(src_image), "expected test.jpg fixture"
+    image_bytes = open(src_image, "rb").read()
+    expected_sha1 = hashlib.sha1(image_bytes).hexdigest()
+
+    prs = Presentation()
+    blank_layout = prs.slide_layouts[6]  # blank layout
+    for _ in range(3):
+        slide = prs.slides.add_slide(blank_layout)
+        slide.shapes.add_picture(src_image, Inches(1), Inches(1))
+
+    deck_path = tmp_path / "dedup.pptx"
+    prs.save(str(deck_path))
+
+    out_dir = tmp_path / "imgs"
+    markitdown = MarkItDown()
+    result = markitdown.convert(
+        str(deck_path),
+        extract_images_to=str(out_dir),
+    )
+
+    written = [p for p in out_dir.iterdir() if p.is_file()]
+    assert (
+        len(written) == 1
+    ), f"expected dedup to leave exactly one file on disk, got {written}"
+    only_file = written[0]
+    assert (
+        hashlib.sha1(only_file.read_bytes()).hexdigest() == expected_sha1
+    ), "written blob should match the source image"
+
+    # The markdown should reference the same filename multiple times (one
+    # per slide) rather than emitting a fresh name for every duplicate.
+    expected_prefix = str(out_dir).replace("\\", "/")
+    expected_link = f"]({expected_prefix}/{only_file.name})"
+    assert result.markdown.count(expected_link) >= 2, (
+        f"expected the deduplicated link {expected_link!r} to appear at "
+        f"least twice in the markdown output:\n{result.markdown}"
+    )
 
 
 def test_pptx_extract_images_keep_data_uris_takes_precedence(tmp_path) -> None:

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -532,6 +532,85 @@ def test_markitdown_llm() -> None:
     validate_strings(result, PPTX_TEST_STRINGS)
 
 
+def test_pptx_extract_images_to_dir(tmp_path) -> None:
+    """When extract_images_to is provided, embedded PPTX images should be
+    written to the target directory and referenced from the markdown."""
+    out_dir = tmp_path / "imgs"
+    markitdown = MarkItDown()
+    result = markitdown.convert(
+        os.path.join(TEST_FILES_DIR, "test.pptx"),
+        extract_images_to=str(out_dir),
+    )
+
+    assert out_dir.is_dir(), "extract directory should be created"
+    written = sorted(p for p in out_dir.iterdir() if p.is_file())
+    assert written, "at least one image should have been written to disk"
+    # Every written file must be non-empty.
+    for path in written:
+        assert path.stat().st_size > 0, f"{path} is empty"
+
+    # The markdown should reference the actual file names that were written,
+    # not the legacy "Picture4.jpg" placeholder.
+    written_names = {p.name for p in written}
+    for name in written_names:
+        assert (
+            f"]({name})" in result.markdown
+        ), f"markdown should reference written file {name}"
+    assert "](Picture4.jpg)" not in result.markdown
+
+
+def test_pptx_extract_images_dedup(tmp_path) -> None:
+    """Identical embedded images should be written to disk only once even
+    when referenced multiple times by the markdown."""
+    import hashlib
+
+    out_dir = tmp_path / "imgs"
+    markitdown = MarkItDown()
+    result = markitdown.convert(
+        os.path.join(TEST_FILES_DIR, "test.pptx"),
+        extract_images_to=str(out_dir),
+    )
+
+    # Build a map of {sha1: [files...]} for everything that landed on disk.
+    digests: dict[str, list[str]] = {}
+    for path in out_dir.iterdir():
+        if not path.is_file():
+            continue
+        sha1 = hashlib.sha1(path.read_bytes()).hexdigest()
+        digests.setdefault(sha1, []).append(path.name)
+
+    # No two written files should share the same content.
+    duplicates = {h: names for h, names in digests.items() if len(names) > 1}
+    assert not duplicates, f"duplicate image content written to disk: {duplicates}"
+
+    # Sanity-check that the markdown actually reuses each written name at
+    # least once. (A duplicate reference would point to the same file.)
+    for name in digests.values():
+        assert f"]({name[0]})" in result.markdown
+
+
+def test_pptx_extract_images_keep_data_uris_takes_precedence(tmp_path) -> None:
+    """When both keep_data_uris and extract_images_to are passed, the
+    base64 inline behaviour wins and no files are written to the target
+    directory."""
+    out_dir = tmp_path / "imgs"
+    markitdown = MarkItDown()
+    result = markitdown.convert(
+        os.path.join(TEST_FILES_DIR, "test.pptx"),
+        extract_images_to=str(out_dir),
+        keep_data_uris=True,
+    )
+
+    # base64 payloads are present in the markdown
+    assert "data:image/jpeg;base64," in result.markdown
+
+    # The extraction directory either was never created, or contains no files.
+    if out_dir.exists():
+        assert not any(
+            p.is_file() for p in out_dir.iterdir()
+        ), "no files should be written when keep_data_uris is set"
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     for test in [


### PR DESCRIPTION
## What

Adds an `extract_images_to` option (Python API) and a corresponding `--extract-images-to` CLI flag to the PPTX converter. When set, embedded PPTX images are written to the supplied directory (deduplicated by content SHA1) and the markdown output references them via `<extract_images_to>/<filename>`, instead of emitting placeholder filenames that point at non-existent files.

Closes #56

## Why

Today the PPTX converter emits markdown like

    ![alt](Picture4.jpg)

but `Picture4.jpg` is never written to disk, so the link is dead. Issue #56 asked for the images to be exported so that markdown preview tools can actually render them. This change makes that opt-in via `extract_images_to`, while keeping the default behaviour completely unchanged for backward compatibility.

## How

- New `extract_images_to: Optional[str]` kwarg on the PPTX converter; when set, images are written to that directory.
- New `--extract-images-to DIR` CLI flag in the same style as the existing `--keep-data-uris`.
- Filenames follow `slide{NN}_{shape_idx}_{sanitized_name}.{ext}` with Unicode-safe sanitisation so non-ASCII shape names don't collapse to a single character.
- Identical images (matched by `image.sha1`) are written once and referenced by all slides that embed them.
- Disk-side filename collisions (e.g. when reusing the same output directory across runs) get a `_2`, `_3` suffix; existing files on disk are never silently overwritten.
- Markdown links use `posixpath.join(extract_images_to, filename)` with forward slashes, so the output is safe on Windows too.
- Extension detection is layered: `image.ext` -> `image.content_type` -> `mimetypes.guess_extension` -> `image.filename` -> `bin`, each step wrapped in `try/except` because `python-pptx` raises `ValueError` on SVG/EMF/ICO when resolving `ext`.
- If a write fails for any reason we fall back to the legacy placeholder behaviour and emit a one-time `warnings.warn` rather than crashing the whole conversion.
- When both `keep_data_uris=True` and `extract_images_to` are passed, `keep_data_uris` wins (base64 inline) and no files are written.

## Backward compatibility

The default code path is untouched: if neither flag is set, the converter still emits the same `Picture4.jpg`-style placeholder that the existing `_test_vectors.py` regression tests assert on. All seven existing PPTX vector tests continue to pass.

## Tests

Added in `packages/markitdown/tests/test_module_misc.py`:

- `test_pptx_extract_images_to_dir` - basic write-and-reference.
- `test_pptx_extract_images_to_relative_dir` - verifies relative paths in the markdown link, no absolute-path leak.
- `test_pptx_extract_images_does_not_overwrite_existing` - asserts pre-existing files in the target directory get the `_2` suffix instead of being clobbered.
- `test_pptx_extract_images_dedup` - programmatically generates a PPTX with the same image embedded three times and asserts exactly one file is written and the markdown references it multiple times.
- `test_pptx_extract_images_keep_data_uris_takes_precedence` - verifies the precedence rule.

Added in `packages/markitdown/tests/test_cli_misc.py`:

- `test_extract_images_to` - CLI smoke test via subprocess.

Local results: all 6 new tests pass and the 11 existing PPTX vector tests (`test_*[test_vector3]`) still pass, confirming no regression in the default placeholder behaviour. `black` passes on the touched files.

## Notes

- README is untouched in this PR. Happy to send a follow-up doc PR once the API shape is approved here, since the wording depends on whether you'd like the markdown link to be the user-supplied path verbatim (current behaviour) or something more clever (e.g. relative to the markdown output file). I went with the simplest option that matches issue #56's framing.
- Unsupported image types (SVG/EMF/WMF) are still written to disk with their real extension, but downstream markdown renderers may not display them. That seems strictly better than the status quo of writing nothing at all; happy to add a doc note if you'd like.