### PR TITLE
Add 30s timeout to requests.get() HTTP call

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -472,7 +472,7 @@ class MarkItDown:
             )
         # HTTP/HTTPS URIs
         elif uri.startswith("http:") or uri.startswith("https:"):
-            response = self._requests_session.get(uri, stream=True)
+            response = self._requests_session.get(uri, stream=True, timeout=30)
             response.raise_for_status()
             return self.convert_response(
                 response,


### PR DESCRIPTION
## Description

The `convert_uri()` method in MarkItDown makes a `requests.get()` call with `stream=True` but no timeout. This means a request to a slow or malicious server can hang indefinitely, blocking the process.

Added `timeout=30` to the call at `_markitdown.py:475`. This matches standard practice — `requests` itself has no default timeout, which is a well-known footgun. 30 seconds is generous enough for large files while preventing indefinite hangs.