### PR TITLE
docs: remove spaces in pip extras specifier example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cat path-to-file.pdf | markitdown
 MarkItDown has optional dependencies for activating various file formats. Earlier in this document, we installed all optional dependencies with the `[all]` option. However, you can also install them individually for more control. For example:
 
 ```bash
-pip install 'markitdown[pdf, docx, pptx]'
+pip install 'markitdown[pdf,docx,pptx]'
 ```
 
 will install only the dependencies for PDF, DOCX, and PPTX files.


### PR DESCRIPTION
Fix pip install example: remove spaces inside extras brackets.