### PR TITLE
feat: support TSV/other delimiters and fix Markdown table collisions

### DIFF
--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -61,7 +61,7 @@ class DocumentConverter:
 
         IMPORTANT: In rare cases, (e.g., OutlookMsgConverter) we need to read more from the stream to make a final
         determination. Read operations inevitably advances the position in file_stream. In these case, the position
-        MUST be reset it MUST be reset before returning. This is because the convert() method may be called immediately
+        MUST be reset before returning. This is because the convert() method may be called immediately
         after accepts(), and will expect the file_stream to be at the original position.
 
         E.g.,

--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -8,13 +8,15 @@ from .._stream_info import StreamInfo
 ACCEPTED_MIME_TYPE_PREFIXES = [
     "text/csv",
     "application/csv",
+    "text/tab-separated-values",
+    "text/tsv"
 ]
-ACCEPTED_FILE_EXTENSIONS = [".csv"]
+ACCEPTED_FILE_EXTENSIONS = [".csv", ".tsv", ".psv", ".ssv"]
 
 
 class CsvConverter(DocumentConverter):
     """
-    Converts CSV files to Markdown tables.
+    Converts CSV and TSV files to Markdown tables.
     """
 
     def __init__(self):
@@ -46,9 +48,18 @@ class CsvConverter(DocumentConverter):
             content = file_stream.read().decode(stream_info.charset)
         else:
             content = str(from_bytes(file_stream.read()).best())
+        
+        SAMPLE_SNIFF_SIZE = 8192
+        try:
+            sample_chunk = content[:SAMPLE_SNIFF_SIZE]
+        except IndexError:
+            sample_chunk = content
+            
+        delimiter = self.get_delimiter(stream_info, kwargs.get("delimiter", ""), sample_chunk) # Option to specify delimiter.
 
         # Parse CSV content
-        reader = csv.reader(io.StringIO(content))
+      
+        reader = csv.reader(io.StringIO(content), delimiter=delimiter) 
         rows = list(reader)
 
         if not rows:
@@ -75,3 +86,19 @@ class CsvConverter(DocumentConverter):
         result = "\n".join(markdown_table)
 
         return DocumentConverterResult(markdown=result)
+    
+    def get_delimiter(self, stream_info: StreamInfo, delimiter: str, sample_chunk: str) -> str:
+        if delimiter:
+            return delimiter
+        try:
+            dialect = csv.Sniffer().sniff(sample_chunk or "", delimiters=",\t|;")
+            return dialect.delimiter
+        except csv.Error:
+            if stream_info.mimetype == "text/tab-separated-values" or stream_info.extension.lower() == ".tsv":
+                return "\t"
+            if stream_info.extension.lower() == ".psv":
+                return "|"
+            if stream_info.extension.lower() == ".ssv":
+                return ";"
+            return ","
+            

--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -57,8 +57,7 @@ class CsvConverter(DocumentConverter):
             
         delimiter = self.get_delimiter(stream_info, kwargs.get("delimiter", ""), sample_chunk) # Option to specify delimiter.
 
-        # Parse CSV content
-      
+        # Parse CSV content using the determined delimiter
         reader = csv.reader(io.StringIO(content), delimiter=delimiter) 
         rows = list(reader)
 
@@ -69,24 +68,24 @@ class CsvConverter(DocumentConverter):
         markdown_table = []
 
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        safe_header = [self.sanitize_cell(cell) for cell in rows[0]]
+        markdown_table.append("| " + " | ".join(safe_header) + " |")
 
         # Add separator row
-        markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
-
+        markdown_table.append("| " + " | ".join(["---"] * len(safe_header)) + " |")
         # Add data rows
         for row in rows[1:]:
             # Make sure row has the same number of columns as header
-            while len(row) < len(rows[0]):
+            while len(row) < len(safe_header):
                 row.append("")
             # Truncate if row has more columns than header
-            row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
-
+            row = row[: len(safe_header)]
+            markdown_table.append("| " + " | ".join([self.sanitize_cell(cell) for cell in row]) + " |")
         result = "\n".join(markdown_table)
 
         return DocumentConverterResult(markdown=result)
     
+    # Determine the delimiter using the provided option, CSV sniffer, or file extension and MIME type as fallbacks.
     def get_delimiter(self, stream_info: StreamInfo, delimiter: str, sample_chunk: str) -> str:
         if delimiter:
             return delimiter
@@ -101,4 +100,11 @@ class CsvConverter(DocumentConverter):
             if stream_info.extension.lower() == ".ssv":
                 return ";"
             return ","
