### PR TITLE
fix: IpynbConverter.accepts() catches UnicodeDecodeError on non-ASCII files (#1894)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -29,7 +29,12 @@ class IpynbConverter(DocumentConverter):
 
         for prefix in CANDIDATE_MIME_TYPE_PREFIXES:
             if mimetype.startswith(prefix):
-                # Read further to see if it's a notebook
+                # Read further to see if it's a notebook.
+                # Guard against UnicodeDecodeError: accepts() must never raise —
+                # it should return False for any file it cannot decode.
+                # This can happen with binary files (e.g. French PDF with UTF-8
+                # accented characters) that happen to share the application/json
+                # MIME prefix.
                 cur_pos = file_stream.tell()
                 try:
                     encoding = stream_info.charset or "utf-8"
@@ -38,6 +43,9 @@ class IpynbConverter(DocumentConverter):
                         "nbformat" in notebook_content
                         and "nbformat_minor" in notebook_content
                     )
+                except (UnicodeDecodeError, ValueError):
+                    # Non-decodable or non-parseable content — not a notebook
+                    return False
                 finally:
                     file_stream.seek(cur_pos)
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -552,3 +552,30 @@ if __name__ == "__main__":
         test()
         print("OK")
     print("All tests passed!")
+
+
+def test_ipynb_accepts_non_decodable_content() -> None:
+    """IpynbConverter.accepts() returns False (not raises) on non-decodable content.
+
+    Regression test for https://github.com/microsoft/markitdown/issues/1894.
+    """
+    from markitdown.converters._ipynb_converter import IpynbConverter
+    from markitdown._stream_info import StreamInfo
+
+    converter = IpynbConverter()
+
+    # French text bytes that fail ASCII decode
+    french_bytes = "Bonjour, ça va très bien?".encode("utf-8")
+    result = converter.accepts(
+        io.BytesIO(french_bytes),
+        StreamInfo(mimetype="application/json", extension=".bin", charset="ascii"),
+    )
+    assert result is False
+
+    # Bad JSON bytes that cause ValueError
+    bad_json = b'{"not": "a notebook", \xff\xfe}'
+    result = converter.accepts(
+        io.BytesIO(bad_json),
+        StreamInfo(mimetype="application/json", extension=".txt", charset="utf-8"),
+    )
+    assert result is False


### PR DESCRIPTION
## Summary

Fix #1894: \IpynbConverter.accepts()\ crashes with \UnicodeDecodeError\ when processing non-ASCII files (e.g. a French PDF containing accented characters like é, è, à) that have an \pplication/json\ MIME type. Since \ccepts()\ must never raise, this causes the entire conversion pipeline to fail.

## Changes

### \_ipynb_converter.py\
Wrap the \ile_stream.read().decode(encoding)\ block with \except (UnicodeDecodeError, ValueError)\ and return \False\ when the content cannot be decoded — a non-decodable file is definitely not a Jupyter notebook.

### \	est_module_misc.py\
Added \	est_ipynb_accepts_non_decodable_content()\ with two cases:
1. UTF-8 French text decoded with \charset='ascii'\ — must return \False\
2. Malformed JSON bytes — must return \False\

## Issue

Fixes #1894