### PR TITLE
fix: preserve malformed docx math content

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -272,7 +272,9 @@ class oMath2Latex(Tag2Method):
                 if FUNC.get(t):
                     latex_chars.append(FUNC[t])
                 else:
-                    raise NotImplementedError("Not support func %s" % t)
+                    latex_chars.append(
+                        "\\operatorname{%s}(%s)" % (escape_latex(t), FUNC_PLACE)
+                    )
             else:
                 latex_chars.append(t)
         t = BLANK.join(latex_chars)

--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -44,6 +44,8 @@ def _convert_omath_to_latex(tag: Tag) -> str:
     math_root = ET.fromstring(MATH_ROOT_TEMPLATE.format(str(tag)))
     # Find the 'oMath' element within the XML document
     math_element = math_root.find(OMML_NS + "oMath")
+    if math_element is None:
+        return tag.get_text("", strip=True)
     # Convert the 'oMath' element to LaTeX using the oMath2Latex function
     latex = oMath2Latex(math_element).latex
     return latex

--- a/packages/markitdown/tests/test_docx_math.py
+++ b/packages/markitdown/tests/test_docx_math.py
@@ -1,0 +1,26 @@
+from bs4 import BeautifulSoup
+from defusedxml import ElementTree as ET
+
+from markitdown.converter_utils.docx.math.omml import oMath2Latex
+from markitdown.converter_utils.docx.pre_process import _convert_omath_to_latex
+
+
+def test_convert_omath_without_namespaced_child_returns_text() -> None:
+    soup = BeautifulSoup(b"<oMath><r><t>x</t></r></oMath>", "xml")
+
+    assert _convert_omath_to_latex(soup.find("oMath")) == "x"
+
+
+def test_unknown_omml_function_uses_operatorname() -> None:
+    root = ET.fromstring(
+        """
+        <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+          <m:func>
+            <m:fName><m:r><m:t>log</m:t></m:r></m:fName>
+            <m:e><m:r><m:t>x</m:t></m:r></m:e>
+          </m:func>
+        </m:oMath>
+        """
+    )
+
+    assert oMath2Latex(root).latex == r"\operatorname{log}(x)"


### PR DESCRIPTION
﻿## Summary
- keep malformed OMML tags from crashing the DOCX math preprocessor when no namespaced `oMath` child is found
- render unknown OMML function names with `\operatorname{...}` instead of raising `NotImplementedError`
- add focused regression tests for the missing-child and unknown-function paths

Fixes #1979.
Fixes #1982.

## To verify
- `$env:PYTHONPATH=(Resolve-Path packages\markitdown\src).Path; python -m pytest packages\markitdown\tests\test_docx_math.py -q`
- `python -m py_compile packages\markitdown\src\markitdown\converter_utils\docx\pre_process.py packages\markitdown\src\markitdown\converter_utils\docx\math\omml.py packages\markitdown\tests\test_docx_math.py`
- `git diff --check`
