### PR TITLE
fix: IpynbConverter.accepts() catches UnicodeDecodeError on non-ASCII files (fixes #1894)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -38,6 +38,8 @@ class IpynbConverter(DocumentConverter):
                         "nbformat" in notebook_content
                         and "nbformat_minor" in notebook_content
                     )
+                except (UnicodeDecodeError, ValueError):
+                    return False
                 finally:
                     file_stream.seek(cur_pos)
 


### PR DESCRIPTION
## Summary

\\IpynbConverter.accepts()\\ reads the full file stream and decodes it to detect Jupyter notebooks. When a non-ASCII file (e.g., a French PDF with accented characters like é/è/à) produces a MIME type starting with \\pplication/json\\, the \\.decode()\\ call raises \\UnicodeDecodeError\\ which propagates uncaught and crashes the entire conversion pipeline.

This fix wraps the decode block in \\	ry/except (UnicodeDecodeError, ValueError)\\ so that \\ccepts()\\ gracefully returns \\False\\ instead of crashing.

## Issue

Fixes #1894

## Verification

- Binary non-ASCII content with \\pplication/json\\ MIME → returns \\False\\ (no crash)
- Valid \\.ipynb\\ notebook → still returns \\True\\
- Plain JSON → returns \\False\\
- 2/3 existing tests pass (1 pre-existing failure due to missing docx dependency)