### PR TITLE
Fix ipynb title extraction stripping leading # from heading text

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -71,7 +71,7 @@ class IpynbConverter(DocumentConverter):
                     if title is None:
                         for line in source_lines:
                             if line.startswith("# "):
-                                title = line.lstrip("# ").strip()
+                                title = line[len("# ") :].strip()
                                 break
 
                 elif cell_type == "code":

--- a/packages/markitdown/tests/test_ipynb_converter.py
+++ b/packages/markitdown/tests/test_ipynb_converter.py
@@ -1,0 +1,42 @@
+import io
+import json
+
+from markitdown.converters._ipynb_converter import IpynbConverter
+from markitdown._stream_info import StreamInfo
+
+IPYNB_STREAM_INFO = StreamInfo(extension=".ipynb", mimetype="application/json")
+
+
+def _convert(notebook: dict):
+    data = json.dumps(notebook).encode("utf-8")
+    return IpynbConverter().convert(io.BytesIO(data), IPYNB_STREAM_INFO)
+
+
+def _notebook(first_markdown_line: str) -> dict:
+    return {
+        "cells": [
+            {"cell_type": "markdown", "source": [first_markdown_line, "body text"]},
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def test_title_keeps_leading_hash_in_text():
+    # The "# " marker should be removed as a prefix, not as a character set, so
+    # a heading whose text itself starts with "#" must keep it.
+    result = _convert(_notebook("# #100DaysOfCode\n"))
+    assert result.title == "#100DaysOfCode"
+
+
+def test_title_keeps_internal_spacing_after_marker():
+    # Only the single "# " marker is stripped; extra spaces in the title text
+    # must survive the prefix removal (outer whitespace is still trimmed).
+    result = _convert(_notebook("#  Spaced   Title \n"))
+    assert result.title == "Spaced   Title"
+
+
+def test_plain_title_unchanged():
+    result = _convert(_notebook("# Introduction\n"))
+    assert result.title == "Introduction"


### PR DESCRIPTION
## Problem

When converting a Jupyter notebook, the document title is taken from the first Markdown `# ` heading. The extraction uses:

```python
title = line.lstrip("# ").strip()
```

`str.lstrip(chars)` treats its argument as a *set of characters* to strip, not a prefix. So it removes every leading `#` and space character, not just the single `"# "` marker. A heading whose text itself begins with `#` loses those characters.

Example: a notebook whose first heading is `# #100DaysOfCode` produces the title `100DaysOfCode` instead of `#100DaysOfCode`.

## Fix

Strip only the `"# "` marker by slicing off its known length:

```python
title = line[len("# ") :].strip()
```

The line already passed `line.startswith("# ")`, so the prefix is guaranteed present. Outer whitespace is still trimmed by `.strip()`.

## Tests

Added `tests/test_ipynb_converter.py`:
- a heading whose text starts with `#` keeps it (`# #100DaysOfCode` -> `#100DaysOfCode`)
- only the marker is removed, internal spacing preserved
- a plain heading is unchanged

All three pass; the first fails on the old code.

---
Disclosure: I used AI assistance while preparing this change. I reproduced the bug and verified the fix and tests locally.