### PR TITLE
Escape pipes and newlines in CSV to Markdown table cells

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -12,6 +12,14 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ACCEPTED_FILE_EXTENSIONS = [".csv"]
 
 
+def _escape_cell(value: str) -> str:
+    # A literal pipe or newline inside a cell would split it into extra
+    # columns or rows when rendered, so escape pipes and flatten newlines.
+    return value.replace("|", "\\|").replace("\r\n", " ").replace("\n", " ").replace(
+        "\r", " "
+    )
+
+
 class CsvConverter(DocumentConverter):
     """
     Converts CSV files to Markdown tables.
@@ -58,7 +66,9 @@ class CsvConverter(DocumentConverter):
         markdown_table = []
 
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        markdown_table.append(
+            "| " + " | ".join(_escape_cell(cell) for cell in rows[0]) + " |"
+        )
 
         # Add separator row
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
@@ -70,7 +80,9 @@ class CsvConverter(DocumentConverter):
                 row.append("")
             # Truncate if row has more columns than header
             row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+            markdown_table.append(
+                "| " + " | ".join(_escape_cell(cell) for cell in row) + " |"
+            )
 
         result = "\n".join(markdown_table)
 

--- a/packages/markitdown/tests/test_csv_converter.py
+++ b/packages/markitdown/tests/test_csv_converter.py
@@ -1,0 +1,29 @@
+import io
+
+from markitdown.converters._csv_converter import CsvConverter
+from markitdown._stream_info import StreamInfo
+
+CSV_STREAM_INFO = StreamInfo(extension=".csv", mimetype="text/csv")
+
+
+def _convert(data: bytes) -> str:
+    return CsvConverter().convert(io.BytesIO(data), CSV_STREAM_INFO).markdown
+
+
+def test_pipe_in_cell_is_escaped():
+    markdown = _convert(b"name,note\nAlice,a|b\nBob,plain\n")
+    lines = markdown.splitlines()
+    # Header, separator and two data rows.
+    assert len(lines) == 4
+    # Every row must have the same number of unescaped column separators.
+    expected_pipes = lines[0].count("|")
+    for line in lines:
+        assert line.replace("\\|", "").count("|") == expected_pipes
+    assert "a\\|b" in markdown
+
+
+def test_newline_in_cell_does_not_break_row():
+    markdown = _convert(b'name,note\n"Bob","line1\nline2"\n')
+    lines = markdown.splitlines()
+    assert len(lines) == 3
+    assert "line1 line2" in lines[2]


### PR DESCRIPTION
## Summary

`CsvConverter` writes cell values straight into the Markdown table without escaping. Two cases produce malformed output:

- A cell containing a literal `|` adds an extra column separator.
- A quoted CSV field with an embedded newline (valid CSV) splits the row in two.

In both cases the data rows no longer match the header column count, so the table renders incorrectly.

## Reproduction

```
input:  name,note\nAlice,a|b\nBob,plain
```

The `Alice` row renders as three columns instead of two. A quoted multi-line field like `"line1\nline2"` similarly breaks into two rows.

## Fix

Added an `_escape_cell` helper that escapes `|` as `\|` and flattens `\r\n` / `\n` / `\r` to spaces, applied to header and data cells.

```
| Alice | a\|b |
| Bob | line1 line2 |
```

## Tests

Added `packages/markitdown/tests/test_csv_converter.py` with `test_pipe_in_cell_is_escaped` (asserts every row has equal unescaped pipe count) and `test_newline_in_cell_does_not_break_row`. Both fail on the unpatched converter and pass after the change. The existing module test vectors still pass.

```
$ python -m pytest tests/test_csv_converter.py -q
2 passed
```

---
Developed with AI assistance and verified locally as described above.