### PR TITLE
fix(csv): escape pipe characters in CsvConverter to produce valid Markdown tables

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -57,20 +57,23 @@ class CsvConverter(DocumentConverter):
         # Create markdown table
         markdown_table = []
 
+        def _escape_cell(value: str) -> str:
+            """Escape pipe characters so they don't break GFM table structure."""
+            value = value.replace("|", r"\|")
+            return value
+
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        markdown_table.append("| " + " | ".join(_escape_cell(c) for c in rows[0]) + " |")
 
         # Add separator row
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
 
         # Add data rows
         for row in rows[1:]:
-            # Make sure row has the same number of columns as header
             while len(row) < len(rows[0]):
                 row.append("")
-            # Truncate if row has more columns than header
             row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+            markdown_table.append("| " + " | ".join(_escape_cell(c) for c in row) + " |")
 
         result = "\n".join(markdown_table)
 


### PR DESCRIPTION
## What this fixes

Fixes #2019 

`CsvConverter` was joining raw cell values with ` | ` without escaping.
Any cell containing a literal `|` was treated as a column separator,
silently corrupting the table structure.

## Change

Added a small `_escape_cell()` helper in `_csv_converter.py` that
escapes `|` → `\|` before each cell is joined into a table row.

## Before
| OR gate | A | B |   ← 4 columns, broken

## After
| OR gate | A | B |  ← 2 columns, correct

## Testing
- Tested with pipe in header and data rows
- Tested normal CSV (no regression)
- Tested empty CSV and header-only CSV