### PR TITLE
fix(docx): guard against None oMath element in malformed equations (fixes #1979)

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -44,6 +44,9 @@ def _convert_omath_to_latex(tag: Tag) -> str:
     math_root = ET.fromstring(MATH_ROOT_TEMPLATE.format(str(tag)))
     # Find the 'oMath' element within the XML document
     math_element = math_root.find(OMML_NS + "oMath")
+    # Guard against malformed equations where the oMath element is missing
+    if math_element is None:
+        return ""
     # Convert the 'oMath' element to LaTeX using the oMath2Latex function
     latex = oMath2Latex(math_element).latex
     return latex


### PR DESCRIPTION
## Summary

Fix DOCX math converter crash when an equation element has no valid \oMath\ child (malformed OMML).

## Changes

- Added None guard in \_convert_omath_to_latex()\ in \converter_utils/docx/pre_process.py\
- When \math_root.find()\ returns None, returns empty string instead of crashing

## Issue

Fixes #1979

## Verification

Code review: the 3-line guard matches the proposed fix in the issue.