+        
+    # makes sure to escape pipes and newlines in cell values to prevent breaking the markdown table format
+    def sanitize_cell(self, cell_value: Any) -> str:
+            val = str(cell_value)
+            val = val.replace("|", "\\|")
+            val = val.replace("\n", " ").replace("\r", "")
+            return val
             

--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -17,6 +17,9 @@ ACCEPTED_FILE_EXTENSIONS = [".csv", ".tsv", ".psv", ".ssv"]
 class CsvConverter(DocumentConverter):
     """
     Converts CSV and TSV files to Markdown tables.
+    Param : delimiter: Optional parameter to specify the delimiter used in the CSV file.
+    If not provided, the converter will attempt to auto-detect the delimiter using the csv.Sniffer
+    class or fall back to common delimiters based on file extension and MIME type.
     """
 
     def __init__(self):

--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -9,7 +9,7 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
     "text/csv",
     "application/csv",
     "text/tab-separated-values",
-    "text/tsv"
+    "text/tsv",
 ]
 ACCEPTED_FILE_EXTENSIONS = [".csv", ".tsv", ".psv", ".ssv"]
 
@@ -48,17 +48,19 @@ class CsvConverter(DocumentConverter):
             content = file_stream.read().decode(stream_info.charset)
         else:
             content = str(from_bytes(file_stream.read()).best())
-        
+
         SAMPLE_SNIFF_SIZE = 8192
         try:
             sample_chunk = content[:SAMPLE_SNIFF_SIZE]
         except IndexError:
             sample_chunk = content
-            
-        delimiter = self.get_delimiter(stream_info, kwargs.get("delimiter", ""), sample_chunk) # Option to specify delimiter.
+
+        delimiter = self.get_delimiter(
+            stream_info, kwargs.get("delimiter", ""), sample_chunk
+        )  # Option to specify delimiter.
 
         # Parse CSV content using the determined delimiter
-        reader = csv.reader(io.StringIO(content), delimiter=delimiter) 
+        reader = csv.reader(io.StringIO(content), delimiter=delimiter)
         rows = list(reader)
 
         if not rows:
@@ -80,31 +82,37 @@ class CsvConverter(DocumentConverter):
                 row.append("")
             # Truncate if row has more columns than header
             row = row[: len(safe_header)]
-            markdown_table.append("| " + " | ".join([self.sanitize_cell(cell) for cell in row]) + " |")
+            markdown_table.append(
+                "| " + " | ".join([self.sanitize_cell(cell) for cell in row]) + " |"
+            )
         result = "\n".join(markdown_table)
 
         return DocumentConverterResult(markdown=result)
-    
+
     # Determine the delimiter using the provided option, CSV sniffer, or file extension and MIME type as fallbacks.
-    def get_delimiter(self, stream_info: StreamInfo, delimiter: str, sample_chunk: str) -> str:
+    def get_delimiter(
+        self, stream_info: StreamInfo, delimiter: str, sample_chunk: str
+    ) -> str:
         if delimiter:
             return delimiter
         try:
             dialect = csv.Sniffer().sniff(sample_chunk or "", delimiters=",\t|;")
             return dialect.delimiter
         except csv.Error:
-            if stream_info.mimetype == "text/tab-separated-values" or stream_info.extension.lower() == ".tsv":
+            if (
+                stream_info.mimetype == "text/tab-separated-values"
+                or stream_info.extension.lower() == ".tsv"
+            ):
                 return "\t"
             if stream_info.extension.lower() == ".psv":
                 return "|"
             if stream_info.extension.lower() == ".ssv":
                 return ";"
             return ","
-        
+
     # makes sure to escape pipes and newlines in cell values to prevent breaking the markdown table format
     def sanitize_cell(self, cell_value: Any) -> str:
-            val = str(cell_value)
-            val = val.replace("|", "\\|")
-            val = val.replace("\n", " ").replace("\r", "")
-            return val
-            
+        val = str(cell_value)
+        val = val.replace("|", "\\|")
+        val = val.replace("\n", " ").replace("\r", "")
+        return val

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -162,7 +162,7 @@ GENERAL_TEST_VECTORS = [
             "| --- | --- | --- | --- |",
             "| 101 | Shekhar | Developer \| Backend | India (New Delhi) |",
             "| 102 | Raghu | UI \| UX Designer | Canada |",
-            "| 103 | Shubham | Engineer | United Kingdom |"
+            "| 103 | Shubham | Engineer | United Kingdom |",
         ],
         must_not_include=[],
     ),
