### PR TITLE
fix: fall back to charset_normalizer when detected charset fails to decode (fixes #1949)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -42,10 +42,14 @@ class CsvConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Read the file content
+        raw = file_stream.read()
         if stream_info.charset:
-            content = file_stream.read().decode(stream_info.charset)
+            try:
+                content = raw.decode(stream_info.charset)
+            except UnicodeDecodeError:
+                content = str(from_bytes(raw).best())
         else:
-            content = str(from_bytes(file_stream.read()).best())
+            content = str(from_bytes(raw).best())
 
         # Parse CSV content
         reader = csv.reader(io.StringIO(content))

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -63,9 +63,13 @@ class PlainTextConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
+        raw = file_stream.read()
         if stream_info.charset:
-            text_content = file_stream.read().decode(stream_info.charset)
+            try:
+                text_content = raw.decode(stream_info.charset)
+            except UnicodeDecodeError:
+                text_content = str(from_bytes(raw).best())
         else:
-            text_content = str(from_bytes(file_stream.read()).best())
+            text_content = str(from_bytes(raw).best())
 
         return DocumentConverterResult(markdown=text_content)


### PR DESCRIPTION
## Summary

Fixes UnicodeDecodeError in CsvConverter and PlainTextConverter when stream_info.charset reports a charset (e.g., 'ascii') that doesn't match the actual file content.

## Root Cause

Both converters call .decode(stream_info.charset) on the full file content. When charset detection runs on a partial file prefix (first 4096 bytes) that happens to be ASCII-only but the full file contains non-ASCII bytes (e.g., UTF-8), the decode fails with UnicodeDecodeError.

## Changes

- _csv_converter.py: Wrap .decode() in try/except, fall back to charset_normalizer on failure
- _plain_text_converter.py: Same fix (same class of bug as #1505)

Both files also now read aw bytes once instead of calling ile_stream.read() twice.

## Issue

Fixes #1949

## Verification

- Reproduction case from the issue now succeeds
- ASCII and known-charset files continue to use the fast path
- Same fix pattern verified in PR #1938 for PlainTextConverter (#1505)
