### PR TITLE
Extract embedded PDF images as separate files with relative Markdown links

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -138,8 +138,22 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "--extract-images",
+        action="store_true",
+        help="Extract embedded PDF images to files and reference them with relative Markdown links.",
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        help="Directory for extracted assets. Required when using --extract-images.",
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
+
+    if args.extract_images and args.output_dir is None:
+        _exit_with_error("--output-dir is required when using --extract-images.")
 
     # Parse the extension hint
     extension_hint = args.extension
@@ -209,7 +223,10 @@ def main():
             _exit_with_error("Filename is required when using Document Intelligence.")
 
         markitdown = MarkItDown(
-            enable_plugins=args.use_plugins, docintel_endpoint=args.endpoint
+            enable_plugins=args.use_plugins,
+            docintel_endpoint=args.endpoint,
+            extract_images=args.extract_images,
+            output_dir=args.output_dir,
         )
     elif args.use_cu:
         if args.cu_endpoint is None:
@@ -240,9 +257,18 @@ def main():
                     _exit_with_error(f"Unknown file type: {name}")
             cu_kwargs["cu_file_types"] = cu_types
 
-        markitdown = MarkItDown(enable_plugins=args.use_plugins, **cu_kwargs)
+        markitdown = MarkItDown(
+            enable_plugins=args.use_plugins,
+            extract_images=args.extract_images,
+            output_dir=args.output_dir,
+            **cu_kwargs,
+        )
     else:
-        markitdown = MarkItDown(enable_plugins=args.use_plugins)
+        markitdown = MarkItDown(
+            enable_plugins=args.use_plugins,
+            extract_images=args.extract_images,
+            output_dir=args.output_dir,
+        )
 
     if args.filename is None:
         result = markitdown.convert_stream(

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -214,6 +214,13 @@ def main():
             )
         sys.exit(0)
 
