### PR TITLE
fix: handle case-mismatched zip entry names in DOCX pre-processing

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -1,3 +1,4 @@
+import struct
 import zipfile
 from io import BytesIO
 from typing import BinaryIO
@@ -28,6 +29,42 @@ MATH_ROOT_TEMPLATE = "".join(
         "{0}</w:document>",
     )
 )
+
+
+def _fix_zip_name_casing(input_docx: BinaryIO) -> BinaryIO:
+    """Fix case mismatches between zip local file headers and central directory.
+
+    Some .docx producers (certain legal document systems, older Word versions)
+    write filenames with inconsistent casing between local file headers and the
+    central directory. Python's ``zipfile`` module strictly validates this and
+    raises ``BadZipFile``. This function patches local headers to match the
+    central directory before opening the zip.
+
+    Args:
+        input_docx: A binary input stream representing the DOCX file.
+
+    Returns:
+        The original stream if no patch was needed, or a new stream with
+        corrected local header names.
+    """
+    input_docx.seek(0)
+    raw = bytearray(input_docx.read())
+    patched = False
+    with zipfile.ZipFile(BytesIO(bytes(raw)), mode="r") as zf:
+        for info in zf.infolist():
+            offset = info.header_offset
+            if raw[offset:offset + 4] != b"PK\x03\x04":
+                continue
+            fname_len = struct.unpack_from("<H", raw, offset + 26)[0]
+            local_name = raw[offset + 30:offset + 30 + fname_len]
+            central_name = info.filename.encode("utf-8")
+            if local_name != central_name and len(local_name) == len(central_name):
+                raw[offset + 30:offset + 30 + fname_len] = central_name
+                patched = True
+    if patched:
+        return BytesIO(bytes(raw))
+    input_docx.seek(0)
+    return input_docx
 
 
 def _convert_omath_to_latex(tag: Tag) -> str:
@@ -129,6 +166,7 @@ def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
     Returns:
         BinaryIO: A binary output stream representing the processed DOCX file.
     """
+    input_docx = _fix_zip_name_casing(input_docx)
     output_docx = BytesIO()
     # The files that need to be pre-processed from .docx
     pre_process_enable_files = [


### PR DESCRIPTION
## Summary

Add `_fix_zip_name_casing()` to `pre_process.py` that patches local file header names to match the central directory before opening the zip. This prevents `BadZipFile` crashes on `.docx` files where zip entry names differ in casing between local headers and central directory (common with legal document systems and older Word versions).

## Issue

Fixes #1812

## Verification

- Existing docx tests (`test_docx_comments`, `test_docx_equations`) pass
- `_fix_zip_name_casing()` runs as the first step in `pre_process_docx` with no side effects on normal files
