### PR TITLE
fix: handle RSS feeds without channel titles

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -143,6 +143,7 @@ class RssConverter(DocumentConverter):
         channel_title = self._get_data_by_tag_name(channel, "title")
         channel_description = self._get_data_by_tag_name(channel, "description")
         items = channel.getElementsByTagName("item")
+        md_text = ""
         if channel_title:
             md_text = f"# {channel_title}\n"
         if channel_description:

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -288,6 +288,26 @@ def test_input_as_strings() -> None:
     assert "# Test" in result.text_content
 
 
+def test_rss_without_channel_title() -> None:
+    markitdown = MarkItDown()
+    feed = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <description>Updates without a channel title</description>
+    <item>
+      <title>First item</title>
+      <description>Item body</description>
+    </item>
+  </channel>
+</rss>"""
+
+    result = markitdown.convert_stream(io.BytesIO(feed), file_extension=".rss")
+
+    assert "Updates without a channel title" in result.text_content
+    assert "## First item" in result.text_content
+    assert "Item body" in result.text_content
+
+
 def test_deeply_nested_html_fallback() -> None:
     """Large, deeply nested HTML should fall back to plain-text extraction
     instead of silently returning unconverted HTML (issue #1636).


### PR DESCRIPTION
﻿Fixes #1946.

## Summary
- initialize RSS markdown output before optional channel title handling
- keep channel descriptions and items when the channel title is missing
- add a regression test for untitled RSS feeds

## Verification
- `.\.venv\Scripts\python.exe -m pytest packages\markitdown\tests\test_module_misc.py::test_rss_without_channel_title -q`
- `.\.venv\Scripts\python.exe -m py_compile packages\markitdown\src\markitdown\converters\_rss_converter.py packages\markitdown\tests\test_module_misc.py`
- `git diff --check`
