### PR TITLE
fix: render unknown math functions as \\operatorname instead of crashing (#1982)

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -272,7 +272,7 @@ class oMath2Latex(Tag2Method):
                 if FUNC.get(t):
                     latex_chars.append(FUNC[t])
                 else:
-                    raise NotImplementedError("Not support func %s" % t)
+                    latex_chars.append("\\operatorname{%s}%s" % (t, FUNC_PLACE))
             else:
                 latex_chars.append(t)
         t = BLANK.join(latex_chars)


### PR DESCRIPTION
## Summary

Fix #1982: When the OMML-to-LaTeX converter encounters a math function not in the hardcoded FUNC dictionary (e.g., log, ln, exp, det, gcd, lcm), it now renders it as `\operatorname{func_name}` instead of raising NotImplementedError and crashing the entire DOCX conversion.

## Changes

In `packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py`:
- Replaced `raise NotImplementedError("Not support func %s" % t)` with a fallback that renders the unknown function name as `\operatorname{func_name}{argument}`

## Issue

Fixes #1982
