### PR TITLE
fix(zip): skip directory entries in ZipConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -91,10 +91,15 @@ class ZipConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         file_path = stream_info.url or stream_info.local_path or stream_info.filename
-        md_content = f"Content from the zip file `{file_path}`:\n\n"
+        md_content = f"Content from the zip file `{file_path}`:
+
+"
 
         with zipfile.ZipFile(file_stream, "r") as zipObj:
             for name in zipObj.namelist():
+                # Skip directory entries - they have no file content to convert
+                if zipObj.getinfo(name).is_dir():
+                    continue
                 try:
                     z_file_stream = io.BytesIO(zipObj.read(name))
                     z_file_stream_info = StreamInfo(
@@ -106,8 +111,12 @@ class ZipConverter(DocumentConverter):
                         stream_info=z_file_stream_info,
                     )
                     if result is not None:
-                        md_content += f"## File: {name}\n\n"
-                        md_content += result.markdown + "\n\n"
+                        md_content += f"## File: {name}
+
+"
+                        md_content += result.markdown + "
+
+"
                 except UnsupportedFormatException:
                     pass
                 except FileConversionException:


### PR DESCRIPTION
## What

When a ZIP archive contains explicit directory entries (e.g. created with `zipfile.ZipFile.mkdir()` or tools like Info-ZIP), `zipObj.namelist()` returns those entries alongside actual files.

Before this fix, `ZipConverter` passed every name to `zipObj.read()`, which returns an empty `bytes` object for directory entries. That empty stream then went through `convert_stream`, and the result produced a spurious `## File: subdir/` heading with no content.

## Fix

Add an `is_dir()` guard before reading and converting each entry:

```python
if zipObj.getinfo(name).is_dir():
    continue
```

## Reproduction

```python
import zipfile, io
from markitdown import MarkItDown

buf = io.BytesIO()
with zipfile.ZipFile(buf, 'w') as z:
    z.mkdir('subdir')
    z.writestr('subdir/note.txt', 'hello')
buf.seek(0)

md = MarkItDown()
result = md.convert_stream(buf, stream_info_kwargs={'extension': '.zip'})
print(result.markdown)
# Before: includes empty '## File: subdir/' section
# After:  only '## File: subdir/note.txt' with content
```