### PR TITLE
Use frozenset for OMML direct tag lookup

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -174,7 +174,9 @@ class oMath2Latex(Tag2Method):
 
     _t_dict = T
 
-    __direct_tags = ("box", "sSub", "sSup", "sSubSup", "num", "den", "deg", "e")
+    __direct_tags = frozenset(
+        ("box", "sSub", "sSup", "sSubSup", "num", "den", "deg", "e")
+    )
 
     def __init__(self, element):
         self._latex = self.process_children(element)


### PR DESCRIPTION
## Summary

Replaces `__direct_tags` from `tuple` to `frozenset` in the DOCX OMML math converter (`oMath2Latex`) to improve membership lookup efficiency in a hot code path.

## Motivation

`process_unknow()` checks `if stag in self.__direct_tags` while recursively traversing OMML nodes.  
For math-heavy documents, this check executes frequently.

- `tuple` membership is linear scan: O(n)
- `frozenset` membership is hash-based on average: O(1)

`frozenset` is immutable like `tuple`, and better represents an unordered constant set used only for membership checks.

## Change

- `packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py`
  - `__direct_tags` changed from `tuple` to `frozenset`
- No API or behavior change

## Validation

- `pre-commit run --all-files`: passed (`black`)
- `hatch test`: 331 passed, 4 skipped, 1 pre-existing unrelated failure (`test_speech_transcription`)

## Risk

- Single-file, single-concept change
- No change to converter output semantics