### PR TITLE
Implement pipe character escaping in CSV converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -35,6 +35,10 @@ class CsvConverter(DocumentConverter):
                 return True
         return False
 
+    def _escape_pipe(self, cell: str) -> str:
+        """Escape pipe characters in CSV cells for Markdown tables."""
+        return cell.replace("|", "\\|")
+
     def convert(
         self,
         file_stream: BinaryIO,
@@ -58,7 +62,8 @@ class CsvConverter(DocumentConverter):
         markdown_table = []
 
         # Add header row
-        markdown_table.append("| " + " | ".join(rows[0]) + " |")
+        escaped_header = [self._escape_pipe(cell) for cell in rows[0]]
+        markdown_table.append("| " + " | ".join(escaped_header) + " |")
 
         # Add separator row
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
@@ -70,7 +75,8 @@ class CsvConverter(DocumentConverter):
                 row.append("")
             # Truncate if row has more columns than header
             row = row[: len(rows[0])]
-            markdown_table.append("| " + " | ".join(row) + " |")
+            escaped_row = [self._escape_pipe(cell) for cell in row]
+            markdown_table.append("| " + " | ".join(escaped_row) + " |")
 
         result = "\n".join(markdown_table)
 

--- a/packages/markitdown/tests/test_csv_pipe_fix.py
+++ b/packages/markitdown/tests/test_csv_pipe_fix.py
@@ -1,0 +1,23 @@
+import io
+from markitdown.converters._csv_converter import CsvConverter
+from markitdown._stream_info import StreamInfo
+
+# Test CSV with pipe characters
+csv_content = b"""name,description
+John|Doe,Developer|Engineer
+Alice,Manager|Lead"""
+
+converter = CsvConverter()
+stream_info = StreamInfo(extension=".csv", charset="utf-8")
+
+result = converter.convert(
+    io.BytesIO(csv_content),
+    stream_info
+)
+
+print(result.markdown)
+# Output should have escaped pipes:
+# | name | description |
+# | --- | --- |
+# | John\|Doe | Developer\|Engineer |
+# | Alice | Manager\|Lead |


### PR DESCRIPTION
Added a method to escape pipe characters in CSV cells for Markdown tables.

When CSV files contain pipe characters (  |  ) in their cell values, the CsvConverter produces broken Markdown tables because pipe characters are table delimiters in Markdown syntax.

Example Problem:

Code
Input CSV:
name, description
John|Doe,Developer|Engineer
Alice,   #@Manager|Lead

Current Output (BROKEN):
| name | description |
| --- | --- |
| John|Doe | Developer|Engineer |
| Alice | Manager|Lead |

This breaks the Markdown table structure!