### PR TITLE
fix: initialize md_text before conditional in RSS converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -143,6 +143,7 @@ class RssConverter(DocumentConverter):
         channel_title = self._get_data_by_tag_name(channel, "title")
         channel_description = self._get_data_by_tag_name(channel, "description")
         items = channel.getElementsByTagName("item")
+        md_text = ""
         if channel_title:
             md_text = f"# {channel_title}\n"
         if channel_description:


### PR DESCRIPTION
## Summary

Initialize `md_text = ""` before the `if channel_title:` block so that RSS feeds without a `<title>` element don't crash with `UnboundLocalError`.

## Issue

Fixes #1946

## Verification

- RSS feed without `<title>` converts successfully (previously crashed)
- RSS feed with `<title>` still works correctly
