### PR TITLE
fix: remove unused mammoth import from PlainTextConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -1,18 +1,7 @@
-import sys
-
 from typing import BinaryIO, Any
 from charset_normalizer import from_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
-
-# Try loading optional (but in this case, required) dependencies
-# Save reporting of any exceptions for later
-_dependency_exc_info = None
-try:
-    import mammoth  # noqa: F401
-except ImportError:
-    # Preserve the error and stack trace for later
-    _dependency_exc_info = sys.exc_info()
 
 ACCEPTED_MIME_TYPE_PREFIXES = [
     "text/",


### PR DESCRIPTION
## Summary\n\nRemove dead \mammoth\ import and unused \_dependency_exc_info\ variable from \PlainTextConverter\. This was copy-pasted from \DocxConverter\ and serves no purpose.\n\n## Issue\n\nFixes #1951\n\n## Verification\n\n- 4 PlainText-related tests pass\n- Syntax verified