### PR TITLE
fix: guard against None text_frame in PptxConverter chart title (fixes #1958)

### DIFF
--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -2,7 +2,7 @@ import base64
 import os
 from typing import Tuple, Dict
 from urllib.request import url2pathname
-from urllib.parse import urlparse, unquote_to_bytes
+from urllib.parse import urlparse, unquote, unquote_to_bytes
 
 
 def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
@@ -12,7 +12,7 @@ def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
         raise ValueError(f"Not a file URL: {file_uri}")
 
     netloc = parsed.netloc if parsed.netloc else None
-    path = os.path.abspath(url2pathname(parsed.path))
+    path = os.path.abspath(url2pathname(unquote(parsed.path)))
     return netloc, path
 
 

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -235,7 +235,7 @@ class PptxConverter(DocumentConverter):
     def _convert_chart_to_markdown(self, chart):
         try:
             md = "\n\n### Chart"
-            if chart.has_title:
+            if chart.has_title and chart.chart_title.text_frame is not None:
                 md += f": {chart.chart_title.text_frame.text}"
             md += "\n\n"
             data = []


### PR DESCRIPTION
PptxConverter crashes with AttributeError when chart.chart_title.text_frame is None. Added None check.