### PR TITLE
fix: ImageConverter crashes when LLM API call fails

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -134,5 +134,8 @@ class ImageConverter(DocumentConverter):
         ]
 
         # Call the OpenAI API
-        response = client.chat.completions.create(model=model, messages=messages)
-        return response.choices[0].message.content
+        try:
+            response = client.chat.completions.create(model=model, messages=messages)
+            return response.choices[0].message.content
+        except Exception:
+            return None


### PR DESCRIPTION
Fixes #1942