### PR TITLE
fix: preserve currency formatting in XLSX conversion (fixes #53)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -1,5 +1,8 @@
+import io
+import re
 import sys
-from typing import BinaryIO, Any
+from typing import BinaryIO, Any, Dict, List, Optional, Tuple
+
 from ._html_converter import HtmlConverter
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
@@ -9,14 +12,12 @@ from .._stream_info import StreamInfo
 # Save reporting of any exceptions for later
 _xlsx_dependency_exc_info = None
 try:
-    import pandas as pd
-    import openpyxl  # noqa: F401
+    import openpyxl
 except ImportError:
     _xlsx_dependency_exc_info = sys.exc_info()
 
 _xls_dependency_exc_info = None
 try:
-    import pandas as pd  # noqa: F811
     import xlrd  # noqa: F401
 except ImportError:
     _xls_dependency_exc_info = sys.exc_info()
@@ -32,6 +33,55 @@ ACCEPTED_XLS_MIME_TYPE_PREFIXES = [
 ]
 ACCEPTED_XLS_FILE_EXTENSIONS = [".xls"]
 
+_CURRENCY_PREFIXES = re.compile(r"^[\$€£¥₩₽₹₨฿₫₪₴₸₺₼₾]")
+
+
+def _has_currency_format(number_format: Optional[str]) -> Optional[str]:
+    """Check if number format indicates currency and return the currency symbol if so."""
+    if not number_format or number_format == "General":
+        return None
+    match = _CURRENCY_PREFIXES.match(number_format)
+    if match:
+        return match.group(0)
+    return None
+
+
+def _build_currency_map(ws: Any) -> Dict[Tuple[int, int], str]:
+    """Build {(row_idx, col_idx): symbol} for currency-formatted cells."""
+    currency_map: Dict[Tuple[int, int], str] = {}
+    for row in ws.iter_rows():
+        for cell in row:
+            symbol = _has_currency_format(cell.number_format)
+            if symbol:
+                currency_map[(cell.row - 1, cell.column - 1)] = symbol
+    return currency_map
+
+
+def _markdown_table_from_worksheet(ws: Any, currency_map: Dict[Tuple[int, int], str]) -> str:
+    """Convert an openpyxl worksheet to a Markdown table with currency symbols."""
+    rows: List[List[str]] = []
+    for row_idx, row in enumerate(ws.iter_rows()):
+        cells: List[str] = []
+        for col_idx, cell in enumerate(row):
+            if cell.value is None:
+                cells.append("")
+            elif (row_idx, col_idx) in currency_map:
+                symbol = currency_map[(row_idx, col_idx)]
+                v = cell.value
+                if isinstance(v, float) and v == int(v):
+                    v = int(v)
+                cells.append(f"{symbol}{v}")
+            else:
+                cells.append(str(cell.value))
+        rows.append(cells)
+    if not rows:
+        return ""
+    header = "| " + " | ".join(rows[0]) + " |"
+    sep = "| " + " | ".join(["---"] * len(rows[0])) + " |"
+    body_lines = ["| " + " | ".join(r) + " |" for r in rows[1:]]
+    body = "\n".join(body_lines)
+    return header + "\n" + sep + ("\n" + body if body else "")
+
 
 class XlsxConverter(DocumentConverter):
     """
@@ -40,33 +90,28 @@ class XlsxConverter(DocumentConverter):
 
     def __init__(self):
         super().__init__()
-        self._html_converter = HtmlConverter()
 
     def accepts(
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,  # Options to pass to the converter
+        **kwargs: Any,
     ) -> bool:
         mimetype = (stream_info.mimetype or "").lower()
         extension = (stream_info.extension or "").lower()
-
         if extension in ACCEPTED_XLSX_FILE_EXTENSIONS:
             return True
-
         for prefix in ACCEPTED_XLSX_MIME_TYPE_PREFIXES:
             if mimetype.startswith(prefix):
                 return True
-
         return False
 
     def convert(
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,  # Options to pass to the converter
+        **kwargs: Any,
     ) -> DocumentConverterResult:
-        # Check the dependencies
         if _xlsx_dependency_exc_info is not None:
             raise MissingDependencyException(
                 MISSING_DEPENDENCY_MESSAGE.format(
@@ -76,22 +121,19 @@ class XlsxConverter(DocumentConverter):
                 )
             ) from _xlsx_dependency_exc_info[
                 1
-            ].with_traceback(  # type: ignore[union-attr]
+            ].with_traceback(
                 _xlsx_dependency_exc_info[2]
             )
 
-        sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
+        file_stream.seek(0)
+        wb = openpyxl.load_workbook(file_stream, data_only=True)
         md_content = ""
-        for s in sheets:
-            md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
-            md_content += (
-                self._html_converter.convert_string(
-                    html_content, **kwargs
-                ).markdown.strip()
-                + "\n\n"
-            )
-
+        for sheet_name in wb.sheetnames:
+            ws = wb[sheet_name]
+            currency_map = _build_currency_map(ws)
+            md_content += f"## {sheet_name}\n"
+            md_content += _markdown_table_from_worksheet(ws, currency_map) + "\n\n"
+        wb.close()
         return DocumentConverterResult(markdown=md_content.strip())
 
 
@@ -108,27 +150,23 @@ class XlsConverter(DocumentConverter):
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,  # Options to pass to the converter
+        **kwargs: Any,
     ) -> bool:
         mimetype = (stream_info.mimetype or "").lower()
         extension = (stream_info.extension or "").lower()
-
         if extension in ACCEPTED_XLS_FILE_EXTENSIONS:
             return True
-
         for prefix in ACCEPTED_XLS_MIME_TYPE_PREFIXES:
             if mimetype.startswith(prefix):
                 return True
-
         return False
 
     def convert(
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,  # Options to pass to the converter
+        **kwargs: Any,
     ) -> DocumentConverterResult:
-        # Load the dependencies
         if _xls_dependency_exc_info is not None:
             raise MissingDependencyException(
                 MISSING_DEPENDENCY_MESSAGE.format(
@@ -138,10 +176,11 @@ class XlsConverter(DocumentConverter):
                 )
             ) from _xls_dependency_exc_info[
                 1
-            ].with_traceback(  # type: ignore[union-attr]
+            ].with_traceback(
                 _xls_dependency_exc_info[2]
             )
 
+        import pandas as pd
         sheets = pd.read_excel(file_stream, sheet_name=None, engine="xlrd")
         md_content = ""
         for s in sheets:
@@ -153,5 +192,4 @@ class XlsConverter(DocumentConverter):
                 ).markdown.strip()
                 + "\n\n"
             )
-
         return DocumentConverterResult(markdown=md_content.strip())

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -1,8 +1,6 @@
-import io
 import re
 import sys
 from typing import BinaryIO, Any, Dict, List, Optional, Tuple
-
 from ._html_converter import HtmlConverter
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
@@ -12,12 +10,14 @@ from .._stream_info import StreamInfo
 # Save reporting of any exceptions for later
 _xlsx_dependency_exc_info = None
 try:
+    import pandas as pd
     import openpyxl
 except ImportError:
     _xlsx_dependency_exc_info = sys.exc_info()
 
 _xls_dependency_exc_info = None
 try:
+    import pandas as pd  # noqa: F811
     import xlrd  # noqa: F401
 except ImportError:
     _xls_dependency_exc_info = sys.exc_info()
@@ -33,54 +33,33 @@ ACCEPTED_XLS_MIME_TYPE_PREFIXES = [
 ]
 ACCEPTED_XLS_FILE_EXTENSIONS = [".xls"]
 
-_CURRENCY_PREFIXES = re.compile(r"^[\$€£¥₩₽₹₨฿₫₪₴₸₺₼₾]")
+# Regex to detect the most common currency symbols in Excel number format strings.
+_CURRENCY_PATTERN = re.compile(r"^[\$€£¥]")
 
 
-def _has_currency_format(number_format: Optional[str]) -> Optional[str]:
-    """Check if number format indicates currency and return the currency symbol if so."""
-    if not number_format or number_format == "General":
+def _get_currency_symbol(format_str: Optional[str]) -> Optional[str]:
+    """Return the currency symbol if *format_str* starts with one, else None."""
+    if not format_str or format_str == "General":
         return None
-    match = _CURRENCY_PREFIXES.match(number_format)
-    if match:
-        return match.group(0)
-    return None
+    m = _CURRENCY_PATTERN.match(format_str)
+    return m.group(0) if m else None
 
 
-def _build_currency_map(ws: Any) -> Dict[Tuple[int, int], str]:
-    """Build {(row_idx, col_idx): symbol} for currency-formatted cells."""
-    currency_map: Dict[Tuple[int, int], str] = {}
-    for row in ws.iter_rows():
+def _apply_currency_formats(df: "pd.DataFrame", ws: Any) -> None:
+    """Mutate *df* in-place: prepend currency symbols to numeric cells that
+    have a currency-style number format in the worksheet."""
+    for row_idx, row in enumerate(ws.iter_rows(min_row=2)):
+        df_row = row_idx
+        if df_row >= len(df):
+            break
         for cell in row:
-            symbol = _has_currency_format(cell.number_format)
-            if symbol:
-                currency_map[(cell.row - 1, cell.column - 1)] = symbol
-    return currency_map
-
-
-def _markdown_table_from_worksheet(ws: Any, currency_map: Dict[Tuple[int, int], str]) -> str:
-    """Convert an openpyxl worksheet to a Markdown table with currency symbols."""
-    rows: List[List[str]] = []
-    for row_idx, row in enumerate(ws.iter_rows()):
-        cells: List[str] = []
-        for col_idx, cell in enumerate(row):
-            if cell.value is None:
-                cells.append("")
-            elif (row_idx, col_idx) in currency_map:
-                symbol = currency_map[(row_idx, col_idx)]
-                v = cell.value
-                if isinstance(v, float) and v == int(v):
-                    v = int(v)
-                cells.append(f"{symbol}{v}")
-            else:
-                cells.append(str(cell.value))
-        rows.append(cells)
-    if not rows:
-        return ""
-    header = "| " + " | ".join(rows[0]) + " |"
-    sep = "| " + " | ".join(["---"] * len(rows[0])) + " |"
-    body_lines = ["| " + " | ".join(r) + " |" for r in rows[1:]]
-    body = "\n".join(body_lines)
-    return header + "\n" + sep + ("\n" + body if body else "")
+            symbol = _get_currency_symbol(cell.number_format)
+            if symbol is None:
+                continue
+            col_name = df.columns[cell.column - 1]
+            val = df.iloc[df_row, cell.column - 1]
+            if isinstance(val, (int, float)):
+                df.iloc[df_row, cell.column - 1] = f"{symbol}{val}"
 
 
 class XlsxConverter(DocumentConverter):
@@ -90,28 +69,33 @@ class XlsxConverter(DocumentConverter):
 
     def __init__(self):
         super().__init__()
+        self._html_converter = HtmlConverter()
 
     def accepts(
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,
+        **kwargs: Any,  # Options to pass to the converter
     ) -> bool:
         mimetype = (stream_info.mimetype or "").lower()
         extension = (stream_info.extension or "").lower()
+
         if extension in ACCEPTED_XLSX_FILE_EXTENSIONS:
             return True
+
         for prefix in ACCEPTED_XLSX_MIME_TYPE_PREFIXES:
             if mimetype.startswith(prefix):
                 return True
+
         return False
 
     def convert(
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,
+        **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
+        # Check the dependencies
         if _xlsx_dependency_exc_info is not None:
             raise MissingDependencyException(
                 MISSING_DEPENDENCY_MESSAGE.format(
@@ -121,18 +105,26 @@ class XlsxConverter(DocumentConverter):
                 )
             ) from _xlsx_dependency_exc_info[
                 1
-            ].with_traceback(
+            ].with_traceback(  # type: ignore[union-attr]
                 _xlsx_dependency_exc_info[2]
             )
 
         file_stream.seek(0)
         wb = openpyxl.load_workbook(file_stream, data_only=True)
+        file_stream.seek(0)
+        sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
         md_content = ""
-        for sheet_name in wb.sheetnames:
+        for sheet_name in sheets:
             ws = wb[sheet_name]
-            currency_map = _build_currency_map(ws)
+            _apply_currency_formats(sheets[sheet_name], ws)
             md_content += f"## {sheet_name}\n"
-            md_content += _markdown_table_from_worksheet(ws, currency_map) + "\n\n"
+            html_content = sheets[sheet_name].to_html(index=False)
+            md_content += (
+                self._html_converter.convert_string(
+                    html_content, **kwargs
+                ).markdown.strip()
+                + "\n\n"
+            )
         wb.close()
         return DocumentConverterResult(markdown=md_content.strip())
 
@@ -150,23 +142,27 @@ class XlsConverter(DocumentConverter):
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,
+        **kwargs: Any,  # Options to pass to the converter
     ) -> bool:
         mimetype = (stream_info.mimetype or "").lower()
         extension = (stream_info.extension or "").lower()
+
         if extension in ACCEPTED_XLS_FILE_EXTENSIONS:
             return True
+
         for prefix in ACCEPTED_XLS_MIME_TYPE_PREFIXES:
             if mimetype.startswith(prefix):
                 return True
+
         return False
 
     def convert(
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
-        **kwargs: Any,
+        **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
+        # Load the dependencies
         if _xls_dependency_exc_info is not None:
             raise MissingDependencyException(
                 MISSING_DEPENDENCY_MESSAGE.format(
@@ -176,11 +172,10 @@ class XlsConverter(DocumentConverter):
                 )
             ) from _xls_dependency_exc_info[
                 1
-            ].with_traceback(
+            ].with_traceback(  # type: ignore[union-attr]
                 _xls_dependency_exc_info[2]
             )
 
-        import pandas as pd
         sheets = pd.read_excel(file_stream, sheet_name=None, engine="xlrd")
         md_content = ""
         for s in sheets:
@@ -192,4 +187,5 @@ class XlsConverter(DocumentConverter):
                 ).markdown.strip()
                 + "\n\n"
             )
+
         return DocumentConverterResult(markdown=md_content.strip())


### PR DESCRIPTION
## Summary

Numeric cells with currency-style Excel number formats now render with their
currency symbol (\$, €, £, ¥) before Markdown output.

The existing pandas-based XLSX conversion path is kept intact. The only
addition is a thin formatting overlay that reads cell number formats via
openpyxl and prepends the currency symbol where applicable.

## Changes

- \_xlsx_converter.py\: added \_get_currency_symbol()\ and
  \_apply_currency_formats()\ helpers; both are called after pandas reads
  the worksheet and before the DataFrame is serialized to HTML/Markdown.

## Issue

Fixes #53

## Unhandled edge cases (explicitly out of scope)

- Locale-specific currency formats (e.g. \1.234,56 €\)
- Accounting formats (e.g. \_(\$* ...\)
- Negative-number currency formats (e.g. \-\,234\)