### PR TITLE
fix: handle UnicodeDecodeError in CsvConverter when charset detection is inaccurate (fixes #1949)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -42,10 +42,14 @@ class CsvConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Read the file content
+        file_bytes = file_stream.read()
         if stream_info.charset:
-            content = file_stream.read().decode(stream_info.charset)
+            try:
+                content = file_bytes.decode(stream_info.charset)
+            except UnicodeDecodeError:
+                content = str(from_bytes(file_bytes).best())
         else:
-            content = str(from_bytes(file_stream.read()).best())
+            content = str(from_bytes(file_bytes).best())
 
         # Parse CSV content
         reader = csv.reader(io.StringIO(content))


### PR DESCRIPTION
## Summary
`CsvConverter.decode()` uses `stream_info.charset` (detected from partial file content) to decode CSV files. When the detected charset is inaccurate (e.g., `'ascii'` from the first 4096 bytes, but the full file contains UTF-8 characters), the decode fails with `UnicodeDecodeError`.

This fix adds a fallback: if decoding with the detected charset fails, use `charset_normalizer` for automatic charset detection on the full file content.

This is the same class of bug as #1505 (PlainTextConverter), which was fixed in PR #1938.

## Issue
Fixes #1949

## Verification
- UTF-8 CSV files with non-ASCII characters now decode correctly
- Pure ASCII CSV files continue to work as before
