### PR TITLE
fix: decode exiftool JSON output as UTF-8 instead of locale encoding (fixes #1972)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_exiftool.py
+++ b/packages/markitdown/src/markitdown/converters/_exiftool.py
@@ -1,5 +1,4 @@
 import json
-import locale
 import subprocess
 from typing import Any, BinaryIO, Union
 
@@ -46,7 +45,7 @@ def exiftool_metadata(
         ).stdout
 
         return json.loads(
-            output.decode(locale.getpreferredencoding(False)),
+            output.decode("utf-8"),
         )[0]
     finally:
         file_stream.seek(cur_pos)


### PR DESCRIPTION
## Summary

Fixes UnicodeDecodeError in exiftool_metadata() on systems where the locale encoding is not UTF-8 (e.g., Windows with Chinese locale cp936). ExifTool always outputs JSON in UTF-8 per RFC 8259, so decoding with locale.getpreferredencoding() is incorrect.

## Changes

- _exiftool.py: Removed unused locale import; changed output.decode(locale.getpreferredencoding(False)) to output.decode("utf-8")

## Issue

Fixes #1972

## Verification

- JSON is always UTF-8 per RFC 8259; this change aligns with that specification
- All existing exiftool tests continue to pass on UTF-8 systems (behavior unchanged)
