### PR TITLE
fix: handle UnicodeDecodeError in PlainTextConverter when charset detection is inaccurate (fixes #1505)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -63,9 +63,13 @@ class PlainTextConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
+        file_bytes = file_stream.read()
         if stream_info.charset:
-            text_content = file_stream.read().decode(stream_info.charset)
+            try:
+                text_content = file_bytes.decode(stream_info.charset)
+            except UnicodeDecodeError:
+                text_content = str(from_bytes(file_bytes).best())
         else:
-            text_content = str(from_bytes(file_stream.read()).best())
+            text_content = str(from_bytes(file_bytes).best())
 
         return DocumentConverterResult(markdown=text_content)


### PR DESCRIPTION
## Summary
When `stream_info.charset` is detected from partial file content (first 4096 bytes) and returns `'ascii'`, but the full file contains non-ASCII characters (e.g., Spanish accents, UTF-8 characters), `.decode('ascii')` raises `UnicodeDecodeError`.

This fix adds a fallback: if decoding with the detected charset fails, fall back to `charset_normalizer` for automatic charset detection on the full file content.

## Issue
Fixes #1505

## Verification
- UTF-8 files with Spanish characters now decode correctly
- Pure ASCII files continue to work as before
- Files where charset detection from partial content returns `'ascii'` but full content has UTF-8 characters fall back gracefully
