### PR TITLE
fix: let DocumentIntelligenceConverter use SDK default API version (fixes #1904)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -134,7 +134,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
         self,
         *,
         endpoint: str,
-        api_version: str = "2024-07-31-preview",
+        api_version: str | None = None,
         credential: AzureKeyCredential | TokenCredential | None = None,
         file_types: List[DocumentIntelligenceFileType] = [
             DocumentIntelligenceFileType.DOCX,
@@ -152,7 +152,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         Args:
             endpoint (str): The endpoint for the Document Intelligence service.
-            api_version (str): The API version to use. Defaults to "2024-07-31-preview".
+            api_version (str | None): The API version to use. Defaults to None (SDK default).
             credential (AzureKeyCredential | TokenCredential | None): The credential to use for authentication.
             file_types (List[DocumentIntelligenceFileType]): The file types to accept. Defaults to all supported file types.
         """


### PR DESCRIPTION
## Summary

Changes the default value of pi_version in DocumentIntelligenceConverter from "2024-07-31-preview" to None, allowing the Azure SDK's DocumentIntelligenceClient to use its own default API version (2024-11-30).

The hardcoded preview version 2024-07-31-preview is outdated and doesn't match the current SDK default. Users who don't explicitly set an API version get a 404 error because the wrong version is sent to the service.

## Changes

- packages/markitdown/src/markitdown/converters/_doc_intel_converter.py: Changed pi_version default from "2024-07-31-preview" to None and updated type to str | None

## Issue

Fixes #1904

## Verification

The MarkItDown constructor (_markitdown.py:221-223) already handles the None case correctly ? it only passes pi_version to the converter when the user explicitly provides docintel_api_version.
