### PR TITLE
zip protection to zip converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -25,6 +25,8 @@ ZIP_UNCOMPRESSED_SIZE_THRESHOLD = 500
 
 class ZipConverter(DocumentConverter):
     """Converts ZIP files to markdown by extracting and converting all contained files.
+    
+    Before extracting markdown validate no zip bomb exist in zip file
 
     The converter extracts the ZIP contents to a temporary directory, processes each file
     using appropriate converters based on file extensions, and then combines the results
@@ -107,7 +109,7 @@ class ZipConverter(DocumentConverter):
                 track_uncompressed += file.file_size
                 #check for zip bomb
                 if track_uncompressed > ZIP_UNCOMPRESSED_SIZE_THRESHOLD:
-                    raise FileConversionException(message= "total zip uncmpressed exceeds compressed by threshold")
+                    raise FileConversionException(message= "total zip uncompressed exceeds compressed by threshold")
 
 
 

--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -4,9 +4,6 @@ import os
 
 from typing import BinaryIO, Any, TYPE_CHECKING
 
-from packages.markitdown.src.markitdown._exceptions import FileConversionException
-from packages.markitdown.src.markitdown.converters._zip_converter import (
-    ZIP_UNCOMPRESSED_SIZE_THRESHOLD)
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
 from .._exceptions import UnsupportedFormatException, FileConversionException
@@ -21,7 +18,9 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 
 ACCEPTED_FILE_EXTENSIONS = [".zip"]
 
-ZIP_UNCOMPRESSED_SIZE_THRESHOLD = 500
+ZIP_UNCOMPRESSED_SIZE_THRESHOLD = 100 * 1024 * 1024  # 100 MB
+MAX_FILE_COUNT = 1000
+MAX_DEPTH = 3
 
 class ZipConverter(DocumentConverter):
     """Converts ZIP files to markdown by extracting and converting all contained files.
@@ -94,17 +93,24 @@ class ZipConverter(DocumentConverter):
         self,
         file_stream: BinaryIO,
         stream_info: StreamInfo,
+        *,
+        _depth = 0,
         **kwargs: Any,  # Options to pass to the converter
+
     ) -> DocumentConverterResult:
+        #base case recursion
+        if _depth > MAX_DEPTH:
+            raise FileConversionException(message="Max zip nesting depth exceeded")
+        
         file_path = stream_info.url or stream_info.local_path or stream_info.filename
         md_content = f"Content from the zip file `{file_path}`:\n\n"
 
-#files in zip more than 10000 files
-#zips in zips dont recurse forever , depth counter/limit
-
-
         with zipfile.ZipFile(file_stream, "r") as zipObj:
             track_uncompressed = 0
+
+            if len(zipObj.namelist()) > MAX_FILE_COUNT:
+                raise FileConversionException(message="Too many files in zip")
+
             for file in zipObj.infolist():
                 track_uncompressed += file.file_size
                 #check for zip bomb
@@ -123,6 +129,7 @@ class ZipConverter(DocumentConverter):
                     result = self._markitdown.convert_stream(
                         stream=z_file_stream,
                         stream_info=z_file_stream_info,
+                        _depth = _depth+1,
                     )
                     if result is not None:
                         md_content += f"## File: {name}\n\n"

--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -4,6 +4,9 @@ import os
 
 from typing import BinaryIO, Any, TYPE_CHECKING
 
+from packages.markitdown.src.markitdown._exceptions import FileConversionException
+from packages.markitdown.src.markitdown.converters._zip_converter import (
+    ZIP_UNCOMPRESSED_SIZE_THRESHOLD)
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
 from .._exceptions import UnsupportedFormatException, FileConversionException
@@ -18,6 +21,7 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 
 ACCEPTED_FILE_EXTENSIONS = [".zip"]
 
+ZIP_UNCOMPRESSED_SIZE_THRESHOLD = 500
 
 class ZipConverter(DocumentConverter):
     """Converts ZIP files to markdown by extracting and converting all contained files.
@@ -93,7 +97,20 @@ class ZipConverter(DocumentConverter):
         file_path = stream_info.url or stream_info.local_path or stream_info.filename
         md_content = f"Content from the zip file `{file_path}`:\n\n"
 
+#files in zip more than 10000 files
+#zips in zips dont recurse forever , depth counter/limit
+
+
         with zipfile.ZipFile(file_stream, "r") as zipObj:
+            track_uncompressed = 0
+            for file in zipObj.infolist():
+                track_uncompressed += file.file_size
+                #check for zip bomb
+                if track_uncompressed > ZIP_UNCOMPRESSED_SIZE_THRESHOLD:
+                    raise FileConversionException(message= "total zip uncmpressed exceeds compressed by threshold")
+
+
+
             for name in zipObj.namelist():
                 try:
                     z_file_stream = io.BytesIO(zipObj.read(name))


### PR DESCRIPTION
## Problem
ZipConverter had no protection against zip bombs. A maliciously crafted 
zip could cause OOM or infinite recursion if these exist:
- High compression ratio (small zip → massive uncompressed size)
- Millions of tiny files
- Deeply nested zips (zip inside zip inside zip...)

## Changes
- Added `ZIP_UNCOMPRESSED_SIZE_THRESHOLD = 100 MB` — rejects zips whose 
  total uncompressed size exceeds limit
- Added `MAX_FILE_COUNT = 1000` — rejects zips with too many files
- Added `MAX_DEPTH = 3` — rejects zips nested deeper than 3 levels
- Depth counter passed through `convert_stream` recursively

## Testing
Manually verified with normal zips and simulated oversized inputs.