### PR TITLE
fix: fallback when CSV charset hint fails

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -42,10 +42,14 @@ class CsvConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Read the file content
+        data = file_stream.read()
         if stream_info.charset:
-            content = file_stream.read().decode(stream_info.charset)
+            try:
+                content = data.decode(stream_info.charset)
+            except UnicodeDecodeError:
+                content = str(from_bytes(data).best())
         else:
-            content = str(from_bytes(file_stream.read()).best())
+            content = str(from_bytes(data).best())
 
         # Parse CSV content
         reader = csv.reader(io.StringIO(content))

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -220,6 +220,20 @@ def test_data_uris() -> None:
     assert data == b"Hello, World!"
 
 
+def test_csv_falls_back_when_charset_hint_fails() -> None:
+    content = ("x" * 4096 + ",café\n").encode("utf-8")
+    result = MarkItDown().convert(
+        io.BytesIO(content),
+        stream_info=StreamInfo(
+            extension=".csv",
+            mimetype="text/csv",
+            charset="ascii",
+        ),
+    )
+
+    assert "café" in result.markdown
+
+
 def test_file_uris() -> None:
     # Test file URI with an empty host
     file_uri = "file:///path/to/file.txt"


### PR DESCRIPTION
## Summary
- read CSV input bytes once before decoding
- fall back to charset-normalizer when a provided charset hint raises UnicodeDecodeError
- add a regression test for an ASCII hint on UTF-8 CSV content with non-ASCII text after the initial ASCII prefix

Fixes #1949

## Tests
- `uv run --with pytest python -m pytest tests/test_module_misc.py::test_csv_falls_back_when_charset_hint_fails`
- `uv run --with pytest python -m pytest tests/test_module_misc.py::test_csv_falls_back_when_charset_hint_fails tests/test_module_vectors.py -k 'csv or mskanji'`