### PR TITLE
docs: quote optional dependency install examples

### DIFF
--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -13,7 +13,7 @@
 From PyPI:
 
 ```bash
-pip install markitdown[all]
+pip install 'markitdown[all]'
 ```
 
 From source:
@@ -21,7 +21,7 @@ From source:
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e packages/markitdown[all]
+pip install -e 'packages/markitdown[all]'
 ```
 
 ## Usage

--- a/packages/markitdown/src/markitdown/_exceptions.py
+++ b/packages/markitdown/src/markitdown/_exceptions.py
@@ -2,9 +2,9 @@ from typing import Optional, List, Any
 
 MISSING_DEPENDENCY_MESSAGE = """{converter} recognized the input as a potential {extension} file, but the dependencies needed to read {extension} files have not been installed. To resolve this error, include the optional dependency [{feature}] or [all] when installing MarkItDown. For example:
 
-* pip install markitdown[{feature}]
-* pip install markitdown[all]
-* pip install markitdown[{feature}, ...]
+* pip install 'markitdown[{feature}]'
+* pip install 'markitdown[all]'
+* pip install 'markitdown[{feature}, ...]'
 * etc."""
 
 

--- a/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
+++ b/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
@@ -24,7 +24,10 @@ def transcribe_audio(file_stream: BinaryIO, *, audio_format: str = "wav") -> str
     # Check for installed dependencies
     if _dependency_exc_info is not None:
         raise MissingDependencyException(
-            "Speech transcription requires installing MarkItdown with the [audio-transcription] optional dependencies. E.g., `pip install markitdown[audio-transcription]` or `pip install markitdown[all]`"
+            "Speech transcription requires installing MarkItDown with the "
+            "[audio-transcription] optional dependencies. E.g., "
+            "`pip install 'markitdown[audio-transcription]'` or "
+            "`pip install 'markitdown[all]'`"
         ) from _dependency_exc_info[
             1
         ].with_traceback(  # type: ignore[union-attr]


### PR DESCRIPTION
Quotes optional dependency install examples so shells do not expand package extras, and fixes a small MarkItDown typo in an audio dependency message.