### PR TITLE
Don't abort PDF conversion on a single malformed page

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,11 +1,14 @@
 import sys
 import io
+import logging
 import re
 from typing import BinaryIO, Any
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
+
+_log = logging.getLogger(__name__)
 
 # Pattern for MasterFormat-style partial numbering (e.g., ".1", ".2", ".10")
 PARTIAL_NUMBERING_PATTERN = re.compile(r"^\.\d+$")
@@ -551,37 +554,59 @@ class PdfConverter(DocumentConverter):
 
             with pdfplumber.open(pdf_bytes) as pdf:
                 for page_idx, page in enumerate(pdf.pages):
-                    page_content = _extract_form_content_from_words(page)
+                    try:
+                        page_content = _extract_form_content_from_words(page)
 
-                    if page_content is not None:
-                        form_page_count += 1
-                        if page_content.strip():
-                            markdown_chunks.append(page_content)
-                    else:
-                        plain_page_indices.append(page_idx)
-                        text = page.extract_text()
-                        if text and text.strip():
-                            markdown_chunks.append(text.strip())
+                        if page_content is not None:
+                            form_page_count += 1
+                            if page_content.strip():
+                                markdown_chunks.append(page_content)
+                        else:
+                            plain_page_indices.append(page_idx)
+                            text = page.extract_text()
+                            if text and text.strip():
+                                markdown_chunks.append(text.strip())
+                    except Exception:
+                        # A single malformed page (e.g. a form XObject with an
+                        # invalid /BBox that makes the PDF backend raise) must
+                        # not abort the whole document. Skip it and keep the
+                        # text recovered from the other pages.
+                        _log.debug(
+                            "Skipping PDF page %d due to extraction error",
+                            page_idx,
+                            exc_info=True,
+                        )
+                    finally:
+                        page.close()  # Free cached page data immediately
 
-                    page.close()  # Free cached page data immediately
-
-            # If no pages had form-style content, use pdfminer for
-            # the whole document (better text spacing for prose).
+            # If no pages had form-style content, use pdfminer for the whole
+            # document (better text spacing for prose). If pdfminer fails (e.g.
+            # on a malformed page), fall back to the per-page text already
+            # collected via pdfplumber.
             if form_page_count == 0:
                 pdf_bytes.seek(0)
-                markdown = pdfminer.high_level.extract_text(pdf_bytes)
+                try:
+                    markdown = pdfminer.high_level.extract_text(pdf_bytes)
+                except Exception:
+                    markdown = "\n\n".join(markdown_chunks).strip()
             else:
                 markdown = "\n\n".join(markdown_chunks).strip()
 
         except Exception:
-            # Fallback if pdfplumber fails
+            # Fallback if pdfplumber fails entirely
             pdf_bytes.seek(0)
-            markdown = pdfminer.high_level.extract_text(pdf_bytes)
+            try:
+                markdown = pdfminer.high_level.extract_text(pdf_bytes)
+            except Exception:
+                markdown = ""
 
         # Fallback if still empty
         if not markdown:
             pdf_bytes.seek(0)
-            markdown = pdfminer.high_level.extract_text(pdf_bytes)
+            try:
+                markdown = pdfminer.high_level.extract_text(pdf_bytes)
+            except Exception:
+                markdown = ""
 
         # Post-process to merge MasterFormat-style partial numbering with following text
         markdown = _merge_partial_numbering_lines(markdown)

