### PR TITLE
fix(mcp): block file:// URIs by default to prevent local file read  (#1905)

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -10,7 +10,7 @@
 
 The `markitdown-mcp` package provides a lightweight STDIO, Streamable HTTP, and SSE MCP server for calling MarkItDown.
 
-It exposes one tool: `convert_to_markdown(uri)`, where uri can be any `http:`, `https:`, `file:`, or `data:` URI.
+It exposes one tool: `convert_to_markdown(uri)`, where uri can be any `http:`, `https:`, or `data:` URI. `file:` URIs are disabled by default and require the `--allow-local-files` flag to enable.
 
 ## Installation
 
@@ -131,7 +131,11 @@ Finally:
 
 ## Security Considerations
 
-The server does not support authentication, and runs with the privileges of the user running it. For this reason, when running in SSE or Streamable HTTP mode, the server binds by default to `localhost`. Even still, it is important to recognize that the server can be accessed by any process or users on the same local machine, and that the `convert_to_markdown` tool can be used to read any file that the server's user has access to, or any data from the network. If you require additional security, consider running the server in a sandboxed environment, such as a virtual machine or container, and ensure that the user permissions are properly configured to limit access to sensitive files and network segments. Above all, DO NOT bind the server to other interfaces (non-localhost) unless you understand the security implications of doing so.
+The server does not support authentication, and runs with the privileges of the user running it. For this reason, when running in SSE or Streamable HTTP mode, the server binds by default to `localhost`. Even still, it is important to recognize that the server can be accessed by any process or user on the same local machine.
+
+`file://` URI support is disabled by default to prevent unauthorized local file access. To enable it, start the server with the `--allow-local-files` flag. Only do this in trusted environments where you understand that any process on the machine could instruct the server to read local files on your behalf.
+
+If you require additional security, consider running the server in a sandboxed environment, such as a virtual machine or container, and ensure that the user permissions are properly configured to limit access to sensitive files and network segments. Above all, DO NOT bind the server to other interfaces (non-localhost) unless you understand the security implications of doing so.
 
 ## Trademarks
 

--- a/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
+++ b/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
@@ -2,6 +2,7 @@ import contextlib
 import sys
 import os
 from collections.abc import AsyncIterator
+from urllib.parse import urlparse
 from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
 from mcp.server.sse import SseServerTransport
@@ -19,12 +20,26 @@ mcp = FastMCP("markitdown")
 
 @mcp.tool()
 async def convert_to_markdown(uri: str) -> str:
-    """Convert a resource described by an http:, https:, file: or data: URI to markdown"""
+    """Convert a resource described by an http:, https:, or data: URI to markdown"""
+    if urlparse(uri).scheme == "file":
+        if not check_local_files_allowed():
+            raise ValueError(
+                "file:// URIs are disabled by default. "
+                "Start the server with --allow-local-files to enable local file access."
+            )
     return MarkItDown(enable_plugins=check_plugins_enabled()).convert_uri(uri).markdown
 
 
 def check_plugins_enabled() -> bool:
     return os.getenv("MARKITDOWN_ENABLE_PLUGINS", "false").strip().lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
+def check_local_files_allowed() -> bool:
+    return os.getenv("MARKITDOWN_ALLOW_LOCAL_FILES", "false").strip().lower() in (
         "true",
         "1",
         "yes",
@@ -102,6 +117,11 @@ def main():
     parser.add_argument(
         "--port", type=int, default=None, help="Port to listen on (default: 3001)"
     )
+    parser.add_argument(
+        "--allow-local-files",
+        action="store_true",
+        help="Allow file:// URIs to be converted. Only use this in trusted environments (default: False)",
+    )
     args = parser.parse_args()
 
     use_http = args.http or args.sse
@@ -111,6 +131,16 @@ def main():
             "Host and port arguments are only valid when using streamable HTTP or SSE transport (see: --http)."
         )
         sys.exit(1)
+
+    if args.allow_local_files:
+        os.environ["MARKITDOWN_ALLOW_LOCAL_FILES"] = "true"
+        print(
+            "\n"
+            "WARNING: Local file access is enabled (--allow-local-files).\n"
+            "Any process on this machine can request files accessible to this user via this server.\n"
+            "Only proceed if you understand the security implications.\n",
+            file=sys.stderr,
+        )
 
     if use_http:
         host = args.host if args.host else "127.0.0.1"

