### PR TITLE
fix: preserve underscores in LaTeX math blocks during DOCX conversion

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -5,6 +5,36 @@ from typing import Any, Optional
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
 
+def _fix_math_escaping(text: str) -> str:
+    """Fix markdownify's incorrect escaping inside $...$ math blocks.
+
+    markdownify treats underscores and asterisks as emphasis markers and
+    escapes them inside math delimiters, producing $v\\_{c}$ instead of
+    $v_{c}$.  This post-processor restores the correct LaTeX inside both
+    inline ($...$) and display ($$...$$) math regions.
+    """
+
+    def _fix_delimiters(text: str) -> str:
+        return text.replace(r"\_", "_").replace(r"\*", "*")
+
+    # Fix display math $$...$$ first (may be multiline)
+    text = re.sub(
+        r"\$\$(.*?)\$\$",
+        lambda m: "$$" + _fix_delimiters(m.group(1)) + "$$",
+        text,
+        flags=re.DOTALL,
+    )
+
+    # Fix inline math $...$
+    text = re.sub(
+        r"\$([^$\n]+?)\$",
+        lambda m: "$" + _fix_delimiters(m.group(1)) + "$",
+        text,
+    )
+
+    return text
+
+
 class _CustomMarkdownify(markdownify.MarkdownConverter):
     """
     A custom version of markdownify's MarkdownConverter. Changes include:
@@ -13,6 +43,7 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
     - Removing javascript hyperlinks.
     - Truncating images with large data:uri sources.
     - Ensuring URIs are properly escaped, and do not conflict with Markdown syntax
+    - Fixing escaped underscores/asterisks inside math delimiters ($...$, $$...$$)
     """
 
     def __init__(self, **options: Any):
@@ -123,4 +154,5 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         return ""
 
     def convert_soup(self, soup: Any) -> str:
-        return super().convert_soup(soup)  # type: ignore
+        result = super().convert_soup(soup)  # type: ignore
+        return _fix_math_escaping(result)

