### PR TITLE
fix: remove unused mammoth import from PlainTextConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -1,18 +1,7 @@
-import sys
-
 from typing import BinaryIO, Any
 from charset_normalizer import from_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
-
-# Try loading optional (but in this case, required) dependencies
-# Save reporting of any exceptions for later
-_dependency_exc_info = None
-try:
-    import mammoth  # noqa: F401
-except ImportError:
-    # Preserve the error and stack trace for later
-    _dependency_exc_info = sys.exc_info()
 
 ACCEPTED_MIME_TYPE_PREFIXES = [
     "text/",


### PR DESCRIPTION
## Summary

Remove unused  import and  variable from .

## Problem

The  module () has an unused  import that was copy-pasted from . The import also stores  on import failure, but this variable is never checked or used anywhere in the class.

## Fix

- Remove  (no longer needed)
- Remove the  block that imports  and stores 
- Remove the associated comment block

The  only needs  for text decoding — it has no dependency on .

Fixes #1951

## Testing

- The file has no remaining references to  or 
- All other imports are still used by the  and  methods