### PR TITLE
fix: guard against None text in PptxConverter shape/notes concatenation

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
@@ -148,9 +148,9 @@ class PptxConverterWithOCR(DocumentConverter):
                 # Text areas
                 elif shape.has_text_frame:
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\\n"
+                        md_content += "# " + (shape.text or "").lstrip() + "\\n"
                     else:
-                        md_content += shape.text + "\\n"
+                        md_content += (shape.text or "") + "\\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -180,7 +180,7 @@ class PptxConverterWithOCR(DocumentConverter):
                 md_content += "\\n\\n### Notes:\\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
+                    md_content += (notes_frame.text or "")
                 md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -162,9 +162,9 @@ class PptxConverter(DocumentConverter):
                 # Text areas
                 elif shape.has_text_frame:
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\n"
+                        md_content += "# " + (shape.text or "").lstrip() + "\n"
                     else:
-                        md_content += shape.text + "\n"
+                        md_content += (shape.text or "") + "\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -194,7 +194,7 @@ class PptxConverter(DocumentConverter):
                 md_content += "\n\n### Notes:\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
+                    md_content += (notes_frame.text or "")
                 md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())


### PR DESCRIPTION
## Summary

Guard `shape.text` and `notes_frame.text` with `(... or "")` in PptxConverter and its OCR variant to prevent `TypeError` when python-pptx returns `None` for certain shapes (charts, SmartArt, third-party-generated decks with missing `<a:t>` elements).

## Issue

Fixes #1808

## Verification

- Tested with a PPTX where `shape.text` returns `None` — conversion succeeds instead of crashing
- Normal PPTX conversion continues to work correctly
