### PR TITLE
fix: handle FileNotFoundError gracefully in exiftool_metadata() (#1960)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_exiftool.py
+++ b/packages/markitdown/src/markitdown/converters/_exiftool.py
@@ -32,18 +32,24 @@ def exiftool_metadata(
                 f"ExifTool version {version_output} is vulnerable to CVE-2021-22204. "
                 "Please upgrade to version 12.24 or later."
             )
+    except OSError:
+        # Binary not found or not executable — no metadata available
+        return {}
     except (subprocess.CalledProcessError, ValueError) as e:
         raise RuntimeError("Failed to verify ExifTool version.") from e
 
     # Run exiftool
     cur_pos = file_stream.tell()
     try:
-        output = subprocess.run(
-            [exiftool_path, "-json", "-"],
-            input=file_stream.read(),
-            capture_output=True,
-            text=False,
-        ).stdout
+        try:
+            output = subprocess.run(
+                [exiftool_path, "-json", "-"],
+                input=file_stream.read(),
+                capture_output=True,
+                text=False,
+            ).stdout
+        except OSError:
+            return {}
 
         return json.loads(
             output.decode(locale.getpreferredencoding(False)),


### PR DESCRIPTION
## Description

When `exiftool_path` is set but points to a non-existent binary, `exiftool_metadata()` crashes with an unhandled `FileNotFoundError` instead of returning an empty metadata dict or raising a clear error.

The `subprocess.run()` call on line 22 (and 41) raises `FileNotFoundError` when the binary is not found, but the `except` clause only catches `CalledProcessError` and `ValueError`.

## Root Cause

`packages/markitdown/src/markitdown/converters/_exiftool.py`, lines 21-27:
```python
try:
    version_output = subprocess.run(
        [exiftool_path, "-ver"],
        capture_output=True, text=True, check=True,
    ).stdout.strip()
    ...
except (subprocess.CalledProcessError, ValueError) as e:
    raise RuntimeError("Failed to verify ExifTool version.") from e
```

`FileNotFoundError` (when the binary doesn't exist) is a subclass of `OSError`, not `CalledProcessError` or `ValueError`, so it propagates uncaught.

## Expected Behavior

If `exiftool_path` points to a non-existent file, `exiftool_metadata()` should return an empty dict (graceful degradation) rather than crashing the entire conversion.

## Proposed Fix

Add `OSError` (parent of `FileNotFoundError`) to the except clause.
