### PR TITLE
fix: detect HTML charset from <meta> tag to fix garbled output on CJK-locale systems

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_html_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_html_converter.py
@@ -1,4 +1,5 @@
 import io
+import re
 import warnings
 from typing import Any, BinaryIO, Optional
 from bs4 import BeautifulSoup
@@ -39,6 +40,50 @@ class HtmlConverter(DocumentConverter):
 
         return False
 
+    def _detect_html_encoding(self, file_stream: BinaryIO) -> Optional[str]:
+        """Peek at the HTML content to find charset declaration (<meta charset>).
+
+        Follows the HTML5 encoding sniffing algorithm: the <meta charset> tag
+        (or Content-Type http-equiv) is the authoritative source, taking
+        precedence over heuristic detection that is unreliable for non-Latin
+        scripts on some platforms.
+        """
+        cur_pos = file_stream.tell()
+        try:
+            # Read first 4 KB — enough to cover <head> and <meta> in any
+            # reasonable HTML document (HTML5 spec uses 1024 bytes minimum).
+            raw = file_stream.read(4096)
+            # Decode as ASCII-superset (Latin-1) so we can scan for meta tags
+            # without committing to the real encoding yet.
+            try:
+                head = raw.decode("ascii")
+            except UnicodeDecodeError:
+                head = raw.decode("latin-1")
+
+            # Pattern 1: <meta charset="utf-8">   (HTML5)
+            m = re.search(
+                r'<meta\b[^>]*\bcharset\s*=\s*["\']?\s*([\w\-\d]+)\s*["\']?',
+                head,
+                re.IGNORECASE,
+            )
+            if m:
+                return m.group(1)
+
+            # Pattern 2: <meta http-equiv="Content-Type"
+            #            content="text/html; charset=utf-8">
+            m = re.search(
+                r'<meta\b[^>]*\bhttp-equiv\s*=\s*["\']?Content-Type["\']?[^>]*\b'
+                r'content\s*=\s*["\'][^"\']*\bcharset\s*=\s*([\w\-\d]+)',
+                head,
+                re.IGNORECASE,
+            )
+            if m:
+                return m.group(1)
+
+            return None
+        finally:
+            file_stream.seek(cur_pos)
+
     def convert(
         self,
         file_stream: BinaryIO,
@@ -49,8 +94,21 @@ class HtmlConverter(DocumentConverter):
         # strict=True raises RecursionError instead of falling back to plain text.
         strict: bool = kwargs.pop("strict", False)
 
+        # Determine encoding — prefer the HTML <meta charset> declaration,
+        # then the stream_info hint, then UTF-8:
+        #   - <meta charset> is the HTML5-authoritative source.
+        #   - stream_info.charset comes from charset_normalizer which can
+        #     mis-detect non-Latin UTF-8 files (e.g. Chinese) on CJK-locale
+        #     Windows systems.
+        meta_encoding = self._detect_html_encoding(file_stream)
+        if meta_encoding:
+            encoding = meta_encoding
+        elif stream_info.charset is not None:
+            encoding = stream_info.charset
+        else:
+            encoding = "utf-8"
+
         # Parse the stream
-        encoding = "utf-8" if stream_info.charset is None else stream_info.charset
         soup = BeautifulSoup(file_stream, "html.parser", from_encoding=encoding)
 
         # Remove javascript and style blocks


### PR DESCRIPTION
## Problem

On CJK-locale Windows systems (where the system default encoding is GBK/CP936), `charset_normalizer` can mis-detect UTF-8 HTML files containing Chinese characters. For a valid UTF-8 HTML file with `<meta charset="UTF-8">`, the library reported **cp855** with only **5.8% confidence**, causing completely garbled Chinese output.

### Steps to Reproduce

1. Set system locale to Chinese (Windows code page 936)
2. Create a UTF-8 HTML file with Chinese content and `<meta charset="UTF-8">`
3. Run `markitdown file.html` without `-c UTF-8`

### Expected

```
# 第十一号*病人*
```

### Actual

```
# уггтЇЂСИђтЈи*уЌЁС║║*
```

## Root Cause

`HtmlConverter.convert()` used:  
```python
encoding = "utf-8" if stream_info.charset is None else stream_info.charset
```

Since `stream_info.charset` was set to `cp855` (the wrong detection result from `charset_normalizer`), it overrode the correct UTF-8 default. The `charset_normalizer` detection happens in `_markitdown.py`'s `_get_stream_info_guesses()` and affects all text-based converters.

## Fix

Added `_detect_html_encoding()` to the HTML converter that **peeks at the first 4 KB** of the HTML file and extracts the charset from:
- `<meta charset="utf-8">` (HTML5 standard)
- `<meta http-equiv="Content-Type" content="...; charset=...">` (legacy)

This follows the HTML5 encoding sniffing algorithm: the `<meta>` declaration is the authoritative source and **takes precedence** over heuristic detection.

### Encoding Priority (after fix)
1. `<meta charset>` declaration in HTML (most authoritative)
2. `stream_info.charset` from `charset_normalizer` (fallback)
3. `utf-8` (default)

## Testing

Tested on Windows 11 (Chinese locale, CP936) with HTML files containing Chinese characters:

| Test File | Before Fix | After Fix |
|---|---|---|
| GDD_Patient11_v1.html (71KB) | Garbled (detected as cp855) | Correct UTF-8 output |
| 分工文档 (30KB) | Garbled (detected as cp855) | Correct UTF-8 output |

The fix is non-breaking: if no `<meta charset>` tag is found, it falls back to the previous behavior.