--- a/packages/markitdown-mcp/tests/test_security.py
+++ b/packages/markitdown-mcp/tests/test_security.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2024-present Adam Fourney <adamfo@microsoft.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for MCP server security controls.
+
+Covers issue #1905: Local file read via unsafe file:// URI resolution in
+convert_to_markdown. Verifies that file:// URIs are blocked by default and
+only permitted when MARKITDOWN_ALLOW_LOCAL_FILES is explicitly enabled.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import MagicMock, patch
+
+from markitdown_mcp.__main__ import convert_to_markdown
+
+
+def test_file_uri_blocked_by_default(monkeypatch) -> None:
+    """file:// URIs must raise ValueError when --allow-local-files is not set."""
+    monkeypatch.delenv("MARKITDOWN_ALLOW_LOCAL_FILES", raising=False)
+
+    with pytest.raises(ValueError, match="file:// URIs are disabled by default"):
+        asyncio.run(convert_to_markdown("file:///C:/Windows/System32/drivers/etc/hosts"))
+
+
+def test_file_uri_allowed_when_opted_in(monkeypatch) -> None:
+    """file:// URIs must be accepted when MARKITDOWN_ALLOW_LOCAL_FILES is enabled."""
+    monkeypatch.setenv("MARKITDOWN_ALLOW_LOCAL_FILES", "true")
+
+    with patch("markitdown_mcp.__main__.MarkItDown") as mock_markitdown:
+        mock_instance = MagicMock()
+        mock_instance.convert_uri.return_value.markdown = "# Test"
+        mock_markitdown.return_value = mock_instance
+
+        result = asyncio.run(
+            convert_to_markdown("file:///C:/Windows/System32/drivers/etc/hosts")
+        )
+        assert result == "# Test"
+
+
+def test_http_uri_not_affected_by_restriction(monkeypatch) -> None:
+    """http:// and https:// URIs must pass through regardless of the local files flag."""
+    monkeypatch.delenv("MARKITDOWN_ALLOW_LOCAL_FILES", raising=False)
+
+    with patch("markitdown_mcp.__main__.MarkItDown") as mock_markitdown:
+        mock_instance = MagicMock()
+        mock_instance.convert_uri.return_value.markdown = "# Test"
+        mock_markitdown.return_value = mock_instance
+
+        result = asyncio.run(convert_to_markdown("https://example.com"))
+        assert result == "# Test"
+
+
+def test_data_uri_not_affected_by_restriction(monkeypatch) -> None:
+    """data: URIs must pass through regardless of the local files flag."""
+    monkeypatch.delenv("MARKITDOWN_ALLOW_LOCAL_FILES", raising=False)
+
+    with patch("markitdown_mcp.__main__.MarkItDown") as mock_markitdown:
+        mock_instance = MagicMock()
+        mock_instance.convert_uri.return_value.markdown = "# Test"
+        mock_markitdown.return_value = mock_instance
+
+        result = asyncio.run(convert_to_markdown("data:text/plain;base64,SGVsbG8="))
+        assert result == "# Test"


### PR DESCRIPTION
## Summary

Fixes #1905.
The `convert_to_markdown` tool accepted any URI scheme including `file://`, allowing any process on the machine to instruct the MCP server to read arbitrary local files accessible to the user running the server. This is especially concerning in HTTP mode where the server is reachable by any local process, and in prompt injection scenarios where a malicious web page could manipulate an AI agent into reading sensitive files without the user's knowledge.

## Root Cause
The `convert_to_markdown` tool passed the URI directly to `MarkItDown.convert_uri()` with no scheme validation. The README explicitly listed `file:` as a supported scheme, but this posed a risk in agentic contexts.

## Fix
- `file://` URIs are now blocked by default with a clear error message
- A new `--allow-local-files` startup flag re-enables them for users who explicitly need local file access
- When `--allow-local-files` is set, a warning is printed to stderr at  startup which is consistent with the existing pattern for non-localhost binding
- README updated to reflect that `file:` is no longer a default supported scheme and documents the opt-in flag

This approach was chosen over a hard block to preserve intentional functionality (Docker users who mount directories, local trusted workflows) while making the secure behavior the default. It follows the existing security philosophy of the project: warn loudly rather than silently restrict.

## Security Research
The solution used: blocking file:// by default with an explicit opt-in flag,  is consistent with how the AWS MCP server handles the same class of vulnerability (CVE-2026-4270), and aligns with the official MCP security documentation guidance to restrict local file access when using HTTP transport.

## Testing
- Verified the vulnerability reproduces before the fix by sending a `file:///C:/Windows/System32/drivers/etc/hosts` URI to the running  server
- Verified the fix blocks the request with a clear error message
- Verified `--allow-local-files` restores the original behavior
- Added 4 automated tests covering: default block, opt-in allow, and confirming http:// and data: URIs are unaffected

## Files Changed
- `packages/markitdown-mcp/src/markitdown_mcp/__main__.py`
- `packages/markitdown-mcp/tests/test_security.py` *(new)*
- `packages/markitdown-mcp/README.md