### PR TITLE
fix: catch UnicodeDecodeError in IpynbConverter.accepts()

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -38,6 +38,8 @@ class IpynbConverter(DocumentConverter):
                         "nbformat" in notebook_content
                         and "nbformat_minor" in notebook_content
                     )
+                except (UnicodeDecodeError, ValueError):
+                    return False
                 finally:
                     file_stream.seek(cur_pos)
 


### PR DESCRIPTION
## Summary

Wrap the file decoding in `IpynbConverter.accepts()` with `except (UnicodeDecodeError, ValueError)` so that non-ASCII non-ipynb files (e.g. French PDFs) don't crash the entire conversion pipeline with `UnicodeDecodeError`.

## Issue

Fixes #1894

## Verification

- Non-ASCII content with `application/json` MIME type: `accepts()` returns `False` instead of raising
- Binary content (random bytes): `accepts()` returns `False` instead of raising
- Actual `.ipynb` files are still correctly detected and converted
