### PR TITLE
fix: handle missing oMath element in DOCX math converter (fixes #1979)

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -44,6 +44,8 @@ def _convert_omath_to_latex(tag: Tag) -> str:
     math_root = ET.fromstring(MATH_ROOT_TEMPLATE.format(str(tag)))
     # Find the 'oMath' element within the XML document
     math_element = math_root.find(OMML_NS + "oMath")
+    if math_element is None:
+        return ""
     # Convert the 'oMath' element to LaTeX using the oMath2Latex function
     latex = oMath2Latex(math_element).latex
     return latex


### PR DESCRIPTION
## Summary

`_convert_omath_to_latex()` in `pre_process.py` crashes with `TypeError` when an equation element has no valid `oMath` child. The `math_root.find()` call returns `None` for malformed OMML, and `oMath2Latex(None)` raises an unhandled exception.

This fix adds a `None` check after `math_root.find()`, returning an empty string as fallback. One bad equation no longer fails the entire document conversion.

## Issue

Fixes #1979

## Verification

- 6/7 existing tests pass (1 pre-existing failure due to missing outlook dependency)
- Code compiles and imports cleanly
