### PR TITLE
fix: escape pipe characters in CSV table cells

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -1,15 +1,23 @@
 import csv
 import io
 from typing import BinaryIO, Any
+
 from charset_normalizer import from_bytes
+
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
+
 
 ACCEPTED_MIME_TYPE_PREFIXES = [
     "text/csv",
     "application/csv",
 ]
+
 ACCEPTED_FILE_EXTENSIONS = [".csv"]
+
+
+def _escape_markdown_table_cell(cell: str) -> str:
+    return cell.replace("|", r"\|")
 
 
 class CsvConverter(DocumentConverter):
@@ -28,11 +36,14 @@ class CsvConverter(DocumentConverter):
     ) -> bool:
         mimetype = (stream_info.mimetype or "").lower()
         extension = (stream_info.extension or "").lower()
+
         if extension in ACCEPTED_FILE_EXTENSIONS:
             return True
+
         for prefix in ACCEPTED_MIME_TYPE_PREFIXES:
             if mimetype.startswith(prefix):
                 return True
+
         return False
 
     def convert(
@@ -58,7 +69,8 @@ class CsvConverter(DocumentConverter):
         markdown_table = []
 
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        header_row = [_escape_markdown_table_cell(cell) for cell in rows[0]]
+        markdown_table.append("| " + " | ".join(header_row) + " |")
 
         # Add separator row
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
@@ -68,10 +80,14 @@ class CsvConverter(DocumentConverter):
             # Make sure row has the same number of columns as header
             while len(row) < len(rows[0]):
                 row.append("")
+
             # Truncate if row has more columns than header
             row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+
+            escaped_row = [_escape_markdown_table_cell(cell) for cell in row]
+            markdown_table.append("| " + " | ".join(escaped_row) + " |")
 
         result = "\n".join(markdown_table)
 
         return DocumentConverterResult(markdown=result)
+    

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -152,6 +152,23 @@ GENERAL_TEST_VECTORS = [
         ],
         must_not_include=[],
     ),
+        FileTestVector(
+        filename="test_pipe_chars.csv",
+        mimetype="text/csv",
+        charset="ascii",
+        url=None,
+        must_include=[
+            "| Name | Formula | Notes |",
+            "| --- | --- | --- |",
+            "| OR Gate | A \\| B | Pipe character should be escaped |",
+            "| AND Gate | A & B | Regular value |",
+            "| Regex | foo\\|bar | Pipe in regex-like value |",
+        ],
+        must_not_include=[
+            "| OR Gate | A | B | Pipe character should be escaped |",
+            "| Regex | foo|bar | Pipe in regex-like value |",
+        ],
+    ),
     FileTestVector(
         filename="test.json",
         mimetype="application/json",

--- a/packages/markitdown/tests/test_files/test_pipe_chars.csv
+++ b/packages/markitdown/tests/test_files/test_pipe_chars.csv
@@ -1,0 +1,4 @@
+Name,Formula,Notes
+OR Gate,A | B,Pipe character should be escaped
+AND Gate,A & B,Regular value
+Regex,foo|bar,Pipe in regex-like value


### PR DESCRIPTION
## Summary

This pull request fixes a Markdown table formatting issue in `CsvConverter`.

When a CSV cell contains a literal pipe character (`|`), the generated Markdown table can be parsed incorrectly because the pipe is treated as a column separator. This change escapes pipe characters inside CSV cell values before joining them into Markdown table rows.

## Changes

- Added a helper function to escape literal `|` characters in Markdown table cells.
- Applied escaping to CSV header cells.
- Applied escaping to CSV data cells.
- Improved CSV to Markdown table output for values containing pipe characters.

## Why This Matters

CSV files may contain pipe characters in formulas, command examples, regular expressions, SQL snippets, and other real-world data. Without escaping, the generated Markdown output can become structurally incorrect.

Closes #2019