### PR TITLE
fix(ocr): trigger OCR fallback when scanned PDF has only page numbers (fixes #1863)

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
@@ -4,6 +4,7 @@ Extracts images from PDFs and performs OCR while maintaining document context.
 """
 
 import io
+import re
 import sys
 from typing import Any, BinaryIO, Optional
 
@@ -293,6 +294,13 @@ class PdfConverterWithOCR(DocumentConverter):
                 if not markdown:
                     pdf_bytes.seek(0)
                     markdown = pdfminer.high_level.extract_text(pdf_bytes)
+
+                # If markdown contains only page headers with no extracted text and OCR is available,
+                # treat as empty so the OCR fallback below runs on the full pages.
+                if ocr_service:
+                    lines = [l.strip() for l in markdown.split("\n") if l.strip()]
+                    if lines and all(re.match(r"^## Page \d+$", l) for l in lines):
+                        markdown = ""
 
         except Exception:
             # Fallback to pdfminer


### PR DESCRIPTION
## Summary

When `PdfConverterWithOCR` processes a scanned PDF (no text layer), page headers (`## Page N`) are unconditionally appended to the markdown output before text extraction. When the page contains no extractable text, only page headers end up in the output — and since the markdown is non-empty, the OCR fallback (`_ocr_full_pages`) is never triggered.

## Changes

- Added a check after the pdfplumber extraction loop: if the assembled markdown consists entirely of page headers (`## Page N`) with no real text content, treat it as empty so the existing OCR fallback runs on the full pages.

## Issue

Fixes #1863

## Verification

```
python -c "
import re
# Only page headers → treat as empty
lines = [l.strip() for l in '## Page 1\n\n## Page 2'.split('\n') if l.strip()]
assert all(re.match(r'^## Page \d+$', l) for l in lines)
# Headers + content → keep as-is
lines = [l.strip() for l in '## Page 1\n\nSome text'.split('\n') if l.strip()]
assert not all(re.match(r'^## Page \d+$', l) for l in lines)
print('Logic verified')
"
```
