### PR TITLE
fix: guard against None llm_description in PptxConverter image alt text (fixes #1534)

### DIFF
--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -2,7 +2,7 @@ import base64
 import os
 from typing import Tuple, Dict
 from urllib.request import url2pathname
-from urllib.parse import urlparse, unquote_to_bytes
+from urllib.parse import urlparse, unquote, unquote_to_bytes
 
 
 def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
@@ -12,7 +12,7 @@ def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
         raise ValueError(f"Not a file URL: {file_uri}")
 
     netloc = parsed.netloc if parsed.netloc else None
-    path = os.path.abspath(url2pathname(parsed.path))
+    path = os.path.abspath(url2pathname(unquote(parsed.path)))
     return netloc, path
 
 

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -235,7 +235,7 @@ class PptxConverter(DocumentConverter):
     def _convert_chart_to_markdown(self, chart):
         try:
             md = "\n\n### Chart"
-            if chart.has_title:
+            if chart.has_title and chart.chart_title.text_frame is not None:
                 md += f": {chart.chart_title.text_frame.text}"
             md += "\n\n"
             data = []

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -136,7 +136,7 @@ class PptxConverter(DocumentConverter):
                         pass
 
                     # Prepare the alt, escaping any special characters
-                    alt_text = "\n".join([llm_description, alt_text]) or shape.name
+                    alt_text = "\n".join([llm_description or "", alt_text]) or shape.name
                     alt_text = re.sub(r"[\r\n\[\]]", " ", alt_text)
                     alt_text = re.sub(r"\s+", " ", alt_text).strip()
 


### PR DESCRIPTION
PptxConverter crashes with TypeError when llm_caption() returns None. Fix: add or empty string guard before join().