### PR TITLE
fix: guard IpynbConverter.accepts() against UnicodeDecodeError on non-ASCII files (fixes #1894)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -38,6 +38,8 @@ class IpynbConverter(DocumentConverter):
                         "nbformat" in notebook_content
                         and "nbformat_minor" in notebook_content
                     )
+                except (UnicodeDecodeError, ValueError):
+                    return False
                 finally:
                     file_stream.seek(cur_pos)
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -532,6 +532,36 @@ def test_markitdown_llm() -> None:
     validate_strings(result, PPTX_TEST_STRINGS)
 
 
+def test_ipynb_converter_accepts_non_ascii():
+    """Test that IpynbConverter.accepts() handles non-ASCII bytes gracefully.
+
+    Regression test for https://github.com/microsoft/markitdown/issues/1894.
+    Non-ASCII files (e.g. French PDFs with accented characters) should not
+    crash the conversion pipeline with UnicodeDecodeError.
+    """
+    from markitdown.converters._ipynb_converter import IpynbConverter
+
+    converter = IpynbConverter()
+
+    # Non-ASCII bytes that could be mistaken for JSON
+    non_ascii_data = b'{"data": "caf\xe9 cr\xe8me"}\n'
+    stream = io.BytesIO(non_ascii_data)
+    stream_info = StreamInfo(mimetype="application/json")
+
+    result = converter.accepts(stream, stream_info)
+    assert result is False
+    assert stream.tell() == 0  # stream position restored
+
+    # Normal notebook should still be accepted
+    notebook_data = b'{"nbformat": 4, "nbformat_minor": 5, "cells": []}'
+    stream2 = io.BytesIO(notebook_data)
+    stream_info2 = StreamInfo(mimetype="application/json")
+
+    result2 = converter.accepts(stream2, stream_info2)
+    assert result2 is True
+    assert stream2.tell() == 0
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     for test in [


### PR DESCRIPTION
## Summary

Wraps the file decode in `IpynbConverter.accepts()` with `except (UnicodeDecodeError, ValueError)` so that non-ASCII files (e.g. French PDFs with accented characters) don't crash the entire conversion pipeline.

## Issue

Closes #1894

## Root Cause

`accepts()` reads the file stream and decodes it as UTF-8 to check for Jupyter notebook markers. When a non-ASCII file (like a French PDF invoice) is evaluated, `decode()` raises `UnicodeDecodeError`, which propagates uncaught — even though `accepts()` should only return `True` or `False`.

## Fix

```python
except (UnicodeDecodeError, ValueError):
    return False
```

Added to the existing try/finally block. The stream position is still restored in the `finally` block regardless of the outcome.

## Edge Cases Not Covered

- `accepts()` is only guarded for the MIME-type-prefix path; the extension-based path (`extension in ACCEPTED_FILE_EXTENSIONS`) does not read the file, so it's unaffected.
- The `convert()` method still does unguarded `decode()` — but it runs after `accepts()` has confirmed the file is a notebook, so a properly-identified notebook should decode fine.

## Verification

```
Non-ASCII bytes → accepts() returns False: PASS
Normal notebook → accepts() returns True: PASS
Stream position restored after accepts(): PASS
```
