### PR TITLE
fix: prevent UnboundLocalError in RSS converter when channel title is missing (fixes #1946)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -107,7 +107,7 @@ class RssConverter(DocumentConverter):
         title = self._get_data_by_tag_name(root, "title")
         subtitle = self._get_data_by_tag_name(root, "subtitle")
         entries = root.getElementsByTagName("entry")
-        md_text = f"# {title}\n"
+        md_text = f"# {title}\n" if title else ""
         if subtitle:
             md_text += f"{subtitle}\n"
         for entry in entries:
@@ -143,6 +143,7 @@ class RssConverter(DocumentConverter):
         channel_title = self._get_data_by_tag_name(channel, "title")
         channel_description = self._get_data_by_tag_name(channel, "description")
         items = channel.getElementsByTagName("item")
+        md_text = ""
         if channel_title:
             md_text = f"# {channel_title}\n"
         if channel_description:


### PR DESCRIPTION
## Summary

Fixes two bugs in the RSS/Atom converter:

1. **UnboundLocalError** in _parse_rss_type(): When an RSS feed has no <title> element, md_text was never initialized but subsequent += operations referenced it. Added md_text = "" initialization before the conditional block.

2. **# None display bug** in _parse_atom_type(): When an Atom feed has no <title> element, line 110 rendered # None as the document heading. Changed to "# {title}\n" if title else "".

## Changes

- packages/markitdown/src/markitdown/converters/_rss_converter.py:
  - Line 110: Guard Atom title assignment against None
  - Line 146: Initialize md_text = "" before conditional blocks in RSS parser

## Issue

Fixes #1946

## Verification

- Code inspection confirms both fixes handle the None/missing title case correctly
- Existing code paths for valid RSS/Atom feeds are unaffected (conditionals remain the same)