--- a/packages/markitdown/tests/test_pdf_invalid_bbox.py
+++ b/packages/markitdown/tests/test_pdf_invalid_bbox.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests that PDF conversion is resilient to malformed form XObjects.
+
+Some PDFs contain a form XObject whose ``/BBox`` is not the four-number
+rectangle required by the spec. This used to make the underlying PDF backend
+raise ``ValueError: not enough values to unpack (expected 4, got 2)`` and abort
+the whole conversion. The converter should skip the malformed page and still
+recover the text from the other pages.
+"""
+
+import io
+
+from markitdown import MarkItDown
+
+
+def _pdf_with_invalid_form_bbox() -> bytes:
+    """Build a two-page PDF whose second page has a form XObject /BBox [0 0].
+
+    The first page holds the text "Hello from markitdown"; the second invokes a
+    form XObject with a malformed (two-number) /BBox. Built in-memory so the test
+    stays self-contained and free of line-ending conversion on a committed PDF.
+    """
+    form_stream = b"q Q"
+    text_stream = b"BT /F1 12 Tf 50 100 Td (Hello from markitdown) Tj ET"
+    objs = [
+        b"<</Type/Catalog/Pages 2 0 R>>",
+        b"<</Type/Pages/Kids[3 0 R 4 0 R]/Count 2>>",
+        b"<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]"
+        b"/Resources<</Font<</F1 7 0 R>>>>/Contents 5 0 R>>",
+        b"<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]"
+        b"/Resources<</XObject<</Fm0 6 0 R>>>>/Contents 8 0 R>>",
+        b"<</Length %d>>\nstream\n%s\nendstream" % (len(text_stream), text_stream),
+        b"<</Type/XObject/Subtype/Form/FormType 1/BBox [0 0]/Resources<<>>"
+        b"/Length %d>>\nstream\n%s\nendstream" % (len(form_stream), form_stream),
+        b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>",
+        b"<</Length 7>>\nstream\n/Fm0 Do\nendstream",
+    ]
+    out = b"%PDF-1.4\n"
+    offsets = []
+    for i, obj in enumerate(objs, 1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n%s\nendobj\n" % (i, obj)
+    startxref = len(out)
+    out += b"xref\n0 %d\n0000000000 65535 f \n" % (len(objs) + 1)
+    for offset in offsets:
+        out += b"%010d 00000 n \n" % offset
+    out += b"trailer<</Size %d/Root 1 0 R>>\nstartxref\n%d\n%%%%EOF" % (
+        len(objs) + 1,
+        startxref,
+    )
+    return out
+
+
+def test_invalid_form_bbox_does_not_crash():
+    """A page with an invalid form /BBox must not abort the whole document."""
+    pdf_bytes = io.BytesIO(_pdf_with_invalid_form_bbox())
+
+    result = MarkItDown().convert_stream(pdf_bytes, file_extension=".pdf")
+
+    # The good first page is recovered even though the second page is malformed.
+    assert result.text_content is not None
+    assert "Hello from markitdown" in result.text_content
+    # A skipped page must not leak a raw Python traceback into the output.
+    assert "Traceback" not in result.text_content


### PR DESCRIPTION
## Summary

Closes #2071.

`PdfConverter.convert` ran the entire per-page `pdfplumber` loop inside a single `try`, and on any page error it abandoned the whole loop and fell back to an **unguarded** whole-document `pdfminer.high_level.extract_text` call. A single malformed page — for example a form XObject whose `/BBox` is not a four-number rectangle, which makes the PDF backend raise `ValueError: not enough values to unpack (expected 4, got 2)` — therefore aborted the entire conversion with `FileConversionException`, even when every other page was fine.

## Change

- Each page's extraction is wrapped in `try/except` so one malformed page is skipped (logged at `debug` level via a module logger) while the text recovered from the other pages is kept. `page.close()` moved to a `finally` so cached page data is always freed.
- The `form_page_count == 0` whole-document `pdfminer` call is now guarded and falls back to the per-page `pdfplumber` text already collected.
- The two remaining `extract_text` fallbacks are guarded so they degrade to `""` instead of raising.

The deeper root cause is a robustness gap in `pdfminer.six` (it unpacks `/BBox` without validating its length); that is being fixed upstream separately. This PR makes `markitdown` degrade gracefully regardless of the backend version.

## Tests

Added `packages/markitdown/tests/test_pdf_invalid_bbox.py` (self-contained, building the PDF in-memory): a two-page document whose second page has a malformed form `/BBox` converts without raising and still recovers the first page's text.

`pytest packages/markitdown/tests/test_pdf_invalid_bbox.py packages/markitdown/tests/test_pdf_masterformat.py` → passes; `black --check` clean.

---

AI assistance (Claude) was used; I have reviewed every line and run the tests.
