### PR TITLE
 adds ENV PYTHONDONTWRITEBYTECODE=1 to the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,9 @@ ARG GROUPID=nogroup
 
 USER $USERID:$GROUPID
 
+#Prevent Python from writing .pyc files and __pycache__ folders to disk
+#Make the runtime faster
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
 ENTRYPOINT [ "markitdown" ]


### PR DESCRIPTION
It stops Python from creating .pyc files and pycache folders every time code runs inside the container. This keeps the filesystem cleaner, avoids pointless disk writes (especially useful with read-only mounts or tmpfs), reduces permission headaches.