### PR TITLE
fix: allow DocumentIntelligenceConverter api_version to default to None (fixes #1904)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -134,7 +134,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
         self,
         *,
         endpoint: str,
-        api_version: str = "2024-07-31-preview",
+        api_version: str | None = None,
         credential: AzureKeyCredential | TokenCredential | None = None,
         file_types: List[DocumentIntelligenceFileType] = [
             DocumentIntelligenceFileType.DOCX,
@@ -152,7 +152,9 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         Args:
             endpoint (str): The endpoint for the Document Intelligence service.
-            api_version (str): The API version to use. Defaults to "2024-07-31-preview".
+            api_version (str | None): The API version to use. When None (the default),
+                the Document Intelligence SDK uses its own built-in default version.
+                Set this explicitly only if you need a specific API version.
             credential (AzureKeyCredential | TokenCredential | None): The credential to use for authentication.
             file_types (List[DocumentIntelligenceFileType]): The file types to accept. Defaults to all supported file types.
         """
@@ -180,11 +182,15 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         self.endpoint = endpoint
         self.api_version = api_version
-        self.doc_intel_client = DocumentIntelligenceClient(
-            endpoint=self.endpoint,
-            api_version=self.api_version,
-            credential=credential,
-        )
+
+        client_kwargs: dict[str, Any] = {
+            "endpoint": self.endpoint,
+            "credential": credential,
+        }
+        if self.api_version is not None:
+            client_kwargs["api_version"] = self.api_version
+
+        self.doc_intel_client = DocumentIntelligenceClient(**client_kwargs)
 
     def accepts(
         self,


### PR DESCRIPTION
## Description

Fixes #1904

The  previously hardcoded  as the default parameter. This overrode the Azure Document Intelligence SDK's own default version (), causing 404 errors for users who didn't explicitly specify an .

## Problem

1. Azure Document Intelligence SDK defaults to 
2.  forced  as default
3. Users with standard Azure deployments (which don't specify api_version) got 404 errors because the converter used an outdated preview version

## Fix

- Changed  default from  to 
- Only passes  to  when explicitly set
- When , the SDK uses its own built-in default version
- Users can still set  explicitly when needed

## Changes

- :
  -  → 
  - Build  dict conditionally, only including  when not None
  - Updated docstring to reflect the new behavior

## Verification

