### PR TITLE
fix: handle missing oMath element in DOCX equation conversion (fixes #1979)

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -44,6 +44,8 @@ def _convert_omath_to_latex(tag: Tag) -> str:
     math_root = ET.fromstring(MATH_ROOT_TEMPLATE.format(str(tag)))
     # Find the 'oMath' element within the XML document
     math_element = math_root.find(OMML_NS + "oMath")
+    if math_element is None:
+        return str(tag)
     # Convert the 'oMath' element to LaTeX using the oMath2Latex function
     latex = oMath2Latex(math_element).latex
     return latex


### PR DESCRIPTION
## Summary

Fixes TypeError crash when a DOCX file contains a malformed equation element with no valid oMath child.

## Root Cause

In _convert_omath_to_latex(), math_root.find(OMML_NS + "oMath") returns None for malformed OMML, and passing None to oMath2Latex() raises TypeError in its constructor.

## Changes

- pre_process.py: Added if math_element is None: return str(tag) guard to gracefully fall back to the raw tag text instead of crashing.

## Issue

Fixes #1979

## Verification

- Code inspection confirms the None check prevents the crash
- Valid equations continue to be processed normally
