### PR TITLE
fix(pptx): guard against None text_frame in chart title (fixes #1958)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -235,7 +235,7 @@ class PptxConverter(DocumentConverter):
     def _convert_chart_to_markdown(self, chart):
         try:
             md = "\n\n### Chart"
-            if chart.has_title:
+            if chart.has_title and chart.chart_title.text_frame is not None:
                 md += f": {chart.chart_title.text_frame.text}"
             md += "\n\n"
             data = []


### PR DESCRIPTION
## Summary

Fix PptxConverter crash when a chart title has no \	ext_frame\ (e.g., when the title was set programmatically via the \	ext\ property rather than the rich text frame API).

## Changes

- Added \chart.chart_title.text_frame is not None\ check before accessing \.text\ in \_convert_chart_to_markdown()\

## Issue

Fixes #1958

## Verification

Code review: the fix follows the same pattern used elsewhere in the codebase for guarding against None text_frame.