### PR TITLE
fix: DocumentIntelligenceConverter should not set a default api_version (fixes #1904)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -134,7 +134,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
         self,
         *,
         endpoint: str,
-        api_version: str = "2024-07-31-preview",
+        api_version: str | None = None,
         credential: AzureKeyCredential | TokenCredential | None = None,
         file_types: List[DocumentIntelligenceFileType] = [
             DocumentIntelligenceFileType.DOCX,
@@ -152,7 +152,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         Args:
             endpoint (str): The endpoint for the Document Intelligence service.
-            api_version (str): The API version to use. Defaults to "2024-07-31-preview".
+            api_version (str | None): The API version to use. When None (default), the Azure SDK's default is used.
             credential (AzureKeyCredential | TokenCredential | None): The credential to use for authentication.
             file_types (List[DocumentIntelligenceFileType]): The file types to accept. Defaults to all supported file types.
         """
@@ -180,11 +180,13 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         self.endpoint = endpoint
         self.api_version = api_version
-        self.doc_intel_client = DocumentIntelligenceClient(
+        client_kwargs = dict(
             endpoint=self.endpoint,
-            api_version=self.api_version,
             credential=credential,
         )
+        if self.api_version is not None:
+            client_kwargs["api_version"] = self.api_version
+        self.doc_intel_client = DocumentIntelligenceClient(**client_kwargs)
 
     def accepts(
         self,


### PR DESCRIPTION
## Summary

`DocumentIntelligenceConverter.__init__` hardcodes `api_version: str = "2024-07-31-preview"`. Azure Document Intelligence's SDK default version has moved forward, and passing an outdated preview version causes `404 Resource Not Found` for users who don't explicitly set `api_version`.

This fix changes the default to `None` and only passes `api_version` to `DocumentIntelligenceClient` when it is explicitly set, letting the Azure SDK use its own default.

## Issue

Fixes #1904

## Verification

- Default `api_version=None` → `DocumentIntelligenceClient` receives no `api_version` kwarg → SDK uses its default
- Explicit `api_version="2024-07-31-preview"` → passed through unchanged
