### PR TITLE
fix: ignore missing exiftool binary

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_exiftool.py
+++ b/packages/markitdown/src/markitdown/converters/_exiftool.py
@@ -32,6 +32,8 @@ def exiftool_metadata(
                 f"ExifTool version {version_output} is vulnerable to CVE-2021-22204. "
                 "Please upgrade to version 12.24 or later."
             )
+    except FileNotFoundError:
+        return {}
     except (subprocess.CalledProcessError, ValueError) as e:
         raise RuntimeError("Failed to verify ExifTool version.") from e
 
@@ -48,5 +50,7 @@ def exiftool_metadata(
         return json.loads(
             output.decode(locale.getpreferredencoding(False)),
         )[0]
+    except FileNotFoundError:
+        return {}
     finally:
         file_stream.seek(cur_pos)

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from markitdown._uri_utils import parse_data_uri, file_uri_to_path
+from markitdown.converters._exiftool import exiftool_metadata
 
 from markitdown import (
     MarkItDown,
@@ -460,6 +461,21 @@ def test_markitdown_exiftool() -> None:
     for key in MP3_TEST_EXIFTOOL:
         target = f"{key}: {MP3_TEST_EXIFTOOL[key]}"
         assert target in result.text_content
+
+
+def test_exiftool_metadata_ignores_missing_binary() -> None:
+    stream = io.BytesIO(b"not really an image")
+
+    assert exiftool_metadata(stream, exiftool_path="missing-exiftool-binary") == {}
+    assert stream.tell() == 0
+
+
+def test_markitdown_missing_exiftool_path_keeps_image_conversion() -> None:
+    markitdown = MarkItDown(exiftool_path="missing-exiftool-binary")
+
+    result = markitdown.convert(os.path.join(TEST_FILES_DIR, "test.jpg"))
+
+    assert result.text_content == ""
 
 
 def test_markitdown_llm_parameters() -> None:


### PR DESCRIPTION
﻿## Summary
- treat a missing explicit `exiftool_path` the same way as no exiftool metadata being available
- keep image conversion from failing when the configured binary no longer exists
- add coverage for the helper and the image conversion path

Fixes #1960.

## To verify
- `.venv\Scripts\python.exe -m pytest packages/markitdown/tests/test_module_misc.py -q -k "missing_exiftool_path or exiftool_metadata_ignores_missing_binary or exceptions"`
- `.venv\Scripts\python.exe -m py_compile packages/markitdown/src/markitdown/converters/_exiftool.py packages/markitdown/tests/test_module_misc.py`
- `git diff --check`
