### PR TITLE
fix: fall back to operatorname for unknown math functions instead of crashing (fixes #1982)

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -272,7 +272,7 @@ class oMath2Latex(Tag2Method):
                 if FUNC.get(t):
                     latex_chars.append(FUNC[t])
                 else:
-                    raise NotImplementedError("Not support func %s" % t)
+                    latex_chars.append(f"\\operatorname{{{t}}}({FUNC_PLACE})")
             else:
                 latex_chars.append(t)
         t = BLANK.join(latex_chars)


### PR DESCRIPTION
## Summary

Fixes NotImplementedError crash when the DOCX math converter encounters a function name not in the hardcoded FUNC dictionary (e.g., log, ln, exp, det, gcd, lcm).

## Root Cause

In omml.py:275, do_fname() raises NotImplementedError for any function not in the FUNC dict, which only contains 13 basic trig functions. Common functions like log, ln, exp, etc. cause the entire DOCX conversion to crash.

## Changes

- omml.py: Changed from raising NotImplementedError to falling back with \operatorname{name}(expr) LaTeX rendering

## Issue

Fixes #1982

## Verification

- Unknown functions now render as \operatorname{name} in LaTeX output
- Known functions (sin, cos, etc.) continue to use their dedicated commands
