### PR TITLE
feat: add TSV support and delimiter auto-detection to CsvConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -8,13 +8,17 @@ from .._stream_info import StreamInfo
 ACCEPTED_MIME_TYPE_PREFIXES = [
     "text/csv",
     "application/csv",
+    "text/tab-separated-values",
+    "text/tsv",
 ]
-ACCEPTED_FILE_EXTENSIONS = [".csv"]
+ACCEPTED_FILE_EXTENSIONS = [".csv", ".tsv"]
+
+SNIFF_SAMPLE_SIZE = 8192
 
 
 class CsvConverter(DocumentConverter):
     """
-    Converts CSV files to Markdown tables.
+    Converts CSV and TSV files to Markdown tables.
     """
 
     def __init__(self):
@@ -47,8 +51,12 @@ class CsvConverter(DocumentConverter):
         else:
             content = str(from_bytes(file_stream.read()).best())
 
-        # Parse CSV content
-        reader = csv.reader(io.StringIO(content))
+        # Auto-detect the delimiter
+        extension = (stream_info.extension or "").lower()
+        delimiter = self._detect_delimiter(content, extension)
+
+        # Parse content
+        reader = csv.reader(io.StringIO(content), delimiter=delimiter)
         rows = list(reader)
 
         if not rows:
@@ -57,8 +65,9 @@ class CsvConverter(DocumentConverter):
         # Create markdown table
         markdown_table = []
 
-        # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        # Add header row (with pipe escaping)
+        header = [self._escape_cell(cell) for cell in rows[0]]
+        markdown_table.append("| " + " | ".join(header) + " |")
 
         # Add separator row
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
@@ -70,8 +79,24 @@ class CsvConverter(DocumentConverter):
                 row.append("")
             # Truncate if row has more columns than header
             row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+            escaped = [self._escape_cell(cell) for cell in row]
+            markdown_table.append("| " + " | ".join(escaped) + " |")
 
         result = "\n".join(markdown_table)
 
         return DocumentConverterResult(markdown=result)
+
+    def _detect_delimiter(self, content: str, extension: str) -> str:
+        """Auto-detect the delimiter using csv.Sniffer, with sensible fallbacks."""
+        try:
+            sample = content[:SNIFF_SAMPLE_SIZE]
+            dialect = csv.Sniffer().sniff(sample)
+            return dialect.delimiter
+        except csv.Error:
+            if extension == ".tsv":
+                return "\t"
+            return ","
+
+    def _escape_cell(self, cell: str) -> str:
+        """Escape characters that would break a Markdown table."""
+        return cell.replace("|", "\\|").replace("\n", " ").replace("\r", "")

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -153,6 +153,20 @@ GENERAL_TEST_VECTORS = [
         must_not_include=[],
     ),
     FileTestVector(
+        filename="test.tsv",
+        mimetype="text/tsv",
+        charset="ascii",
+        url=None,
+        must_include=[
+            "| Name | Age | City | Notes |",
+            "| --- | --- | --- | --- |",
+            "| Alice | 30 | New York | Likes coffee |",
+            "| Bob | 25 | San Francisco | Uses pipes \\| often |",
+            "| Charlie | 35 | Chicago | N/A |",
+        ],
+        must_not_include=[],
+    ),
+    FileTestVector(
         filename="test.json",
         mimetype="application/json",
         charset="ascii",

--- a/packages/markitdown/tests/test_files/test.tsv
+++ b/packages/markitdown/tests/test_files/test.tsv
@@ -1,0 +1,4 @@
+Name	Age	City	Notes
+Alice	30	New York	Likes coffee
+Bob	25	San Francisco	Uses pipes | often
+Charlie	35	Chicago	N/A


### PR DESCRIPTION
## Summary

- Extend `CsvConverter` to accept `.tsv` files and `text/tab-separated-values` / `text/tsv` MIME types
- Auto-detect delimiters using `csv.Sniffer` with sensible fallbacks (tab for `.tsv`, comma otherwise)
- Escape pipe characters (`|`) and newlines in cell values to prevent broken Markdown tables (also addresses #2019)

## Motivation

TSV (Tab-Separated Values) files are extremely common in data science, bioinformatics, and LLM pipelines, but are not currently supported by MarkItDown. This is a natural extension of the existing CSV converter.

## Changes

- **`_csv_converter.py`**: Added `.tsv` extension and TSV MIME types to accepted formats. Added `_detect_delimiter()` using `csv.Sniffer` for auto-detection with fallbacks. Added `_escape_cell()` to escape pipe characters and newlines in cell values.
- **`test_files/test.tsv`**: New test file with tab-delimited data including a pipe character in a cell value.
- **`_test_vectors.py`**: New `FileTestVector` for TSV conversion with `must_include` checks.

## Test plan

- [x] All 312 existing tests pass (0 failures)
- [x] New TSV test vector passes across all test modes (`convert_local`, `convert_stream_with_hints`, `convert_stream_without_hints`, `convert_file_uri`, `convert_data_uri`)
- [x] Existing CSV test (`test_mskanji.csv`) continues to pass — delimiter auto-detected as comma
- [x] Pipe character in TSV cell correctly escaped as `\|` in output