### PR TITLE
Add optional desktop GUI entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 src/.DS_Store
 .DS_Store
 .cursorrules
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,38 @@ pip install -e 'packages/markitdown[all]'
 
 ## Usage
 
+### Desktop GUI
+
+This fork includes a desktop GUI for one-shot file conversion. It lets you choose
+an input file and output Markdown path without writing the CLI command manually.
+
+From the repository root:
+
+```bash
+cd packages/markitdown
+python -m venv .venv
+source .venv/bin/activate
+uv pip install -e .
+markitdown-gui
+```
+
+If you already have `.venv` active, refresh the editable install after pulling
+new changes:
+
+```bash
+cd packages/markitdown
+uv pip install -e .
+markitdown-gui
+```
+
+If you use `pip` instead of `uv`:
+
+```bash
+cd packages/markitdown
+pip install -e .
+markitdown-gui
+```
+
 ### Command-Line
 
 ```bash

--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -26,6 +26,19 @@ pip install -e packages/markitdown[all]
 
 ## Usage
 
+### Desktop GUI
+
+This fork includes a desktop GUI for one-shot file conversion:
+
+```bash
+cd packages/markitdown
+uv pip install -e .
+markitdown-gui
+```
+
+If your `.venv` is already active, run `uv pip install -e .` again after pulling
+new changes so GUI and PDF dependencies are installed.
+
 ### Command-Line
 
 ```bash

--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "magika~=0.6.1",
   "charset-normalizer",
   "defusedxml",
+  "customtkinter>=5.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "magika~=0.6.1",
   "charset-normalizer",
   "defusedxml",
-  "customtkinter>=5.2.2",
+  "PySide6-Essentials>=6.8.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -72,6 +72,7 @@ path = "src/markitdown/__about__.py"
 
 [project.scripts]
 markitdown = "markitdown.__main__:main"
+markitdown-gui = "markitdown.gui:main"
 
 [tool.hatch.envs.default]
 features = ["all"]

--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
   "charset-normalizer",
   "defusedxml",
   "PySide6-Essentials>=6.8.0",
+  "pdfminer.six>=20251230",
+  "pdfplumber>=0.11.9",
 ]
 
 [project.optional-dependencies]

--- a/packages/markitdown/src/markitdown/gui.py
+++ b/packages/markitdown/src/markitdown/gui.py
@@ -1,17 +1,30 @@
 from __future__ import annotations
 
-import threading
+import sys
 from pathlib import Path
-from tkinter import filedialog
 from typing import Protocol
 
-import customtkinter as ctk
+from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal, Slot
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ._base_converter import DocumentConverterResult
 from ._markitdown import MarkItDown
 
 APPEARANCE_MODE = "dark"
-COLOR_THEME = "blue"
+GUI_BACKEND = "pyside6"
 
 
 class Converter(Protocol):
