### PR TITLE
fix: handle None title in WikipediaConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
@@ -75,7 +75,8 @@ class WikipediaConverter(DocumentConverter):
                 main_title = title_elm.string
 
             # Convert the page
-            webpage_text = f"# {main_title}\n\n" + _CustomMarkdownify(
+            heading = f"# {main_title}\n\n" if main_title else ""
+            webpage_text = heading + _CustomMarkdownify(
                 **kwargs
             ).convert_soup(body_elm)
         else:


### PR DESCRIPTION
## Summary

Guard against `main_title` being `None` when building the Wikipedia page heading, so pages without a title don't render `# None`.

## Issue

Fixes #1968

## Verification

- Wikipedia page without title: no `# None` heading
- Wikipedia page with title: heading still shown
