### PR TITLE
fix: exiftool_metadata crashes with FileNotFoundError when exiftool_path binary doesn't exist

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_exiftool.py
+++ b/packages/markitdown/src/markitdown/converters/_exiftool.py
@@ -34,6 +34,8 @@ def exiftool_metadata(
             )
     except (subprocess.CalledProcessError, ValueError) as e:
         raise RuntimeError("Failed to verify ExifTool version.") from e
+    except OSError:
+        return {}
 
     # Run exiftool
     cur_pos = file_stream.tell()


### PR DESCRIPTION
Fixes #1960