+    markitdown_kwargs: Dict[str, Any] = {
+        "enable_plugins": args.use_plugins,
+    }
+    if args.extract_images:
+        markitdown_kwargs["extract_images"] = True
+        markitdown_kwargs["output_dir"] = args.output_dir
+
     if args.use_docintel:
         if args.endpoint is None:
             _exit_with_error(
@@ -223,10 +230,8 @@ def main():
             _exit_with_error("Filename is required when using Document Intelligence.")
 
         markitdown = MarkItDown(
-            enable_plugins=args.use_plugins,
+            **markitdown_kwargs,
             docintel_endpoint=args.endpoint,
-            extract_images=args.extract_images,
-            output_dir=args.output_dir,
         )
     elif args.use_cu:
         if args.cu_endpoint is None:
@@ -258,17 +263,11 @@ def main():
             cu_kwargs["cu_file_types"] = cu_types
 
         markitdown = MarkItDown(
-            enable_plugins=args.use_plugins,
-            extract_images=args.extract_images,
-            output_dir=args.output_dir,
+            **markitdown_kwargs,
             **cu_kwargs,
         )
     else:
-        markitdown = MarkItDown(
-            enable_plugins=args.use_plugins,
-            extract_images=args.extract_images,
-            output_dir=args.output_dir,
-        )
+        markitdown = MarkItDown(**markitdown_kwargs)
 
     if args.filename is None:
         result = markitdown.convert_stream(

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -126,6 +126,11 @@ class MarkItDown:
         self._llm_prompt: Union[str | None] = None
         self._exiftool_path: Union[str | None] = None
         self._style_map: Union[str | None] = None
+        self._extract_images: bool = bool(kwargs.get("extract_images", False))
+        self._output_dir: Union[str | Path | None] = kwargs.get("output_dir")
+
+        if self._extract_images and self._output_dir is None:
+            raise ValueError("output_dir is required when extract_images=True")
 
         # Register the converters
         self._converters: List[ConverterRegistration] = []
@@ -563,6 +568,11 @@ class MarkItDown:
     ) -> DocumentConverterResult:
         res: Union[None, DocumentConverterResult] = None
 
+        extract_images = bool(kwargs.get("extract_images", self._extract_images))
+        output_dir = kwargs.get("output_dir", self._output_dir)
+        if extract_images and output_dir is None:
+            raise ValueError("output_dir is required when extract_images=True")
+
         # Keep track of which converters throw exceptions
         failed_attempts: List[FailedConversionAttempt] = []
 
@@ -599,6 +609,12 @@ class MarkItDown:
 
                 if "exiftool_path" not in _kwargs and self._exiftool_path is not None:
                     _kwargs["exiftool_path"] = self._exiftool_path
+
+                if "extract_images" not in _kwargs:
+                    _kwargs["extract_images"] = extract_images
+
+                if "output_dir" not in _kwargs and output_dir is not None:
+                    _kwargs["output_dir"] = output_dir
 
                 # Add the list of converters for nested processing
                 _kwargs["_parent_converters"] = self._converters

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,6 +1,8 @@
 import sys
 import io
 import re
+from dataclasses import dataclass
+from pathlib import Path
 from typing import BinaryIO, Any
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
@@ -9,6 +11,19 @@ from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 
 # Pattern for MasterFormat-style partial numbering (e.g., ".1", ".2", ".10")
 PARTIAL_NUMBERING_PATTERN = re.compile(r"^\.\d+$")
+
+
+@dataclass(frozen=True)
+class _PositionedMarkdownItem:
+    top: float
+    markdown: str
+    order: int
+
+
+@dataclass(frozen=True)
+class _ExtractedPdfImage:
+    top: float
+    markdown: str
 
 
 def _merge_partial_numbering_lines(text: str) -> str:
@@ -492,6 +507,217 @@ def _extract_tables_from_words(page: Any) -> list[list[list[str]]]:
     return [table_rows]
 
 
+def _image_extension_from_bytes(data: bytes) -> str | None:
+    """Return a common image extension when bytes are already image-encoded."""
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "jpg"
+    if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+        return "gif"
+    if data.startswith(b"II*\x00") or data.startswith(b"MM\x00*"):
+        return "tiff"
+    if data.startswith(b"\x00\x00\x00\x0cjP  \r\n\x87\n") or data.startswith(
+        b"\xff\x4f\xff\x51"
+    ):
+        return "jp2"
+    return None
+
+
+def _safe_image_bbox(
+    image: dict[str, Any], page: Any
+) -> tuple[float, float, float, float] | None:
+    x0 = float(image.get("x0", 0) or 0)
+    x1 = float(image.get("x1", 0) or 0)
+    top = float(image.get("top", image.get("y0", 0)) or 0)
+    bottom = float(image.get("bottom", image.get("y1", 0)) or 0)
+
+    width = float(getattr(page, "width", x1) or x1)
+    height = float(getattr(page, "height", bottom) or bottom)
+
+    x0 = max(0, min(x0, width))
+    x1 = max(0, min(x1, width))
+    top = max(0, min(top, height))
+    bottom = max(0, min(bottom, height))
+
+    if x1 <= x0 or bottom <= top:
+        return None
+
+    return (x0, top, x1, bottom)
+
+
+def _write_rendered_image(
+    page: Any, bbox: tuple[float, float, float, float], path: Path
+) -> bool:
+    try:
+        cropped_page = page.crop(bbox)
+        page_image = cropped_page.to_image(resolution=600)
+        page_image.original.save(path, format="PNG")
+        return path.exists() and path.stat().st_size > 0
+    except Exception:
+        return False
+
+
+def _write_stream_image(
+    image: dict[str, Any], path_without_suffix: Path
+) -> Path | None:
+    stream = image.get("stream")
+    if stream is None or not hasattr(stream, "get_data"):
+        return None
+
+    try:
+        data = stream.get_data()
+    except Exception:
+        return None
+
+    if not data:
+        return None
+
+    extension = _image_extension_from_bytes(data)
+    if extension is None:
+        return None
+
+    path = path_without_suffix.with_suffix(f".{extension}")
+    try:
+        path.write_bytes(data)
+    except Exception:
+        return None
+
+    if path.exists() and path.stat().st_size > 0:
+        return path
+    return None
+
+
+def _extract_pdf_images_from_page(
+    page: Any,
+    *,
+    page_num: int,
+    images_dir: Path,
+) -> list[_ExtractedPdfImage]:
+    images = list(getattr(page, "images", []) or [])
+    if not images and hasattr(page, "objects"):
+        images = list(getattr(page, "objects", {}).get("image", []) or [])
+
+    extracted: list[_ExtractedPdfImage] = []
+    for image_idx, image in enumerate(images, start=1):
+        bbox = _safe_image_bbox(image, page)
+        top = bbox[1] if bbox is not None else float(image.get("top", 0) or 0)
+        path_without_suffix = images_dir / f"page{page_num}-image{image_idx}"
+
+        image_path = _write_stream_image(image, path_without_suffix)
+        if image_path is None and bbox is not None:
+            rendered_path = path_without_suffix.with_suffix(".png")
+            if _write_rendered_image(page, bbox, rendered_path):
+                image_path = rendered_path
+
+        if image_path is None:
+            continue
+
+        rel_path = Path("images") / image_path.name
+        alt_text = f"Image {image_idx} on page {page_num}"
+        extracted.append(
+            _ExtractedPdfImage(
+                top=top,
+                markdown=f"![{alt_text}]({rel_path.as_posix()})",
+            )
+        )
+
+    return extracted
+
+
+def _extract_text_items_from_page(page: Any) -> list[_PositionedMarkdownItem]:
+    form_content = _extract_form_content_from_words(page)
+    if form_content is not None:
+        return [_PositionedMarkdownItem(top=0, markdown=form_content, order=0)]
+
+    try:
+        lines = page.extract_text_lines()
+        items = [
+            _PositionedMarkdownItem(
+                top=float(line.get("top", idx) or idx),
+                markdown=str(line.get("text", "")).strip(),
+                order=idx,
+            )
+            for idx, line in enumerate(lines)
+            if str(line.get("text", "")).strip()
+        ]
+        if items:
+            return items
+    except Exception:
+        pass
+
+    try:
+        words = page.extract_words(keep_blank_chars=True, x_tolerance=3, y_tolerance=3)
+        if words:
+            rows_by_y: dict[float, list[dict]] = {}
+            y_tolerance = 5.0
+            for word in words:
+                y_key = round(float(word["top"]) / y_tolerance) * y_tolerance
+                rows_by_y.setdefault(y_key, []).append(word)
+
+            items = []
+            for order, y_key in enumerate(sorted(rows_by_y.keys())):
+                row_words = sorted(rows_by_y[y_key], key=lambda w: w["x0"])
+                text = " ".join(w["text"] for w in row_words).strip()
+                if text:
+                    items.append(
+                        _PositionedMarkdownItem(top=y_key, markdown=text, order=order)
+                    )
+            if items:
+                return items
+    except Exception:
+        pass
+
+    text = page.extract_text() or ""
+    return [
+        _PositionedMarkdownItem(top=float(idx), markdown=line.strip(), order=idx)
+        for idx, line in enumerate(text.splitlines())
+        if line.strip()
+    ]
+
+
+def _convert_pdf_with_image_extraction(
+    pdf_bytes: io.BytesIO,
+    *,
+    output_dir: str | Path,
+) -> str:
+    output_root = Path(output_dir)
+    images_dir = output_root / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    chunks: list[str] = []
+    with pdfplumber.open(pdf_bytes) as pdf:
+        for page_idx, page in enumerate(pdf.pages):
+            page_num = page_idx + 1
+            try:
+                items: list[_PositionedMarkdownItem] = _extract_text_items_from_page(
+                    page
+                )
+                image_items = _extract_pdf_images_from_page(
+                    page,
+                    page_num=page_num,
+                    images_dir=images_dir,
+                )
+
+                for image_order, image in enumerate(image_items):
+                    items.append(
+                        _PositionedMarkdownItem(
+                            top=image.top,
+                            markdown=image.markdown,
+                            order=10_000 + image_order,
+                        )
+                    )
+
+                items.sort(key=lambda item: (item.top, item.order))
+                page_markdown = "\n\n".join(item.markdown for item in items).strip()
+                if page_markdown:
+                    chunks.append(page_markdown)
+            finally:
+                page.close()
+
+    return "\n\n".join(chunks).strip()
+
+
 class PdfConverter(DocumentConverter):
     """
     Converts PDFs to Markdown.
@@ -524,59 +750,75 @@ class PdfConverter(DocumentConverter):
         **kwargs: Any,
     ) -> DocumentConverterResult:
         if _dependency_exc_info is not None:
+            missing_dependency_exception = _dependency_exc_info[1]
+            assert missing_dependency_exception is not None
             raise MissingDependencyException(
                 MISSING_DEPENDENCY_MESSAGE.format(
                     converter=type(self).__name__,
                     extension=".pdf",
                     feature="pdf",
                 )
-            ) from _dependency_exc_info[1].with_traceback(
-                _dependency_exc_info[2]
-            )  # type: ignore[union-attr]
+            ) from missing_dependency_exception.with_traceback(_dependency_exc_info[2])
 
         assert isinstance(file_stream, io.IOBase)
 
         # Read file stream into BytesIO for compatibility with pdfplumber
         pdf_bytes = io.BytesIO(file_stream.read())
 
-        try:
-            # Single pass: check every page for form-style content.
-            # Pages with tables/forms get rich extraction; plain-text
-            # pages are collected separately. page.close() is called
-            # after each page to free pdfplumber's cached objects and
-            # keep memory usage constant regardless of page count.
-            markdown_chunks: list[str] = []
-            form_page_count = 0
-            plain_page_indices: list[int] = []
+        extract_images = bool(kwargs.get("extract_images", False))
+        output_dir = kwargs.get("output_dir")
 
-            with pdfplumber.open(pdf_bytes) as pdf:
-                for page_idx, page in enumerate(pdf.pages):
-                    page_content = _extract_form_content_from_words(page)
+        if extract_images:
+            if output_dir is None:
+                raise ValueError("output_dir is required when extract_images=True")
 
-                    if page_content is not None:
-                        form_page_count += 1
-                        if page_content.strip():
-                            markdown_chunks.append(page_content)
-                    else:
-                        plain_page_indices.append(page_idx)
-                        text = page.extract_text()
-                        if text and text.strip():
-                            markdown_chunks.append(text.strip())
-
-                    page.close()  # Free cached page data immediately
-
-            # If no pages had form-style content, use pdfminer for
-            # the whole document (better text spacing for prose).
-            if form_page_count == 0:
+            try:
+                markdown = _convert_pdf_with_image_extraction(
+                    pdf_bytes,
+                    output_dir=output_dir,
+                )
+            except Exception:
                 pdf_bytes.seek(0)
                 markdown = pdfminer.high_level.extract_text(pdf_bytes)
-            else:
-                markdown = "\n\n".join(markdown_chunks).strip()
+        else:
+            try:
+                # Single pass: check every page for form-style content.
+                # Pages with tables/forms get rich extraction; plain-text
+                # pages are collected separately. page.close() is called
+                # after each page to free pdfplumber's cached objects and
+                # keep memory usage constant regardless of page count.
+                markdown_chunks: list[str] = []
+                form_page_count = 0
+                plain_page_indices: list[int] = []
 
-        except Exception:
-            # Fallback if pdfplumber fails
-            pdf_bytes.seek(0)
-            markdown = pdfminer.high_level.extract_text(pdf_bytes)
+                with pdfplumber.open(pdf_bytes) as pdf:
+                    for page_idx, page in enumerate(pdf.pages):
+                        page_content = _extract_form_content_from_words(page)
+
+                        if page_content is not None:
+                            form_page_count += 1
+                            if page_content.strip():
+                                markdown_chunks.append(page_content)
+                        else:
+                            plain_page_indices.append(page_idx)
+                            text = page.extract_text()
+                            if text and text.strip():
+                                markdown_chunks.append(text.strip())
+
+                        page.close()  # Free cached page data immediately
+
+                # If no pages had form-style content, use pdfminer for
+                # the whole document (better text spacing for prose).
+                if form_page_count == 0:
+                    pdf_bytes.seek(0)
+                    markdown = pdfminer.high_level.extract_text(pdf_bytes)
+                else:
+                    markdown = "\n\n".join(markdown_chunks).strip()
+
+            except Exception:
+                # Fallback if pdfplumber fails
+                pdf_bytes.seek(0)
+                markdown = pdfminer.high_level.extract_text(pdf_bytes)
 
         # Fallback if still empty
         if not markdown:

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3 -m pytest
 import subprocess
+import sys
+
 from markitdown import __version__
 
 # This file contains CLI tests that are not directly tested by the FileTestVectors.
@@ -8,7 +10,9 @@ from markitdown import __version__
 
 def test_version() -> None:
     result = subprocess.run(
-        ["python", "-m", "markitdown", "--version"], capture_output=True, text=True
+        [sys.executable, "-m", "markitdown", "--version"],
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 0, f"CLI exited with error: {result.stderr}"
@@ -17,7 +21,9 @@ def test_version() -> None:
 
 def test_invalid_flag() -> None:
     result = subprocess.run(
-        ["python", "-m", "markitdown", "--foobar"], capture_output=True, text=True
+        [sys.executable, "-m", "markitdown", "--foobar"],
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode != 0, f"CLI exited with error: {result.stderr}"
@@ -27,8 +33,33 @@ def test_invalid_flag() -> None:
     assert "SYNTAX" in result.stderr, "Expected 'SYNTAX' to appear in STDERR"
 
 
+def test_extract_images_requires_output_dir() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "markitdown", "--extract-images", "fake.pdf"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "--output-dir is required" in result.stdout
+
+
+def test_help_lists_extract_images_options() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "markitdown", "--help"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--extract-images" in result.stdout
+    assert "--output-dir" in result.stdout
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     test_version()
     test_invalid_flag()
+    test_extract_images_requires_output_dir()
+    test_help_lists_extract_images_options()
     print("All tests passed!")

--- a/packages/markitdown/tests/test_pdf_images.py
+++ b/packages/markitdown/tests/test_pdf_images.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3 -m pytest
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from markitdown import MarkItDown, StreamInfo
+from markitdown.converters._pdf_converter import PdfConverter
+
+
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR"
+    b"\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde"
+)
+
+
+def _mock_pdfplumber_open(pages):
+    def mock_open(stream):
+        mock_pdf = MagicMock()
+        mock_pdf.pages = pages
+        mock_pdf.__enter__ = MagicMock(return_value=mock_pdf)
+        mock_pdf.__exit__ = MagicMock(return_value=False)
+        return mock_pdf
+
+    return mock_open
+
+
+def _make_pdf_page():
+    stream = MagicMock()
+    stream.get_data.return_value = PNG_BYTES
+
+    page = MagicMock()
+    page.width = 612
+    page.height = 792
+    page.images = [
+        {
+            "x0": 72,
+            "x1": 144,
+            "top": 40,
+            "bottom": 120,
+            "stream": stream,
+        }
+    ]
+    page.extract_words.return_value = [
+        {"text": "Before", "x0": 72, "x1": 120, "top": 10, "bottom": 20},
+        {"text": "After", "x0": 72, "x1": 110, "top": 180, "bottom": 190},
+    ]
+    page.extract_text_lines.return_value = [
+        {"text": "Before image", "top": 10},
+        {"text": "After image", "top": 180},
+    ]
+    page.close = MagicMock()
+    return page
+
+
+def test_pdf_extract_images_writes_files_and_relative_links(tmp_path):
+    page = _make_pdf_page()
+
+    with patch(
+        "markitdown.converters._pdf_converter._dependency_exc_info", None
+    ), patch("markitdown.converters._pdf_converter.pdfplumber") as mock_pdfplumber:
+        mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+
+        result = PdfConverter().convert(
+            io.BytesIO(b"%PDF mock"),
+            StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            extract_images=True,
+            output_dir=tmp_path,
+        )
+
+    image_path = tmp_path / "images" / "page1-image1.png"
+    assert image_path.exists()
+    assert image_path.read_bytes().startswith(b"\x89PNG")
+    assert "![Image 1 on page 1](images/page1-image1.png)" in result.markdown
+    assert result.markdown.index("Before image") < result.markdown.index(
+        "images/page1-image1.png"
+    )
+    assert result.markdown.index("images/page1-image1.png") < result.markdown.index(
+        "After image"
+    )
+    assert "data:image" not in result.markdown
+    assert page.close.called
+
+
+def test_extract_images_requires_output_dir_in_constructor():
+    with pytest.raises(ValueError, match="output_dir is required"):
+        MarkItDown(extract_images=True)
+
+
+def test_extract_images_requires_output_dir_per_call():
+    md = MarkItDown()
+    with pytest.raises(ValueError, match="output_dir is required"):
+        md.convert_stream(
+            io.BytesIO(b"%PDF mock"),
+            stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            extract_images=True,
+        )


### PR DESCRIPTION
## Summary

This PR adds an opt-in PDF image extraction workflow for MarkItDown. When enabled, embedded images from PDFs are saved as separate files under an output directory, and the generated Markdown references them using relative links.

This is intended for RAG, document archival, technical documentation, datasheets, schematics, research papers, and other workflows where inline base64 images make Markdown too large or impractical for indexing.

Example:

```bash
markitdown document.pdf --extract-images --output-dir ./output -o ./output/document.md
```

Output:

```text
output/
├── document.md
└── images/
    ├── page1-image1.png
    └── page1-image2.png
```

Markdown:

```markdown
![Image 1 on page 1](images/page1-image1.png)
```

## What changed

### CLI

Adds two new CLI options:

```bash
--extract-images
--output-dir <directory>
```

`--output-dir` is required when `--extract-images` is used. Existing stdout behavior is preserved: if `-o` is not provided, Markdown is still printed to stdout, while images are written under `--output-dir/images/`.

### Python API

Adds constructor-level support:

```python
from markitdown import MarkItDown

md = MarkItDown(extract_images=True, output_dir="./output")
result = md.convert("document.pdf")
```

Also supports per-call overrides:

```python
md = MarkItDown()
result = md.convert(
    "document.pdf",
    extract_images=True,
    output_dir="./output",
)
```

If image extraction is enabled without an output directory, MarkItDown raises:

```text
ValueError: output_dir is required when extract_images=True
```

### PDF conversion

The PDF converter now has an opt-in image extraction path. Default PDF conversion remains unchanged unless `extract_images=True` is explicitly set.

The implementation:

- Detects images from `pdfplumber` page image objects.
- Saves images under `output_dir/images/`.
- Uses deterministic filenames:
  - `page1-image1.png`
  - `page1-image2.png`
  - `page3-image1.jpg`
- Inserts relative Markdown image links near the image's approximate vertical page position.
- Preserves the existing fallback behavior for normal text extraction.
- Keeps page cleanup behavior by still calling `page.close()`.

### Image writing behavior

The converter first tries to save original embedded image stream bytes when they are already recognizable image formats, including:

- PNG
- JPEG
- GIF
- TIFF
- JPEG 2000

If direct stream extraction is not possible, it falls back to rendering/cropping the image region from the PDF page using `pdfplumber`.

The current fallback render setting is:

```python
cropped_page.to_image(resolution=600)
```

This improves output sharpness for diagrams and technical images, but produces larger files and may be slower than lower DPI values such as `150` or `300`.

## Why not inline base64?

Before this feature, PDF/image-heavy Markdown workflows often had two poor options:

- truncate data URIs, losing the actual image content;
- keep full base64 data URIs, creating very large Markdown files.

Both are problematic for RAG and indexing. Extracted image files with relative links keep Markdown lightweight while preserving visual context.

## Testing

Added focused coverage for image extraction, relative Markdown links, `output_dir` validation, CLI help/validation, and existing PDF page cleanup behavior. Full `hatch test` and `pre-commit` checks was also run and `Passed`.

## Manual verification

Example command:

```bash
mkdir -p ./coba

markitdown \
  packages/markitdown-ocr/tests/ocr_test_data/pdf_multiple_images.pdf \
  --extract-images \
  --output-dir ./coba \
  -o ./coba/document.md
```

Expected files:

```text
coba/document.md
coba/images/page1-image1.png
coba/images/page1-image2.png
```

Example Markdown output:

```markdown
Document with Multiple Images

![Image 1 on page 1](images/page1-image1.png)

Text between first and second image.

![Image 2 on page 1](images/page1-image2.png)

Final text after all images.
```

## Files changed

Core implementation:

- `packages/markitdown/src/markitdown/__main__.py`
- `packages/markitdown/src/markitdown/_markitdown.py`
- `packages/markitdown/src/markitdown/converters/_pdf_converter.py`

Tests:

- `packages/markitdown/tests/test_cli_misc.py`
- `packages/markitdown/tests/test_pdf_images.py`

## Future improvements

Possible follow-up work:

- Add a configurable render DPI option, for example `--image-dpi 300`.
- Add custom image directory support, for example `--image-dir assets/images`.
- Add metadata output for page number, image dimensions, bbox, and format.
- Add caption detection when nearby text appears to be a figure caption.
- Add duplicate image detection to avoid writing identical images repeatedly.
- Extend similar extraction behavior to DOCX/PPTX/XLSX if useful.

## Related issues

This feature addresses the same workflow need described in Issue #2049 and complements prior work around base64 data URI handling and image descriptions for RAG workflows.
