### PR TITLE
fix: handle missing text_frame on chart title in PptxConverter (fixes #1958)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -235,7 +235,7 @@ class PptxConverter(DocumentConverter):
     def _convert_chart_to_markdown(self, chart):
         try:
             md = "\n\n### Chart"
-            if chart.has_title:
+            if chart.has_title and chart.chart_title.text_frame is not None:
                 md += f": {chart.chart_title.text_frame.text}"
             md += "\n\n"
             data = []


### PR DESCRIPTION
## Summary

Fixes AttributeError in PptxConverter when a chart title has no 	ext_frame. According to python-pptx, chart_title.text_frame can be None if the title was set via the 	ext property rather than through the rich text frame API.

## Changes

- _pptx_converter.py: Added nd chart.chart_title.text_frame is not None guard before accessing .text

## Issue

Fixes #1958

## Verification

- One-line change, trivially verified by inspection
- Existing charts with text frames are unaffected (condition is additive)
