### PR TITLE
fix: initialize res before try block to prevent UnboundLocalError (fixes #81)

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -624,6 +624,7 @@ class MarkItDown:
                 ), f"{type(converter).__name__}.accept() should NOT change the file_stream position"
 
                 # Attempt the conversion
+                res = None
                 if _accepts:
                     try:
                         res = converter.convert(file_stream, stream_info, **_kwargs)


### PR DESCRIPTION
## Summary

Fixes UnboundLocalError: local variable 'res' referenced before assignment that occurs when a converter raises an exception during convert(). The variable es is now initialized to None before the try block, so the subsequent if res is not None check works correctly regardless of whether the conversion succeeded or failed.

## Root Cause

In _markitdown.py:_convert(), when converter.convert() raises an exception, the assignment es = converter.convert(...) never completes. The except block records the failure but does not assign es, leaving it unbound. The next line if res is not None: then raises UnboundLocalError.

## Changes

- packages/markitdown/src/markitdown/_markitdown.py: Added es = None initialization before the try block (line 627)

## Issue

Fixes #81

## Verification

- One-line change, trivially verified by inspection
- The same pattern (initialize before try, check after) is standard Python practice
