### PR TITLE
fix: handle LLM API errors gracefully in ImageConverter (#1942)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -134,5 +134,8 @@ class ImageConverter(DocumentConverter):
         ]
 
         # Call the OpenAI API
-        response = client.chat.completions.create(model=model, messages=messages)
-        return response.choices[0].message.content
+        try:
+            response = client.chat.completions.create(model=model, messages=messages)
+            return response.choices[0].message.content
+        except Exception:
+            return None


### PR DESCRIPTION
## Description

`ImageConverter.convert()` crashes the entire conversion pipeline when the LLM API call in `_get_llm_description()` fails (e.g. authentication error, rate limit exceeded, network timeout). Unlike `PptxConverter` which wraps its `llm_caption()` call in a try/except (lines 119-129), `ImageConverter._get_llm_description()` makes the OpenAI API call at line 137 without any error handling.

## Root Cause

`packages/markitdown/src/markitdown/converters/_image_converter.py`, line 137:
```python
response = client.chat.completions.create(model=model, messages=messages)
```
If this call raises any exception (e.g. `openai.AuthenticationError`, `openai.RateLimitError`, `openai.APITimeoutError`), the exception propagates up and fails the entire conversion.

## Expected Behavior

A failed LLM caption should be gracefully handled: silently skip the description, and still return the successfully extracted metadata. The image should still be converted to Markdown, just without the LLM-generated caption.

## Proposed Fix

Wrap the API call in a try/except block, similar to how `PptxConverter` handles it:
```python
try:
    response = client.chat.completions.create(model=model, messages=messages)
    return response.choices[0].message.content
except Exception:
    return None
```

## Impact

Anyone using `ImageConverter` with an LLM client configured will have their entire conversion fail if the API call fails for any reason.
