### PR TITLE
fix: repair docx local header casing

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -1,5 +1,6 @@
 import zipfile
 from io import BytesIO
+from struct import unpack_from
 from typing import BinaryIO
 from xml.etree import ElementTree as ET
 
@@ -115,6 +116,42 @@ def _pre_process_math(content: bytes) -> bytes:
     return str(soup).encode()
 
 
+def _fix_zip_local_header_name_casing(input_docx: BinaryIO) -> BinaryIO:
+    input_docx.seek(0)
+    raw = bytearray(input_docx.read())
+    patched = False
+
+    with zipfile.ZipFile(BytesIO(raw), mode="r") as zip_input:
+        for info in zip_input.infolist():
+            offset = info.header_offset
+            if raw[offset : offset + 4] != b"PK\x03\x04":
+                continue
+
+            file_name_length = unpack_from("<H", raw, offset + 26)[0]
+            local_name_start = offset + 30
+            local_name_end = local_name_start + file_name_length
+            local_name = raw[local_name_start:local_name_end]
+
+            try:
+                central_name = info.filename.encode("ascii")
+            except UnicodeEncodeError:
+                continue
+
+            if (
+                local_name != central_name
+                and len(local_name) == len(central_name)
+                and local_name.lower() == central_name.lower()
+            ):
+                raw[local_name_start:local_name_end] = central_name
+                patched = True
+
+    if patched:
+        return BytesIO(bytes(raw))
+
+    input_docx.seek(0)
+    return input_docx
+
+
 def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
     """
     Pre-processes a DOCX file with provided steps.
@@ -129,6 +166,7 @@ def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
     Returns:
         BinaryIO: A binary output stream representing the processed DOCX file.
     """
+    input_docx = _fix_zip_local_header_name_casing(input_docx)
     output_docx = BytesIO()
     # The files that need to be pre-processed from .docx
     pre_process_enable_files = [

--- a/packages/markitdown/tests/test_docx_pre_process.py
+++ b/packages/markitdown/tests/test_docx_pre_process.py
@@ -1,0 +1,40 @@
+import zipfile
+from io import BytesIO
+from struct import unpack_from
+
+import pytest
+
+from markitdown.converter_utils.docx.pre_process import pre_process_docx
+
+
+def _docx_with_case_mismatched_local_header() -> BytesIO:
+    stream = BytesIO()
+    with zipfile.ZipFile(stream, mode="w") as zip_output:
+        zip_output.writestr("customXml/item2.xml", b"<item />")
+
+    raw = bytearray(stream.getvalue())
+    with zipfile.ZipFile(BytesIO(raw), mode="r") as zip_input:
+        info = zip_input.getinfo("customXml/item2.xml")
+
+    offset = info.header_offset
+    file_name_length = unpack_from("<H", raw, offset + 26)[0]
+    local_name_start = offset + 30
+    local_name_end = local_name_start + file_name_length
+    local_name = b"customXML/item2.xml"
+    assert len(local_name) == file_name_length
+
+    raw[local_name_start:local_name_end] = local_name
+    return BytesIO(bytes(raw))
+
+
+def test_pre_process_docx_repairs_case_mismatched_local_headers() -> None:
+    stream = _docx_with_case_mismatched_local_header()
+
+    with pytest.raises(zipfile.BadZipFile):
+        with zipfile.ZipFile(stream, mode="r") as zip_input:
+            zip_input.read("customXml/item2.xml")
+
+    output = pre_process_docx(stream)
+
+    with zipfile.ZipFile(output, mode="r") as zip_input:
+        assert zip_input.read("customXml/item2.xml") == b"<item />"


### PR DESCRIPTION
## Summary

Fixes #1812.

Some DOCX files have a zip central directory entry such as `customXml/item2.xml` while the corresponding local file header uses a different casing such as `customXML/item2.xml`. Python's `zipfile` accepts the central directory, but raises `BadZipFile` when the entry is read.

This patches only case-only ASCII local header mismatches before the DOCX preprocessing step reads the archive. The central directory name stays authoritative, and non-case-only mismatches are left untouched.

## Validation

```bash
$env:PYTHONPATH='C:\dev\GITHUB-clean\markitdown-1812\packages\markitdown\src'; C:\dev\GITHUB-clean\markitdown\.venv\Scripts\python.exe -m pytest packages\markitdown\tests\test_docx_pre_process.py -q
$env:PYTHONPATH='C:\dev\GITHUB-clean\markitdown-1812\packages\markitdown\src'; C:\dev\GITHUB-clean\markitdown\.venv\Scripts\python.exe -m pytest packages\markitdown\tests\test_module_misc.py::test_docx_equations packages\markitdown\tests\test_docx_pre_process.py -q
C:\dev\GITHUB-clean\markitdown\.venv\Scripts\python.exe -m black --check packages\markitdown\src\markitdown\converter_utils\docx\pre_process.py packages\markitdown\tests\test_docx_pre_process.py
$env:PYTHONPATH='C:\dev\GITHUB-clean\markitdown-1812\packages\markitdown\src'; C:\dev\GITHUB-clean\markitdown\.venv\Scripts\python.exe -m mypy --ignore-missing-imports packages\markitdown\src\markitdown\converter_utils\docx\pre_process.py packages\markitdown\tests\test_docx_pre_process.py
git diff --check
```
