### PR TITLE
fix: keep pptx charts without title text frames

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -236,7 +236,10 @@ class PptxConverter(DocumentConverter):
         try:
             md = "\n\n### Chart"
             if chart.has_title:
-                md += f": {chart.chart_title.text_frame.text}"
+                title_frame = chart.chart_title.text_frame
+                title_text = title_frame.text if title_frame is not None else ""
+                if title_text:
+                    md += f": {title_text}"
             md += "\n\n"
             data = []
             category_names = [c.label for c in chart.plots[0].categories]

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -4,9 +4,11 @@ import os
 import re
 import shutil
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from markitdown._uri_utils import parse_data_uri, file_uri_to_path
+from markitdown.converters import PptxConverter
 
 from markitdown import (
     MarkItDown,
@@ -530,6 +532,21 @@ def test_markitdown_llm() -> None:
         assert test_string in result.text_content
     # Standard alt text is included
     validate_strings(result, PPTX_TEST_STRINGS)
+
+
+def test_pptx_chart_title_without_text_frame_keeps_chart_data() -> None:
+    chart = MagicMock()
+    chart.has_title = True
+    chart.chart_title.text_frame = None
+    chart.plots = [SimpleNamespace(categories=[SimpleNamespace(label="FY2026")])]
+    chart.series = [SimpleNamespace(name="Revenue", values=[42])]
+
+    result = PptxConverter()._convert_chart_to_markdown(chart)
+
+    assert "[unsupported chart]" not in result
+    assert "### Chart\n\n" in result
+    assert "| Category | Revenue |" in result
+    assert "| FY2026 | 42 |" in result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary
- skip the PPTX chart title text only when python-pptx exposes no title text frame
- keep converting the chart data table instead of falling back to `[unsupported chart]`
- add a regression test for a titled chart whose `chart_title.text_frame` is `None`

Fixes #1958.

## To verify
- `python -m pytest packages\markitdown\tests\test_module_misc.py -q -k "pptx_chart_title_without_text_frame or exceptions"`
- `python -m py_compile packages\markitdown\src\markitdown\converters\_pptx_converter.py packages\markitdown\tests\test_module_misc.py`
- `git diff --check`