--- a/packages/markitdown/tests/test_math_escaping.py
+++ b/packages/markitdown/tests/test_math_escaping.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for math escaping fix in _markdownify.py.
+
+Regression tests for the bug where markdownify escapes underscores and
+asterisks inside $...$ and $$...$$ math delimiters, producing broken
+LaTeX like $v\\_{c}$ instead of $v_{c}$.
+"""
+
+import pytest
+
+from markitdown.converters._markdownify import _fix_math_escaping
+
+
+# ─── Unit tests for _fix_math_escaping ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "input_text,expected",
+    [
+        # Inline math with subscript
+        ("$v_{c}$", "$v_{c}$"),
+        ("$a_{ij}$", "$a_{ij}$"),
+        ("$x_{i}$", "$x_{i}$"),
+        # Display math with subscript
+        ("$$v_{c} = x^{2}$$", "$$v_{c} = x^{2}$$"),
+        # Multiple inline math blocks
+        ("For $v_{c}$ and $x_{i}$", "For $v_{c}$ and $x_{i}$"),
+        # Inline math with surrounding text
+        ("text $v_{c}$ more text", "text $v_{c}$ more text"),
+        # Display math (multiline)
+        ("$$\nv_{c}\n$$", "$$\nv_{c}\n$$"),
+        # Asterisk escaping inside math
+        ("$a\\*b\\*c$", "$a*b*c$"),
+        # Mixed underscore and asterisk
+        ("$v_{c} * a_{ij}$", "$v_{c} * a_{ij}$"),
+        # No escaping needed (no math delimiters)
+        ("hello world", "hello world"),
+        # Escaped underscores OUTSIDE math should NOT be touched
+        ("hello\\_world", "hello\\_world"),
+        # Superscript (no underscore to fix)
+        ("$x^{2}$", "$x^{2}$"),
+        # Fraction (no underscore to fix)
+        ("$\\frac{a}{b}$", "$\\frac{a}{b}$"),
+        # Mixed: escaped inside math, preserved outside
+        (
+            "hello\\_world $v_{c}$ end",
+            "hello\\_world $v_{c}$ end",
+        ),
+    ],
+)
+def test_fix_math_escaping(input_text, expected):
+    """Test that _fix_math_escaping correctly handles various patterns."""
+    assert _fix_math_escaping(input_text) == expected
+
+
+# ─── Escaped-input tests (simulates markdownify's output) ───────────
+
+
+@pytest.mark.parametrize(
+    "input_text,expected",
+    [
+        # Simulated markdownify output: escaped underscore inside inline math
+        ("$v\\_{c}$", "$v_{c}$"),
+        ("$a\\_{ij}$", "$a_{ij}$"),
+        # Simulated markdownify output: escaped underscore inside display math
+        ("$$v\\_{c} = x^{2}$$", "$$v_{c} = x^{2}$$"),
+        # Simulated markdownify output: multiple inline math blocks
+        (
+            "For $v\\_{c}$ and $x\\_{i}$",
+            "For $v_{c}$ and $x_{i}$",
+        ),
+        # Simulated markdownify output: escaped asterisk inside math
+        ("$a\\*b\\*c$", "$a*b*c$"),
+        # Mixed: markdownify-escaped math + plain text escaped underscore
+        (
+            "hello\\_world $v\\_{c}$ end",
+            "hello\\_world $v_{c}$ end",
+        ),
+        # Real-world example from equations.docx (should be unchanged)
+        (
+            "$$\\frac{m\\lambda}{a}$$",
+            "$$\\frac{m\\lambda}{a}$$",
+        ),
+    ],
+)
+def test_fix_math_escaping_from_markdownify(input_text, expected):
+    """Test _fix_math_escaping on markdownify's actual output patterns."""
+    assert _fix_math_escaping(input_text) == expected
+
+
+# ─── Integration test via _CustomMarkdownify ────────────────────────
+
+
+def test_convert_soup_preserves_math():
+    """Test the full convert_soup path with HTML containing math."""
+    from markitdown.converters._markdownify import _CustomMarkdownify
+    from bs4 import BeautifulSoup
+
+    md = _CustomMarkdownify()
+
+    # Simulate what DocxConverter produces after pre_process_docx + mammoth
+    html = "<p>The velocity $v_{c}$ equals $a_{ij} \\cdot x_{i}$.</p>"
+    soup = BeautifulSoup(html, "html.parser")
+    result = md.convert_soup(soup)
+
+    # Math should be preserved without escaping
+    assert "$v_{c}$" in result
+    assert "$a_{ij} \\cdot x_{i}$" in result
+    assert r"\_" not in result
+
+
+def test_convert_soup_display_math():
+    """Test convert_soup with display math."""
+    from markitdown.converters._markdownify import _CustomMarkdownify
+    from bs4 import BeautifulSoup
+
+    md = _CustomMarkdownify()
+
+    html = "<p>$$v_{c} = x^{2}$$</p>"
+    soup = BeautifulSoup(html, "html.parser")
+    result = md.convert_soup(soup)
+
+    assert "$$v_{c} = x^{2}$$" in result
+    assert r"\_" not in result
+
+
+def test_convert_soup_plain_text_underscore_preserved():
+    """Test that plain-text underscores remain escaped (correct behavior)."""
+    from markitdown.converters._markdownify import _CustomMarkdownify
+    from bs4 import BeautifulSoup
+
+    md = _CustomMarkdownify()
+
+    html = "<p>hello_world</p>"
+    soup = BeautifulSoup(html, "html.parser")
+    result = md.convert_soup(soup)
+
+    # Plain-text underscore should still be escaped
+    assert r"\_" in result
+    assert "hello\\_world" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

When converting DOCX files containing OMML math formulas, the conversion pipeline produces incorrect Markdown output because `markdownify` escapes underscores and asterisks inside LaTeX math delimiters.

**Bug**: `$v_{c}$` → `$v\_{c}$` (broken LaTeX)
**Fix**: Post-process markdownify output to restore correct LaTeX inside `$...$` and `$$...$$` math regions.

## Root Cause

The DOCX conversion pipeline is:
1. `pre_process.py` converts OMML → LaTeX string wrapped in `$...$`
2. `mammoth` converts the modified DOCX → HTML
3. `markdownify` converts HTML → Markdown

At step 3, markdownify treats `_` and `*` as emphasis markers and escapes them, even inside math delimiters. This is documented in `_markdownify.py` line 67: `#29: text nodes underscores are escaped`.

## Changes

- **`_markdownify.py`**: Added `_fix_math_escaping()` post-processor in `convert_soup()` that unescapes `\_` → `_` and `\*` → `*` inside `$...$` and `$$...$$` math blocks only. Plain-text underscores outside math remain escaped (correct Markdown behavior).
- **`test_math_escaping.py`**: 24 test cases covering:
  - Unit tests for `_fix_math_escaping()` with various LaTeX patterns
  - Integration tests through `_CustomMarkdownify.convert_soup()`
  - Regression test ensuring plain-text underscores remain escaped

## Test Plan

- [x] All 24 new tests pass (`pytest tests/test_math_escaping.py -v`)
- [x] No regressions in existing test vectors (DOCX, PPTX, PDF, HTML, EPUB, etc.)
- [x] Verified fix with real DOCX files containing math formulas

🤖 Generated with [Claude Code](https://claude.com/claude-code)