### PR TITLE
fix: avoid hash None heading in WikipediaConverter when title is missing (fixes #1968)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
@@ -75,7 +75,8 @@ class WikipediaConverter(DocumentConverter):
                 main_title = title_elm.string
 
             # Convert the page
-            webpage_text = f"# {main_title}\n\n" + _CustomMarkdownify(
+            heading = f"# {main_title}\n\n" if main_title else ""
+            webpage_text = heading + _CustomMarkdownify(
                 **kwargs
             ).convert_soup(body_elm)
         else:


### PR DESCRIPTION
## Summary

Fixes a bug where WikipediaConverter renders # None as the document heading when the page has no title element or the title element is empty.

## Changes

- _wikipedia_converter.py: Changed from unconditional "# {main_title}\n\n" to a guarded assignment that only renders the heading when main_title is truthy.

## Issue

Fixes #1968

## Verification

- Code inspection confirms # None no longer appears when title is missing
- Existing behavior for pages with valid titles is unchanged
