### PR TITLE
Handle percent-encoded EPUB manifest hrefs

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_epub_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_epub_converter.py
@@ -2,6 +2,7 @@ import os
 import zipfile
 from defusedxml import minidom
 from xml.dom.minidom import Document
+from urllib.parse import unquote, urljoin, urlparse
 
 from typing import BinaryIO, Any, Dict, List
 
@@ -88,11 +89,8 @@ class EpubConverter(HtmlConverter):
             spine_order = [item.getAttribute("idref") for item in spine_items]
 
             # Convert spine order to actual file paths
-            base_path = "/".join(
-                opf_path.split("/")[:-1]
-            )  # Get base directory of content.opf
             spine = [
-                f"{base_path}/{manifest[item_id]}" if base_path else manifest[item_id]
+                self._resolve_manifest_href(opf_path, manifest[item_id])
                 for item_id in spine_order
                 if item_id in manifest
             ]
@@ -144,3 +142,9 @@ class EpubConverter(HtmlConverter):
             if node.firstChild and hasattr(node.firstChild, "nodeValue"):
                 texts.append(node.firstChild.nodeValue.strip())
         return texts
+
+    def _resolve_manifest_href(self, opf_path: str, href: str) -> str:
+        """Resolve a manifest href relative to the OPF file into a ZIP member path."""
+        base_uri = f"{'/'.join(opf_path.split('/')[:-1])}/" if "/" in opf_path else ""
+        parsed = urlparse(urljoin(base_uri, href))
+        return unquote(parsed.path)

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -3,6 +3,7 @@ import io
 import os
 import re
 import shutil
+import zipfile
 import pytest
 from unittest.mock import MagicMock
 
@@ -250,6 +251,45 @@ def test_file_uris() -> None:
     netloc, path = file_uri_to_path(file_uri)
     assert netloc is None
     assert path == "/path/to/file.txt"
+
+
+def test_epub_percent_encoded_manifest_href() -> None:
+    epub = io.BytesIO()
+    with zipfile.ZipFile(epub, "w") as z:
+        z.writestr(
+            "META-INF/container.xml",
+            """<?xml version="1.0"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles>
+    <rootfile full-path="OPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>""",
+        )
+        z.writestr(
+            "OPS/content.opf",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bookid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Encoded href test</dc:title>
+  </metadata>
+  <manifest>
+    <item id="chapter" href="chapter%201.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="chapter"/></spine>
+</package>""",
+        )
+        z.writestr(
+            "OPS/chapter 1.xhtml",
+            """<html xmlns="http://www.w3.org/1999/xhtml">
+<body><h1>Encoded Chapter</h1><p>visible text marker</p></body>
+</html>""",
+        )
+
+    epub.seek(0)
+    result = MarkItDown().convert(epub, stream_info=StreamInfo(extension=".epub"))
+
+    assert "Encoded Chapter" in result.markdown
+    assert "visible text marker" in result.markdown
 
 
 def test_docx_comments() -> None:


### PR DESCRIPTION
## Summary

EPUB manifest `href` values are URI references, so filenames containing spaces or other escaped characters can appear as percent-encoded paths such as `chapter%201.xhtml`.

The current converter compares those raw href values against ZIP member names, which means a valid EPUB containing `OPS/chapter 1.xhtml` can silently omit the chapter content.

This PR resolves manifest hrefs relative to the OPF file and decodes the URI path before matching ZIP members.

## Changes

- Resolve EPUB spine item hrefs via `urljoin` relative to the OPF path.
- Decode percent-encoded URI paths before looking up ZIP members.
- Add a regression test with `href="chapter%201.xhtml"` and ZIP member `chapter 1.xhtml`.

## Verification

- `python -m pytest tests/test_module_vectors.py::test_convert_local[test_vector14] tests/test_module_vectors.py::test_convert_stream_with_hints[test_vector14] tests/test_module_misc.py::test_epub_percent_encoded_manifest_href -q`
- `python -m black --check src/markitdown/converters/_epub_converter.py tests/test_module_misc.py`
- `git diff --check`

I also ran broader vector tests locally, but this environment only has core dependencies installed. Vectors requiring optional extras such as `docx`, `xlsx`, `pdf`, and `outlook` fail with missing optional dependency errors unrelated to this EPUB change.