@@ -42,189 +55,233 @@ def convert_file_to_markdown(
     destination.write_text(result.markdown, encoding="utf-8")
 
 
-class MarkItDownGUI:
-    def __init__(self, root: ctk.CTk):
-        self.root = root
-        self.root.title("MarkItDown GUI")
-        self.root.geometry("760x430")
-        self.root.minsize(680, 390)
-        self.input_path = ctk.StringVar()
-        self.output_path = ctk.StringVar()
-        self.status = ctk.StringVar(value="Choose an input file and output path.")
+class ConversionSignals(QObject):
+    finished = Signal()
+    failed = Signal(str)
+
+
+class ConversionWorker(QRunnable):
+    def __init__(self, input_path: str, output_path: str):
+        super().__init__()
+        self.input_path = input_path
+        self.output_path = output_path
+        self.signals = ConversionSignals()
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            convert_file_to_markdown(self.input_path, self.output_path)
+        except Exception as exc:
+            self.signals.failed.emit(str(exc))
+        else:
+            self.signals.finished.emit()
+
+
+class MarkItDownGUI(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.thread_pool = QThreadPool.globalInstance()
+        self.setWindowTitle("MarkItDown GUI")
+        self.setMinimumSize(760, 430)
+        self.resize(820, 460)
+
+        self.input_entry = QLineEdit()
+        self.output_entry = QLineEdit()
+        self.status_label = QLabel("Choose an input file and output path.")
+        self.browse_button = QPushButton("Browse")
+        self.choose_button = QPushButton("Choose")
+        self.convert_button = QPushButton("Convert")
 
         self._build()
+        self._connect()
         self._update_convert_state()
 
     def _build(self) -> None:
-        self.root.configure(fg_color="#0f172a")
-        self.root.columnconfigure(0, weight=1)
-        self.root.rowconfigure(0, weight=1)
+        root = QWidget()
+        root.setObjectName("root")
+        self.setCentralWidget(root)
 
-        frame = ctk.CTkFrame(self.root, fg_color="#111827", corner_radius=18)
-        frame.grid(row=0, column=0, sticky="nsew", padx=28, pady=28)
-        frame.columnconfigure(0, weight=1)
+        page = QVBoxLayout(root)
+        page.setContentsMargins(28, 28, 28, 28)
 
-        header = ctk.CTkFrame(frame, fg_color="transparent")
-        header.grid(row=0, column=0, sticky="ew", padx=28, pady=(28, 18))
-        header.columnconfigure(0, weight=1)
+        card = QFrame()
+        card.setObjectName("card")
+        page.addWidget(card)
 
-        ctk.CTkLabel(
-            header,
-            text="MarkItDown",
-            font=ctk.CTkFont(size=28, weight="bold"),
-            text_color="#f8fafc",
-        ).grid(row=0, column=0, sticky="w")
-        ctk.CTkLabel(
-            header,
-            text="Convert one document into Markdown",
-            font=ctk.CTkFont(size=14),
-            text_color="#94a3b8",
-        ).grid(row=1, column=0, sticky="w", pady=(4, 0))
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(30, 30, 30, 26)
+        layout.setSpacing(22)
 
-        fields = ctk.CTkFrame(frame, fg_color="#0b1220", corner_radius=14)
-        fields.grid(row=1, column=0, sticky="ew", padx=28, pady=(0, 18))
-        fields.columnconfigure(1, weight=1)
+        title = QLabel("MarkItDown")
+        title.setObjectName("title")
+        subtitle = QLabel("Convert one document into Markdown")
+        subtitle.setObjectName("subtitle")
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
 
-        ctk.CTkLabel(
-            fields,
-            text="Input file",
-            font=ctk.CTkFont(size=13, weight="bold"),
-            text_color="#e5e7eb",
-        ).grid(row=0, column=0, sticky="w", padx=(18, 12), pady=(18, 8))
-        self.input_entry = ctk.CTkEntry(
-            fields,
-            textvariable=self.input_path,
-            state="disabled",
-            height=40,
-            fg_color="#111827",
-            border_color="#334155",
-            text_color="#f8fafc",
-        )
-        self.input_entry.grid(row=0, column=1, sticky="ew", padx=0, pady=(18, 8))
-        self.browse_button = ctk.CTkButton(
-            fields,
-            text="Browse",
-            command=self._browse_input,
-            width=108,
-            height=40,
-        )
-        self.browse_button.grid(row=0, column=2, padx=(12, 18), pady=(18, 8))
+        fields = QFrame()
+        fields.setObjectName("fields")
+        grid = QGridLayout(fields)
+        grid.setContentsMargins(18, 18, 18, 18)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(14)
+        grid.setColumnStretch(1, 1)
 
-        ctk.CTkLabel(
-            fields,
-            text="Output file",
-            font=ctk.CTkFont(size=13, weight="bold"),
-            text_color="#e5e7eb",
-        ).grid(row=1, column=0, sticky="w", padx=(18, 12), pady=(8, 18))
-        self.output_entry = ctk.CTkEntry(
-            fields,
-            textvariable=self.output_path,
-            height=40,
-            fg_color="#111827",
-            border_color="#334155",
-            text_color="#f8fafc",
-        )
-        self.output_entry.grid(row=1, column=1, sticky="ew", padx=0, pady=(8, 18))
-        self.choose_button = ctk.CTkButton(
-            fields,
-            text="Choose",
-            command=self._choose_output,
-            width=108,
-            height=40,
-            fg_color="#334155",
-            hover_color="#475569",
-        )
-        self.choose_button.grid(row=1, column=2, padx=(12, 18), pady=(8, 18))
+        self.input_entry.setReadOnly(True)
+        self.input_entry.setPlaceholderText("Select source file")
+        self.output_entry.setPlaceholderText("Choose markdown output path")
+        self.browse_button.setFixedWidth(110)
+        self.choose_button.setFixedWidth(110)
 
-        actions = ctk.CTkFrame(frame, fg_color="transparent")
-        actions.grid(row=2, column=0, sticky="ew", padx=28, pady=(0, 18))
-        actions.columnconfigure(0, weight=1)
+        grid.addWidget(QLabel("Input file"), 0, 0)
+        grid.addWidget(self.input_entry, 0, 1)
+        grid.addWidget(self.browse_button, 0, 2)
+        grid.addWidget(QLabel("Output file"), 1, 0)
+        grid.addWidget(self.output_entry, 1, 1)
+        grid.addWidget(self.choose_button, 1, 2)
+        layout.addWidget(fields)
 
-        self.status_label = ctk.CTkLabel(
-            actions,
-            textvariable=self.status,
-            font=ctk.CTkFont(size=13),
-            text_color="#cbd5e1",
-            anchor="w",
-            justify="left",
-            wraplength=480,
-        )
-        self.status_label.grid(row=0, column=0, sticky="ew", padx=(0, 18))
+        actions = QHBoxLayout()
+        self.status_label.setObjectName("status")
+        self.status_label.setWordWrap(True)
+        self.status_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self.convert_button.setObjectName("primary")
+        self.convert_button.setFixedSize(148, 44)
+        actions.addWidget(self.status_label)
+        actions.addWidget(self.convert_button)
+        layout.addLayout(actions)
 
-        self.convert_button = ctk.CTkButton(
-            actions,
-            text="Convert",
-            command=self._convert,
-            width=148,
-            height=44,
-            font=ctk.CTkFont(size=15, weight="bold"),
-        )
-        self.convert_button.grid(row=0, column=1, sticky="e")
+        self.setStyleSheet(DARK_STYLESHEET)
 
-        self.input_path.trace_add("write", lambda *_: self._update_convert_state())
-        self.output_path.trace_add("write", lambda *_: self._update_convert_state())
+    def _connect(self) -> None:
+        self.browse_button.clicked.connect(self._browse_input)
+        self.choose_button.clicked.connect(self._choose_output)
+        self.convert_button.clicked.connect(self._convert)
+        self.input_entry.textChanged.connect(self._update_convert_state)
+        self.output_entry.textChanged.connect(self._update_convert_state)
 
     def _browse_input(self) -> None:
-        selected = filedialog.askopenfilename(title="Choose input file")
+        selected, _ = QFileDialog.getOpenFileName(self, "Choose input file")
         if not selected:
             return
-
         path = Path(selected)
-        self.input_path.set(str(path))
-        self.output_path.set(str(path.with_suffix(".md")))
-        self.status.set("Ready to convert.")
+        self.input_entry.setText(str(path))
+        self.output_entry.setText(str(path.with_suffix(".md")))
+        self.status_label.setText("Ready to convert.")
 
     def _choose_output(self) -> None:
-        initial = Path(self.output_path.get()) if self.output_path.get() else None
-        selected = filedialog.asksaveasfilename(
-            title="Choose output Markdown file",
-            defaultextension=".md",
-            filetypes=[("Markdown files", "*.md"), ("All files", "*.*")],
-            initialdir=str(initial.parent) if initial else None,
-            initialfile=initial.name if initial else None,
+        current = self.output_entry.text().strip()
+        initial = current or str(Path.cwd() / "output.md")
+        selected, _ = QFileDialog.getSaveFileName(
+            self,
+            "Choose output Markdown file",
+            initial,
+            "Markdown files (*.md);;All files (*)",
         )
         if selected:
-            self.output_path.set(selected)
+            path = Path(selected)
+            if path.suffix == "":
+                path = path.with_suffix(".md")
+            self.output_entry.setText(str(path))
 
     def _set_busy(self, busy: bool) -> None:
-        state = "disabled" if busy else "normal"
-        self.browse_button.configure(state=state)
-        self.choose_button.configure(state=state)
-        self.output_entry.configure(state=state)
-        self.convert_button.configure(state="disabled" if busy else "normal")
+        for widget in (
+            self.input_entry,
+            self.output_entry,
+            self.browse_button,
+            self.choose_button,
+            self.convert_button,
+        ):
+            widget.setEnabled(not busy)
 
     def _update_convert_state(self) -> None:
-        state = "normal" if self.input_path.get() and self.output_path.get() else "disabled"
-        self.convert_button.configure(state=state)
+        has_paths = bool(self.input_entry.text().strip() and self.output_entry.text().strip())
+        self.convert_button.setEnabled(has_paths)
 
     def _convert(self) -> None:
         self._set_busy(True)
-        self.status.set("Converting...")
+        self.status_label.setText("Converting...")
 
-        def worker() -> None:
-            try:
-                convert_file_to_markdown(self.input_path.get(), self.output_path.get())
-            except Exception as exc:
-                self.root.after(0, lambda: self._finish_with_error(exc))
-            else:
-                self.root.after(0, self._finish_success)
-
-        threading.Thread(target=worker, daemon=True).start()
+        worker = ConversionWorker(self.input_entry.text(), self.output_entry.text())
+        worker.signals.finished.connect(self._finish_success)
+        worker.signals.failed.connect(self._finish_with_error)
+        self.thread_pool.start(worker)
 
     def _finish_success(self) -> None:
         self._set_busy(False)
-        self.status.set(f"Done: {self.output_path.get()}")
+        self.status_label.setText(f"Done: {self.output_entry.text()}")
         self._update_convert_state()
 
-    def _finish_with_error(self, exc: Exception) -> None:
+    def _finish_with_error(self, message: str) -> None:
         self._set_busy(False)
-        self.status.set(f"Error: {exc}")
+        self.status_label.setText(f"Error: {message}")
         self._update_convert_state()
+
+
+DARK_STYLESHEET = """
+QWidget#root {
+    background: #0f172a;
+    color: #e5e7eb;
+    font-family: Inter, Segoe UI, Arial, sans-serif;
+    font-size: 13px;
+}
+QFrame#card {
+    background: #111827;
+    border-radius: 18px;
+}
+QFrame#fields {
+    background: #0b1220;
+    border-radius: 14px;
+}
+QLabel {
+    color: #e5e7eb;
+}
+QLabel#title {
+    color: #f8fafc;
+    font-size: 28px;
+    font-weight: 700;
+}
+QLabel#subtitle, QLabel#status {
+    color: #94a3b8;
+}
+QLineEdit {
+    background: #111827;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    color: #f8fafc;
+    min-height: 38px;
+    padding: 0 12px;
+}
+QLineEdit:focus {
+    border-color: #3b82f6;
+}
+QPushButton {
+    background: #334155;
+    border: 0;
+    border-radius: 8px;
+    color: #f8fafc;
+    min-height: 38px;
+    padding: 0 16px;
+}
+QPushButton:hover {
+    background: #475569;
+}
+QPushButton:disabled {
+    background: #1e293b;
+    color: #64748b;
+}
+QPushButton#primary {
+    background: #2563eb;
+    font-weight: 700;
+}
+QPushButton#primary:hover {
+    background: #1d4ed8;
+}
+"""
 
 
 def main() -> None:
-    ctk.set_appearance_mode(APPEARANCE_MODE)
-    ctk.set_default_color_theme(COLOR_THEME)
-    root = ctk.CTk()
-    MarkItDownGUI(root)
-    root.mainloop()
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = MarkItDownGUI()
+    window.show()
+    raise SystemExit(app.exec())

--- a/packages/markitdown/src/markitdown/gui.py
+++ b/packages/markitdown/src/markitdown/gui.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Literal, Protocol
+from tkinter import filedialog
+from typing import Protocol
 
 import customtkinter as ctk
 
@@ -12,23 +12,6 @@ from ._markitdown import MarkItDown
 
 APPEARANCE_MODE = "dark"
 COLOR_THEME = "blue"
-
-
-@dataclass(frozen=True)
-class DirectoryEntry:
-    path: Path
-    name: str
-    is_dir: bool
-
-
-def list_directory_entries(directory: str | Path) -> list[DirectoryEntry]:
-    path = Path(directory).expanduser().resolve()
-    entries = [
-        DirectoryEntry(child, child.name, child.is_dir())
-        for child in path.iterdir()
-        if not child.name.startswith("__pycache__")
-    ]
-    return sorted(entries, key=lambda entry: (not entry.is_dir, entry.name.lower()))
 
 
 class Converter(Protocol):
@@ -182,31 +165,26 @@ class MarkItDownGUI:
         self.output_path.trace_add("write", lambda *_: self._update_convert_state())
 
     def _browse_input(self) -> None:
-        ModernFilePicker(
-            self.root,
-            mode="open",
-            title="Choose input file",
-            initial_path=Path(self.input_path.get()).parent
-            if self.input_path.get()
-            else Path.cwd(),
-            on_select=self._set_input_file,
-        )
+        selected = filedialog.askopenfilename(title="Choose input file")
+        if not selected:
+            return
 
-    def _choose_output(self) -> None:
-        initial = Path(self.output_path.get()) if self.output_path.get() else None
-        ModernFilePicker(
-            self.root,
-            mode="save",
-            title="Choose output Markdown file",
-            initial_path=initial.parent if initial else Path.cwd(),
-            initial_name=initial.name if initial else "output.md",
-            on_select=lambda path: self.output_path.set(str(path)),
-        )
-
-    def _set_input_file(self, path: Path) -> None:
+        path = Path(selected)
         self.input_path.set(str(path))
         self.output_path.set(str(path.with_suffix(".md")))
         self.status.set("Ready to convert.")
+
+    def _choose_output(self) -> None:
+        initial = Path(self.output_path.get()) if self.output_path.get() else None
+        selected = filedialog.asksaveasfilename(
+            title="Choose output Markdown file",
+            defaultextension=".md",
+            filetypes=[("Markdown files", "*.md"), ("All files", "*.*")],
+            initialdir=str(initial.parent) if initial else None,
+            initialfile=initial.name if initial else None,
+        )
+        if selected:
+            self.output_path.set(selected)
 
     def _set_busy(self, busy: bool) -> None:
         state = "disabled" if busy else "normal"
@@ -242,156 +220,6 @@ class MarkItDownGUI:
         self._set_busy(False)
         self.status.set(f"Error: {exc}")
         self._update_convert_state()
-
-
-class ModernFilePicker(ctk.CTkToplevel):
-    def __init__(
-        self,
-        parent: ctk.CTk,
-        *,
-        mode: Literal["open", "save"],
-        title: str,
-        initial_path: str | Path,
-        on_select: Callable[[Path], None],
-        initial_name: str = "",
-    ):
-        super().__init__(parent)
-        self.mode = mode
-        self.current_dir = Path(initial_path).expanduser().resolve()
-        self.on_select = on_select
-        self.filename = ctk.StringVar(value=initial_name)
-        self.path_label = ctk.StringVar(value=str(self.current_dir))
-
-        self.title(title)
-        self.geometry("760x520")
-        self.minsize(640, 440)
-        self.configure(fg_color="#0f172a")
-        self.transient(parent)
-        self.grab_set()
-
-        self._build(title)
-        self._refresh()
-
-    def _build(self, title: str) -> None:
-        self.columnconfigure(0, weight=1)
-        self.rowconfigure(1, weight=1)
-
-        header = ctk.CTkFrame(self, fg_color="transparent")
-        header.grid(row=0, column=0, sticky="ew", padx=22, pady=(22, 12))
-        header.columnconfigure(1, weight=1)
-
-        ctk.CTkLabel(
-            header,
-            text=title,
-            font=ctk.CTkFont(size=22, weight="bold"),
-            text_color="#f8fafc",
-        ).grid(row=0, column=0, sticky="w")
-        ctk.CTkButton(
-            header,
-            text="Up",
-            width=74,
-            fg_color="#334155",
-            hover_color="#475569",
-            command=self._go_up,
-        ).grid(row=0, column=2, sticky="e")
-
-        path_bar = ctk.CTkEntry(
-            header,
-            textvariable=self.path_label,
-            state="disabled",
-            height=36,
-            fg_color="#111827",
-            border_color="#334155",
-            text_color="#cbd5e1",
-        )
-        path_bar.grid(row=1, column=0, columnspan=3, sticky="ew", pady=(12, 0))
-
-        self.list_frame = ctk.CTkScrollableFrame(
-            self,
-            fg_color="#111827",
-            corner_radius=14,
-            scrollbar_button_color="#334155",
-            scrollbar_button_hover_color="#475569",
-        )
-        self.list_frame.grid(row=1, column=0, sticky="nsew", padx=22, pady=(0, 14))
-        self.list_frame.columnconfigure(0, weight=1)
-
-        footer = ctk.CTkFrame(self, fg_color="transparent")
-        footer.grid(row=2, column=0, sticky="ew", padx=22, pady=(0, 22))
-        footer.columnconfigure(0, weight=1)
-
-        self.name_entry = ctk.CTkEntry(
-            footer,
-            textvariable=self.filename,
-            placeholder_text="File name",
-            height=40,
-            fg_color="#111827",
-            border_color="#334155",
-            text_color="#f8fafc",
-        )
-        self.name_entry.grid(row=0, column=0, sticky="ew", padx=(0, 12))
-        ctk.CTkButton(
-            footer,
-            text="Cancel",
-            width=100,
-            height=40,
-            fg_color="#334155",
-            hover_color="#475569",
-            command=self.destroy,
-        ).grid(row=0, column=1, padx=(0, 10))
-        ctk.CTkButton(
-            footer,
-            text="Open" if self.mode == "open" else "Save",
-            width=100,
-            height=40,
-            command=self._confirm,
-        ).grid(row=0, column=2)
-
-    def _refresh(self) -> None:
-        self.path_label.set(str(self.current_dir))
-        for child in self.list_frame.winfo_children():
-            child.destroy()
-
-        for row, entry in enumerate(list_directory_entries(self.current_dir)):
-            label = f"{'Folder' if entry.is_dir else 'File'}  {entry.name}"
-            button = ctk.CTkButton(
-                self.list_frame,
-                text=label,
-                anchor="w",
-                height=38,
-                fg_color="transparent",
-                hover_color="#1e293b",
-                text_color="#e5e7eb",
-                command=lambda item=entry: self._choose_entry(item),
-            )
-            button.grid(row=row, column=0, sticky="ew", padx=8, pady=3)
-
-    def _go_up(self) -> None:
-        parent = self.current_dir.parent
-        if parent != self.current_dir:
-            self.current_dir = parent
-            self._refresh()
-
-    def _choose_entry(self, entry: DirectoryEntry) -> None:
-        if entry.is_dir:
-            self.current_dir = entry.path
-            self._refresh()
-            return
-        self.filename.set(entry.name)
-        if self.mode == "open":
-            self._confirm()
-
-    def _confirm(self) -> None:
-        name = self.filename.get().strip()
-        if not name:
-            return
-        selected = self.current_dir / name
-        if self.mode == "open" and not selected.is_file():
-            return
-        if self.mode == "save" and selected.suffix == "":
-            selected = selected.with_suffix(".md")
-        self.on_select(selected)
-        self.destroy()
 
 
 def main() -> None:

--- a/packages/markitdown/src/markitdown/gui.py
+++ b/packages/markitdown/src/markitdown/gui.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from ._base_converter import DocumentConverterResult
+from ._markitdown import MarkItDown
+
+
+class Converter(Protocol):
+    def convert(self, path: Path) -> DocumentConverterResult:
+        ...
+
+
+def convert_file_to_markdown(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    converter: Converter | None = None,
+) -> None:
+    source = Path(input_path) if input_path else None
+    destination = Path(output_path) if output_path else None
+
+    if source is None or not source.exists():
+        raise ValueError("Input file does not exist.")
+    if not source.is_file():
+        raise ValueError("Input path is not a file.")
+    if destination is None:
+        raise ValueError("Output path is required.")
+    if not destination.parent.exists():
+        raise ValueError("Output directory does not exist.")
+
+    active_converter = converter or MarkItDown(enable_plugins=False)
+    result = active_converter.convert(source)
+    destination.write_text(result.markdown, encoding="utf-8")

--- a/packages/markitdown/src/markitdown/gui.py
+++ b/packages/markitdown/src/markitdown/gui.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
-from tkinter import Tk, StringVar, filedialog, ttk
+from tkinter import filedialog
 from typing import Protocol
+
+import customtkinter as ctk
 
 from ._base_converter import DocumentConverterResult
 from ._markitdown import MarkItDown
+
+APPEARANCE_MODE = "dark"
+COLOR_THEME = "blue"
 
 
 class Converter(Protocol):
@@ -38,46 +43,123 @@ def convert_file_to_markdown(
 
 
 class MarkItDownGUI:
-    def __init__(self, root: Tk):
+    def __init__(self, root: ctk.CTk):
         self.root = root
         self.root.title("MarkItDown GUI")
-        self.input_path = StringVar()
-        self.output_path = StringVar()
-        self.status = StringVar(value="Choose an input file and output path.")
+        self.root.geometry("760x430")
+        self.root.minsize(680, 390)
+        self.input_path = ctk.StringVar()
+        self.output_path = ctk.StringVar()
+        self.status = ctk.StringVar(value="Choose an input file and output path.")
 
         self._build()
         self._update_convert_state()
 
     def _build(self) -> None:
-        frame = ttk.Frame(self.root, padding=16)
-        frame.grid(row=0, column=0, sticky="nsew")
+        self.root.configure(fg_color="#0f172a")
         self.root.columnconfigure(0, weight=1)
         self.root.rowconfigure(0, weight=1)
-        frame.columnconfigure(1, weight=1)
 
-        ttk.Label(frame, text="Input file").grid(row=0, column=0, sticky="w", pady=4)
-        self.input_entry = ttk.Entry(
-            frame, textvariable=self.input_path, state="readonly", width=56
+        frame = ctk.CTkFrame(self.root, fg_color="#111827", corner_radius=18)
+        frame.grid(row=0, column=0, sticky="nsew", padx=28, pady=28)
+        frame.columnconfigure(0, weight=1)
+
+        header = ctk.CTkFrame(frame, fg_color="transparent")
+        header.grid(row=0, column=0, sticky="ew", padx=28, pady=(28, 18))
+        header.columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(
+            header,
+            text="MarkItDown",
+            font=ctk.CTkFont(size=28, weight="bold"),
+            text_color="#f8fafc",
+        ).grid(row=0, column=0, sticky="w")
+        ctk.CTkLabel(
+            header,
+            text="Convert one document into Markdown",
+            font=ctk.CTkFont(size=14),
+            text_color="#94a3b8",
+        ).grid(row=1, column=0, sticky="w", pady=(4, 0))
+
+        fields = ctk.CTkFrame(frame, fg_color="#0b1220", corner_radius=14)
+        fields.grid(row=1, column=0, sticky="ew", padx=28, pady=(0, 18))
+        fields.columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(
+            fields,
+            text="Input file",
+            font=ctk.CTkFont(size=13, weight="bold"),
+            text_color="#e5e7eb",
+        ).grid(row=0, column=0, sticky="w", padx=(18, 12), pady=(18, 8))
+        self.input_entry = ctk.CTkEntry(
+            fields,
+            textvariable=self.input_path,
+            state="disabled",
+            height=40,
+            fg_color="#111827",
+            border_color="#334155",
+            text_color="#f8fafc",
         )
-        self.input_entry.grid(row=0, column=1, sticky="ew", padx=8, pady=4)
-        self.browse_button = ttk.Button(
-            frame, text="Browse", command=self._browse_input
+        self.input_entry.grid(row=0, column=1, sticky="ew", padx=0, pady=(18, 8))
+        self.browse_button = ctk.CTkButton(
+            fields,
+            text="Browse",
+            command=self._browse_input,
+            width=108,
+            height=40,
         )
-        self.browse_button.grid(row=0, column=2, pady=4)
+        self.browse_button.grid(row=0, column=2, padx=(12, 18), pady=(18, 8))
 
-        ttk.Label(frame, text="Output file").grid(row=1, column=0, sticky="w", pady=4)
-        self.output_entry = ttk.Entry(frame, textvariable=self.output_path, width=56)
-        self.output_entry.grid(row=1, column=1, sticky="ew", padx=8, pady=4)
-        self.choose_button = ttk.Button(
-            frame, text="Choose", command=self._choose_output
+        ctk.CTkLabel(
+            fields,
+            text="Output file",
+            font=ctk.CTkFont(size=13, weight="bold"),
+            text_color="#e5e7eb",
+        ).grid(row=1, column=0, sticky="w", padx=(18, 12), pady=(8, 18))
+        self.output_entry = ctk.CTkEntry(
+            fields,
+            textvariable=self.output_path,
+            height=40,
+            fg_color="#111827",
+            border_color="#334155",
+            text_color="#f8fafc",
         )
-        self.choose_button.grid(row=1, column=2, pady=4)
+        self.output_entry.grid(row=1, column=1, sticky="ew", padx=0, pady=(8, 18))
+        self.choose_button = ctk.CTkButton(
+            fields,
+            text="Choose",
+            command=self._choose_output,
+            width=108,
+            height=40,
+            fg_color="#334155",
+            hover_color="#475569",
+        )
+        self.choose_button.grid(row=1, column=2, padx=(12, 18), pady=(8, 18))
 
-        self.convert_button = ttk.Button(frame, text="Convert", command=self._convert)
-        self.convert_button.grid(row=2, column=1, sticky="e", padx=8, pady=(12, 4))
+        actions = ctk.CTkFrame(frame, fg_color="transparent")
+        actions.grid(row=2, column=0, sticky="ew", padx=28, pady=(0, 18))
+        actions.columnconfigure(0, weight=1)
 
-        self.status_label = ttk.Label(frame, textvariable=self.status, wraplength=520)
-        self.status_label.grid(row=3, column=0, columnspan=3, sticky="ew", pady=(12, 0))
+        self.status_label = ctk.CTkLabel(
+            actions,
+            textvariable=self.status,
+            font=ctk.CTkFont(size=13),
+            text_color="#cbd5e1",
+            anchor="w",
+            justify="left",
+            wraplength=480,
+        )
+        self.status_label.grid(row=0, column=0, sticky="ew", padx=(0, 18))
+
+        self.convert_button = ctk.CTkButton(
+            actions,
+            text="Convert",
+            command=self._convert,
+            width=148,
+            height=44,
+            font=ctk.CTkFont(size=15, weight="bold"),
+        )
+        self.convert_button.grid(row=0, column=1, sticky="e")
 
         self.input_path.trace_add("write", lambda *_: self._update_convert_state())
         self.output_path.trace_add("write", lambda *_: self._update_convert_state())
@@ -141,6 +223,8 @@ class MarkItDownGUI:
 
 
 def main() -> None:
-    root = Tk()
+    ctk.set_appearance_mode(APPEARANCE_MODE)
+    ctk.set_default_color_theme(COLOR_THEME)
+    root = ctk.CTk()
     MarkItDownGUI(root)
     root.mainloop()

--- a/packages/markitdown/src/markitdown/gui.py
+++ b/packages/markitdown/src/markitdown/gui.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import threading
 from pathlib import Path
+from tkinter import Tk, StringVar, filedialog, ttk
 from typing import Protocol
 
 from ._base_converter import DocumentConverterResult
@@ -33,3 +35,112 @@ def convert_file_to_markdown(
     active_converter = converter or MarkItDown(enable_plugins=False)
     result = active_converter.convert(source)
     destination.write_text(result.markdown, encoding="utf-8")
+
+
+class MarkItDownGUI:
+    def __init__(self, root: Tk):
+        self.root = root
+        self.root.title("MarkItDown GUI")
+        self.input_path = StringVar()
+        self.output_path = StringVar()
+        self.status = StringVar(value="Choose an input file and output path.")
+
+        self._build()
+        self._update_convert_state()
+
+    def _build(self) -> None:
+        frame = ttk.Frame(self.root, padding=16)
+        frame.grid(row=0, column=0, sticky="nsew")
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(0, weight=1)
+        frame.columnconfigure(1, weight=1)
+
+        ttk.Label(frame, text="Input file").grid(row=0, column=0, sticky="w", pady=4)
+        self.input_entry = ttk.Entry(
+            frame, textvariable=self.input_path, state="readonly", width=56
+        )
+        self.input_entry.grid(row=0, column=1, sticky="ew", padx=8, pady=4)
+        self.browse_button = ttk.Button(
+            frame, text="Browse", command=self._browse_input
+        )
+        self.browse_button.grid(row=0, column=2, pady=4)
+
+        ttk.Label(frame, text="Output file").grid(row=1, column=0, sticky="w", pady=4)
+        self.output_entry = ttk.Entry(frame, textvariable=self.output_path, width=56)
+        self.output_entry.grid(row=1, column=1, sticky="ew", padx=8, pady=4)
+        self.choose_button = ttk.Button(
+            frame, text="Choose", command=self._choose_output
+        )
+        self.choose_button.grid(row=1, column=2, pady=4)
+
+        self.convert_button = ttk.Button(frame, text="Convert", command=self._convert)
+        self.convert_button.grid(row=2, column=1, sticky="e", padx=8, pady=(12, 4))
+
+        self.status_label = ttk.Label(frame, textvariable=self.status, wraplength=520)
+        self.status_label.grid(row=3, column=0, columnspan=3, sticky="ew", pady=(12, 0))
+
+        self.input_path.trace_add("write", lambda *_: self._update_convert_state())
+        self.output_path.trace_add("write", lambda *_: self._update_convert_state())
+
+    def _browse_input(self) -> None:
+        selected = filedialog.askopenfilename(title="Choose input file")
+        if not selected:
+            return
+
+        path = Path(selected)
+        self.input_path.set(str(path))
+        self.output_path.set(str(path.with_suffix(".md")))
+        self.status.set("Ready to convert.")
+
+    def _choose_output(self) -> None:
+        initial = Path(self.output_path.get()) if self.output_path.get() else None
+        selected = filedialog.asksaveasfilename(
+            title="Choose output Markdown file",
+            defaultextension=".md",
+            filetypes=[("Markdown files", "*.md"), ("All files", "*.*")],
+            initialdir=str(initial.parent) if initial else None,
+            initialfile=initial.name if initial else None,
+        )
+        if selected:
+            self.output_path.set(selected)
+
+    def _set_busy(self, busy: bool) -> None:
+        state = "disabled" if busy else "normal"
+        self.browse_button.configure(state=state)
+        self.choose_button.configure(state=state)
+        self.output_entry.configure(state=state)
+        self.convert_button.configure(state="disabled" if busy else "normal")
+
+    def _update_convert_state(self) -> None:
+        state = "normal" if self.input_path.get() and self.output_path.get() else "disabled"
+        self.convert_button.configure(state=state)
+
+    def _convert(self) -> None:
+        self._set_busy(True)
+        self.status.set("Converting...")
+
+        def worker() -> None:
+            try:
+                convert_file_to_markdown(self.input_path.get(), self.output_path.get())
+            except Exception as exc:
+                self.root.after(0, lambda: self._finish_with_error(exc))
+            else:
+                self.root.after(0, self._finish_success)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _finish_success(self) -> None:
+        self._set_busy(False)
+        self.status.set(f"Done: {self.output_path.get()}")
+        self._update_convert_state()
+
+    def _finish_with_error(self, exc: Exception) -> None:
+        self._set_busy(False)
+        self.status.set(f"Error: {exc}")
+        self._update_convert_state()
+
+
+def main() -> None:
+    root = Tk()
+    MarkItDownGUI(root)
+    root.mainloop()

--- a/packages/markitdown/src/markitdown/gui.py
+++ b/packages/markitdown/src/markitdown/gui.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from pathlib import Path
-from tkinter import filedialog
-from typing import Protocol
+from typing import Callable, Literal, Protocol
 
 import customtkinter as ctk
 
@@ -12,6 +12,23 @@ from ._markitdown import MarkItDown
 
 APPEARANCE_MODE = "dark"
 COLOR_THEME = "blue"
+
+
+@dataclass(frozen=True)
+class DirectoryEntry:
+    path: Path
+    name: str
+    is_dir: bool
+
+
+def list_directory_entries(directory: str | Path) -> list[DirectoryEntry]:
+    path = Path(directory).expanduser().resolve()
+    entries = [
+        DirectoryEntry(child, child.name, child.is_dir())
+        for child in path.iterdir()
+        if not child.name.startswith("__pycache__")
+    ]
+    return sorted(entries, key=lambda entry: (not entry.is_dir, entry.name.lower()))
 
 
 class Converter(Protocol):
@@ -165,26 +182,31 @@ class MarkItDownGUI:
         self.output_path.trace_add("write", lambda *_: self._update_convert_state())
 
     def _browse_input(self) -> None:
-        selected = filedialog.askopenfilename(title="Choose input file")
-        if not selected:
-            return
-
-        path = Path(selected)
-        self.input_path.set(str(path))
-        self.output_path.set(str(path.with_suffix(".md")))
-        self.status.set("Ready to convert.")
+        ModernFilePicker(
+            self.root,
+            mode="open",
+            title="Choose input file",
+            initial_path=Path(self.input_path.get()).parent
+            if self.input_path.get()
+            else Path.cwd(),
+            on_select=self._set_input_file,
+        )
 
     def _choose_output(self) -> None:
         initial = Path(self.output_path.get()) if self.output_path.get() else None
-        selected = filedialog.asksaveasfilename(
+        ModernFilePicker(
+            self.root,
+            mode="save",
             title="Choose output Markdown file",
-            defaultextension=".md",
-            filetypes=[("Markdown files", "*.md"), ("All files", "*.*")],
-            initialdir=str(initial.parent) if initial else None,
-            initialfile=initial.name if initial else None,
+            initial_path=initial.parent if initial else Path.cwd(),
+            initial_name=initial.name if initial else "output.md",
+            on_select=lambda path: self.output_path.set(str(path)),
         )
-        if selected:
-            self.output_path.set(selected)
+
+    def _set_input_file(self, path: Path) -> None:
+        self.input_path.set(str(path))
+        self.output_path.set(str(path.with_suffix(".md")))
+        self.status.set("Ready to convert.")
 
     def _set_busy(self, busy: bool) -> None:
         state = "disabled" if busy else "normal"
@@ -220,6 +242,156 @@ class MarkItDownGUI:
         self._set_busy(False)
         self.status.set(f"Error: {exc}")
         self._update_convert_state()
+
+
+class ModernFilePicker(ctk.CTkToplevel):
+    def __init__(
+        self,
+        parent: ctk.CTk,
+        *,
+        mode: Literal["open", "save"],
+        title: str,
+        initial_path: str | Path,
+        on_select: Callable[[Path], None],
+        initial_name: str = "",
+    ):
+        super().__init__(parent)
+        self.mode = mode
+        self.current_dir = Path(initial_path).expanduser().resolve()
+        self.on_select = on_select
+        self.filename = ctk.StringVar(value=initial_name)
+        self.path_label = ctk.StringVar(value=str(self.current_dir))
+
+        self.title(title)
+        self.geometry("760x520")
+        self.minsize(640, 440)
+        self.configure(fg_color="#0f172a")
+        self.transient(parent)
+        self.grab_set()
+
+        self._build(title)
+        self._refresh()
+
+    def _build(self, title: str) -> None:
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(1, weight=1)
+
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.grid(row=0, column=0, sticky="ew", padx=22, pady=(22, 12))
+        header.columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(
+            header,
+            text=title,
+            font=ctk.CTkFont(size=22, weight="bold"),
+            text_color="#f8fafc",
+        ).grid(row=0, column=0, sticky="w")
+        ctk.CTkButton(
+            header,
+            text="Up",
+            width=74,
+            fg_color="#334155",
+            hover_color="#475569",
+            command=self._go_up,
+        ).grid(row=0, column=2, sticky="e")
+
+        path_bar = ctk.CTkEntry(
+            header,
+            textvariable=self.path_label,
+            state="disabled",
+            height=36,
+            fg_color="#111827",
+            border_color="#334155",
+            text_color="#cbd5e1",
+        )
+        path_bar.grid(row=1, column=0, columnspan=3, sticky="ew", pady=(12, 0))
+
+        self.list_frame = ctk.CTkScrollableFrame(
+            self,
+            fg_color="#111827",
+            corner_radius=14,
+            scrollbar_button_color="#334155",
+            scrollbar_button_hover_color="#475569",
+        )
+        self.list_frame.grid(row=1, column=0, sticky="nsew", padx=22, pady=(0, 14))
+        self.list_frame.columnconfigure(0, weight=1)
+
+        footer = ctk.CTkFrame(self, fg_color="transparent")
+        footer.grid(row=2, column=0, sticky="ew", padx=22, pady=(0, 22))
+        footer.columnconfigure(0, weight=1)
+
+        self.name_entry = ctk.CTkEntry(
+            footer,
+            textvariable=self.filename,
+            placeholder_text="File name",
+            height=40,
+            fg_color="#111827",
+            border_color="#334155",
+            text_color="#f8fafc",
+        )
+        self.name_entry.grid(row=0, column=0, sticky="ew", padx=(0, 12))
+        ctk.CTkButton(
+            footer,
+            text="Cancel",
+            width=100,
+            height=40,
+            fg_color="#334155",
+            hover_color="#475569",
+            command=self.destroy,
+        ).grid(row=0, column=1, padx=(0, 10))
+        ctk.CTkButton(
+            footer,
+            text="Open" if self.mode == "open" else "Save",
+            width=100,
+            height=40,
+            command=self._confirm,
+        ).grid(row=0, column=2)
+
+    def _refresh(self) -> None:
+        self.path_label.set(str(self.current_dir))
+        for child in self.list_frame.winfo_children():
+            child.destroy()
+
+        for row, entry in enumerate(list_directory_entries(self.current_dir)):
+            label = f"{'Folder' if entry.is_dir else 'File'}  {entry.name}"
+            button = ctk.CTkButton(
+                self.list_frame,
+                text=label,
+                anchor="w",
+                height=38,
+                fg_color="transparent",
+                hover_color="#1e293b",
+                text_color="#e5e7eb",
+                command=lambda item=entry: self._choose_entry(item),
+            )
+            button.grid(row=row, column=0, sticky="ew", padx=8, pady=3)
+
+    def _go_up(self) -> None:
+        parent = self.current_dir.parent
+        if parent != self.current_dir:
+            self.current_dir = parent
+            self._refresh()
+
+    def _choose_entry(self, entry: DirectoryEntry) -> None:
+        if entry.is_dir:
+            self.current_dir = entry.path
+            self._refresh()
+            return
+        self.filename.set(entry.name)
+        if self.mode == "open":
+            self._confirm()
+
+    def _confirm(self) -> None:
+        name = self.filename.get().strip()
+        if not name:
+            return
+        selected = self.current_dir / name
+        if self.mode == "open" and not selected.is_file():
+            return
+        if self.mode == "save" and selected.suffix == "":
+            selected = selected.with_suffix(".md")
+        self.on_select(selected)
+        self.destroy()
 
 
 def main() -> None:

--- a/packages/markitdown/tests/test_gui.py
+++ b/packages/markitdown/tests/test_gui.py
@@ -4,12 +4,7 @@ import tomllib
 
 import pytest
 
-from markitdown.gui import (
-    APPEARANCE_MODE,
-    ModernFilePicker,
-    convert_file_to_markdown,
-    list_directory_entries,
-)
+from markitdown.gui import APPEARANCE_MODE, convert_file_to_markdown
 
 
 class FakeConverter:
@@ -104,21 +99,3 @@ def test_markitdown_gui_depends_on_customtkinter():
     )
 
     assert "customtkinter>=5.2.2" in pyproject["project"]["dependencies"]
-
-
-def test_list_directory_entries_sorts_directories_before_files(tmp_path):
-    (tmp_path / "z-file.md").write_text("z", encoding="utf-8")
-    (tmp_path / "a-dir").mkdir()
-    (tmp_path / ".hidden").write_text("hidden", encoding="utf-8")
-
-    entries = list_directory_entries(tmp_path)
-
-    assert [entry.name for entry in entries] == ["a-dir", ".hidden", "z-file.md"]
-    assert [entry.is_dir for entry in entries] == [True, False, False]
-
-
-def test_gui_uses_custom_picker_instead_of_native_filedialog():
-    source = Path("src/markitdown/gui.py").read_text(encoding="utf-8")
-
-    assert "filedialog" not in source
-    assert ModernFilePicker.__name__ == "ModernFilePicker"

--- a/packages/markitdown/tests/test_gui.py
+++ b/packages/markitdown/tests/test_gui.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from markitdown.gui import convert_file_to_markdown
+
+
+class FakeConverter:
+    def __init__(self, markdown: str = "# Converted", error: Exception | None = None):
+        self.markdown = markdown
+        self.error = error
+        self.converted_paths: list[Path] = []
+
+    def convert(self, path: Path):
+        self.converted_paths.append(path)
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(markdown=self.markdown)
+
+
+def test_convert_file_to_markdown_writes_utf8_output(tmp_path):
+    input_path = tmp_path / "source.txt"
+    output_path = tmp_path / "source.md"
+    input_path.write_text("hello", encoding="utf-8")
+    converter = FakeConverter(markdown="# Halo")
+
+    convert_file_to_markdown(input_path, output_path, converter=converter)
+
+    assert output_path.read_text(encoding="utf-8") == "# Halo"
+    assert converter.converted_paths == [input_path]
+
+
+def test_convert_file_to_markdown_requires_existing_input_file(tmp_path):
+    output_path = tmp_path / "out.md"
+
+    with pytest.raises(ValueError, match="Input file does not exist"):
+        convert_file_to_markdown(
+            tmp_path / "missing.pdf", output_path, converter=FakeConverter()
+        )
+
+
+def test_convert_file_to_markdown_rejects_directory_input(tmp_path):
+    output_path = tmp_path / "out.md"
+
+    with pytest.raises(ValueError, match="Input path is not a file"):
+        convert_file_to_markdown(tmp_path, output_path, converter=FakeConverter())
+
+
+def test_convert_file_to_markdown_requires_output_path(tmp_path):
+    input_path = tmp_path / "source.txt"
+    input_path.write_text("hello", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Output path is required"):
+        convert_file_to_markdown(input_path, "", converter=FakeConverter())
+
+
+def test_convert_file_to_markdown_requires_existing_output_parent(tmp_path):
+    input_path = tmp_path / "source.txt"
+    input_path.write_text("hello", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Output directory does not exist"):
+        convert_file_to_markdown(
+            input_path,
+            tmp_path / "missing" / "out.md",
+            converter=FakeConverter(),
+        )
+
+
+def test_convert_file_to_markdown_preserves_conversion_error(tmp_path):
+    input_path = tmp_path / "source.txt"
+    output_path = tmp_path / "source.md"
+    input_path.write_text("hello", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        convert_file_to_markdown(
+            input_path,
+            output_path,
+            converter=FakeConverter(error=RuntimeError("boom")),
+        )

--- a/packages/markitdown/tests/test_gui.py
+++ b/packages/markitdown/tests/test_gui.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
+import tomllib
 
 import pytest
 
@@ -78,3 +79,11 @@ def test_convert_file_to_markdown_preserves_conversion_error(tmp_path):
             output_path,
             converter=FakeConverter(error=RuntimeError("boom")),
         )
+
+
+def test_markitdown_gui_script_points_to_gui_main():
+    pyproject = tomllib.loads(
+        Path("pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert pyproject["project"]["scripts"]["markitdown-gui"] == "markitdown.gui:main"

--- a/packages/markitdown/tests/test_gui.py
+++ b/packages/markitdown/tests/test_gui.py
@@ -4,7 +4,7 @@ import tomllib
 
 import pytest
 
-from markitdown.gui import APPEARANCE_MODE, convert_file_to_markdown
+from markitdown.gui import APPEARANCE_MODE, GUI_BACKEND, convert_file_to_markdown
 
 
 class FakeConverter:
@@ -93,9 +93,23 @@ def test_markitdown_gui_uses_dark_appearance_mode():
     assert APPEARANCE_MODE == "dark"
 
 
-def test_markitdown_gui_depends_on_customtkinter():
+def test_markitdown_gui_uses_pyside_backend():
+    assert GUI_BACKEND == "pyside6"
+
+
+def test_markitdown_gui_depends_on_pyside6_not_customtkinter():
     pyproject = tomllib.loads(
         Path("pyproject.toml").read_text(encoding="utf-8")
     )
 
-    assert "customtkinter>=5.2.2" in pyproject["project"]["dependencies"]
+    dependencies = pyproject["project"]["dependencies"]
+    assert "PySide6-Essentials>=6.8.0" in dependencies
+    assert "customtkinter>=5.2.2" not in dependencies
+
+
+def test_gui_uses_qfiledialog_instead_of_tk_filedialog():
+    source = Path("src/markitdown/gui.py").read_text(encoding="utf-8")
+
+    assert "QFileDialog" in source
+    assert "filedialog" not in source
+    assert "customtkinter" not in source

--- a/packages/markitdown/tests/test_gui.py
+++ b/packages/markitdown/tests/test_gui.py
@@ -113,3 +113,13 @@ def test_gui_uses_qfiledialog_instead_of_tk_filedialog():
     assert "QFileDialog" in source
     assert "filedialog" not in source
     assert "customtkinter" not in source
+
+
+def test_markitdown_gui_installs_pdf_dependencies_by_default():
+    pyproject = tomllib.loads(
+        Path("pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    dependencies = pyproject["project"]["dependencies"]
+    assert "pdfminer.six>=20251230" in dependencies
+    assert "pdfplumber>=0.11.9" in dependencies

--- a/packages/markitdown/tests/test_gui.py
+++ b/packages/markitdown/tests/test_gui.py
@@ -4,7 +4,12 @@ import tomllib
 
 import pytest
 
-from markitdown.gui import APPEARANCE_MODE, convert_file_to_markdown
+from markitdown.gui import (
+    APPEARANCE_MODE,
+    ModernFilePicker,
+    convert_file_to_markdown,
+    list_directory_entries,
+)
 
 
 class FakeConverter:
@@ -99,3 +104,21 @@ def test_markitdown_gui_depends_on_customtkinter():
     )
 
     assert "customtkinter>=5.2.2" in pyproject["project"]["dependencies"]
+
+
+def test_list_directory_entries_sorts_directories_before_files(tmp_path):
+    (tmp_path / "z-file.md").write_text("z", encoding="utf-8")
+    (tmp_path / "a-dir").mkdir()
+    (tmp_path / ".hidden").write_text("hidden", encoding="utf-8")
+
+    entries = list_directory_entries(tmp_path)
+
+    assert [entry.name for entry in entries] == ["a-dir", ".hidden", "z-file.md"]
+    assert [entry.is_dir for entry in entries] == [True, False, False]
+
+
+def test_gui_uses_custom_picker_instead_of_native_filedialog():
+    source = Path("src/markitdown/gui.py").read_text(encoding="utf-8")
+
+    assert "filedialog" not in source
+    assert ModernFilePicker.__name__ == "ModernFilePicker"

--- a/packages/markitdown/tests/test_gui.py
+++ b/packages/markitdown/tests/test_gui.py
@@ -4,7 +4,7 @@ import tomllib
 
 import pytest
 
-from markitdown.gui import convert_file_to_markdown
+from markitdown.gui import APPEARANCE_MODE, convert_file_to_markdown
 
 
 class FakeConverter:
@@ -87,3 +87,15 @@ def test_markitdown_gui_script_points_to_gui_main():
     )
 
     assert pyproject["project"]["scripts"]["markitdown-gui"] == "markitdown.gui:main"
+
+
+def test_markitdown_gui_uses_dark_appearance_mode():
+    assert APPEARANCE_MODE == "dark"
+
+
+def test_markitdown_gui_depends_on_customtkinter():
+    pyproject = tomllib.loads(
+        Path("pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert "customtkinter>=5.2.2" in pyproject["project"]["dependencies"]


### PR DESCRIPTION
## Summary

  Adds a desktop GUI entry point for MarkItDown so users can convert one local file into a Markdown output file without using
  the CLI directly.

  ## Changes

  - Add `markitdown-gui` console script
  - Add PySide6-based dark desktop GUI
  - Add native file picker for input and output paths
  - Reuse existing `MarkItDown` Python API for conversion
  - Add PDF dependencies to default install so GUI PDF conversion works out of the box
  - Add GUI-focused tests
  - Document GUI setup and run commands in README files

  ## How to run

  ```bash
  cd packages/markitdown
  uv pip install -e .
  markitdown-gui

  If using an already active virtual environment:

  cd packages/markitdown
  pip install -e .
  markitdown-gui

  ## Verification

  - uv run --with pytest pytest tests/test_gui.py -q
  - uv run --with pytest pytest tests/test_cli_misc.py -q
  - Manual PDF conversion smoke via GUI helper