@@ -176,11 +176,10 @@ GENERAL_TEST_VECTORS = [
             "| --- | --- | --- | --- |",
             "| 101 | Shekhar | Developer | India |",
             "| 102 | Raghu | Designer | Canada |",
-            "| 103 | Shubham | Engineer | United Kingdom |"
+            "| 103 | Shubham | Engineer | United Kingdom |",
         ],
         must_not_include=[],
     ),
-    
     FileTestVector(
         filename="test.json",
         mimetype="application/json",

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -160,8 +160,8 @@ GENERAL_TEST_VECTORS = [
         must_include=[
             "| ID | Name | Role | Location |",
             "| --- | --- | --- | --- |",
-            "| 101 | Shekhar | Developer | India |",
-            "| 102 | Raghu | Designer | Canada |",
+            "| 101 | Shekhar | Developer \| Backend | India (New Delhi) |",
+            "| 102 | Raghu | UI \| UX Designer | Canada |",
             "| 103 | Shubham | Engineer | United Kingdom |"
         ],
         must_not_include=[],

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -153,6 +153,35 @@ GENERAL_TEST_VECTORS = [
         must_not_include=[],
     ),
     FileTestVector(
+        filename="test.ssv",
+        mimetype=None,
+        charset=None,
+        url=None,
+        must_include=[
+            "| ID | Name | Role | Location |",
+            "| --- | --- | --- | --- |",
+            "| 101 | Shekhar | Developer | India |",
+            "| 102 | Raghu | Designer | Canada |",
+            "| 103 | Shubham | Engineer | United Kingdom |"
+        ],
+        must_not_include=[],
+    ),
+    FileTestVector(
+        filename="test.tsv",
+        mimetype="text/tsv",
+        charset="ascii",
+        url=None,
+        must_include=[
+            "| ID | Name | Role | Location |",
+            "| --- | --- | --- | --- |",
+            "| 101 | Shekhar | Developer | India |",
+            "| 102 | Raghu | Designer | Canada |",
+            "| 103 | Shubham | Engineer | United Kingdom |"
+        ],
+        must_not_include=[],
+    ),
+    
+    FileTestVector(
         filename="test.json",
         mimetype="application/json",
         charset="ascii",

--- a/packages/markitdown/tests/test_files/test.ssv
+++ b/packages/markitdown/tests/test_files/test.ssv
@@ -1,4 +1,5 @@
 ID;Name;Role;Location
-101;Shekhar;Developer;India
-102;Raghu;Designer;Canada
+101;Shekhar;Developer | Backend;"India
+(New Delhi)"
+102;Raghu;UI | UX Designer;Canada
 103;Shubham;Engineer;United Kingdom

--- a/packages/markitdown/tests/test_files/test.ssv
+++ b/packages/markitdown/tests/test_files/test.ssv
@@ -1,0 +1,4 @@
+ID;Name;Role;Location
+101;Shekhar;Developer;India
+102;Raghu;Designer;Canada
+103;Shubham;Engineer;United Kingdom

--- a/packages/markitdown/tests/test_files/test.tsv
+++ b/packages/markitdown/tests/test_files/test.tsv
@@ -1,0 +1,4 @@
+ID	Name	Role	Location
+101	Shekhar	Developer	India
+102	Raghu	Designer	Canada
+103	Shubham	Engineer	United Kingdom


### PR DESCRIPTION
### Problem Statement
The current CSV converter lacks support for alternative delimiter formats (like `.tsv`, `.psv`, `.ssv`) and fails to safely escape structural characters (like pipes and newlines) within cell data, leading to corrupted Markdown table rendering.

### Proposed Solution
1. Dynamic Delimiter Resolution -

-  Gives users the overriding power to explicitly define a delimiter via `kwargs`.
-  If no delimiter is provided, it utilizes `csv.Sniffer()` to dynamically determine the internal delimiter from the file content (handling edge cases where internal data doesn't match the file extension).
- If the sniffer fails (`csv.Error`), it safely falls back to a generic delimiter based on the file's extension or MIME type.
- added the `text/tsv` even though it is not in the official IANA list because many legacy system still use it

2. Iterative Cell Sanitization -

- Routes all cell data through a new sanitize_cell() helper during string construction to preserve Markdown table integrity.
- Escapes rogue pipes (| becomes \|) to prevent column layout collisions.
- Flattens newlines (\n becomes a space) and removes carriage returns (\r becomes "") to ensure rows remain strictly horizontal.
-  Used iterative approach to evaluate the safe rows as the loading the whole content (all rows at once) could cause heap memory spike.

3. Minor Chores
Fixed a small text duplication in the documentation of `_base_converter.py`.

resolves #2019  and #2022