### PR TITLE
fix: catch UnicodeDecodeError in IpynbConverter.accepts() for non-ASCII files

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -38,6 +38,8 @@ class IpynbConverter(DocumentConverter):
                         "nbformat" in notebook_content
                         and "nbformat_minor" in notebook_content
                     )
+                except (UnicodeDecodeError, ValueError):
+                    return False
                 finally:
                     file_stream.seek(cur_pos)
 


### PR DESCRIPTION
## Summary

- `IpynbConverter.accepts()` crashed the entire conversion pipeline with `UnicodeDecodeError` when encountering non-ASCII files (e.g. French PDFs with `é`, `è`, `à` characters) whose MIME type starts with `application/json`.
- The `try/finally` block decoded the file stream but had no `except`, so the error propagated uncaught.
- Added `except (UnicodeDecodeError, ValueError): return False` so non-decodable files are gracefully rejected instead of crashing.

Fixes #1894.

## Test plan

- [ ] Convert a non-ASCII file (e.g. a PDF with French/accented text) — should no longer raise `UnicodeDecodeError`
- [ ] Convert a valid `.ipynb` notebook — should still work correctly
- [ ] Convert a file with `application/json` MIME type that is not a notebook — should return `False` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)