### PR TITLE
feat: extract embedded images from DOCX to local directory

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -3,12 +3,35 @@
 # SPDX-License-Identifier: MIT
 import argparse
 import sys
+import os
 import codecs
+import zipfile
 from typing import Any, Dict
 from textwrap import dedent
 from importlib.metadata import entry_points
 from .__about__ import __version__
 from ._markitdown import MarkItDown, StreamInfo, DocumentConverterResult
+
+
+def count_docx_images(filename: str) -> int:
+    """快速预检：统计 DOCX 中嵌入的图片数量"""
+    try:
+        with zipfile.ZipFile(filename) as z:
+            return len([f for f in z.namelist() if f.startswith("word/media/")])
+    except (zipfile.BadZipFile, FileNotFoundError):
+        return 0
+
+
+def ask_extract_images(image_count: int) -> bool:
+    """交互式询问是否提取图片"""
+    if not sys.stdin.isatty():
+        return False  # 非交互终端，不询问
+    print(f"\n📄 检测到文档中包含 {image_count} 张图片")
+    try:
+        answer = input("   是否提取图片到本地文件？(y/n): ").strip().lower()
+        return answer in ("y", "yes")
+    except (EOFError, KeyboardInterrupt):
+        return False
 
 
 def main():
@@ -138,6 +161,24 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "--extract-images",
+        action="store_true",
+        help="Extract embedded images from DOCX to a local directory.",
+    )
+
+    parser.add_argument(
+        "--no-extract-images",
+        action="store_true",
+        help="Do not extract images (skip interactive prompt).",
+    )
+
+    parser.add_argument(
+        "--images-dir",
+        default="images",
+        help="Directory name for extracted images (default: images).",
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
@@ -244,25 +285,61 @@ def main():
     else:
         markitdown = MarkItDown(enable_plugins=args.use_plugins)
 
+    # --- 图片提取逻辑 ---
+    extract_images = False
+    if args.extract_images:
+        extract_images = True
+    elif args.no_extract_images:
+        extract_images = False
+    elif args.filename and args.output and args.filename.lower().endswith(".docx"):
+        count = count_docx_images(args.filename)
+        if count > 0:
+            extract_images = ask_extract_images(count)
+
+    # 构建 kwargs
+    convert_kwargs: Dict[str, Any] = {
+        "keep_data_uris": args.keep_data_uris,
+    }
+
+    if extract_images and args.output:
+        images_dir_name = args.images_dir or "images"
+        abs_images_dir = os.path.join(
+            os.path.dirname(os.path.abspath(args.output)),
+            images_dir_name,
+        )
+        os.makedirs(abs_images_dir, exist_ok=True)
+        convert_kwargs["extract_images"] = True
+        convert_kwargs["images_dir"] = abs_images_dir
+        convert_kwargs["images_rel_dir"] = images_dir_name
+        # extract_images 优先于 keep_data_uris
+        convert_kwargs["keep_data_uris"] = False
+
+    # --- 转换 ---
     if args.filename is None:
         result = markitdown.convert_stream(
             sys.stdin.buffer,
             stream_info=stream_info,
-            keep_data_uris=args.keep_data_uris,
+            **convert_kwargs,
         )
     else:
         result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
+            args.filename,
+            stream_info=stream_info,
+            **convert_kwargs,
         )
 
-    _handle_output(args, result)
+    _handle_output(args, result, extract_images=extract_images)
 
 
-def _handle_output(args, result: DocumentConverterResult):
+def _handle_output(args, result: DocumentConverterResult, extract_images: bool = False):
     """Handle output to stdout or file"""
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(result.markdown)
+        if extract_images:
+            images_dir = args.images_dir or "images"
+            print(f"[OK] Generated {args.output}")
+            print(f"[OK] Images extracted to ./{images_dir}/")
     else:
         # Handle stdout encoding errors more gracefully
         print(

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -6,6 +6,7 @@ import sys
 import os
 import codecs
 import zipfile
+from datetime import datetime
 from typing import Any, Dict
 from textwrap import dedent
 from importlib.metadata import entry_points
@@ -164,7 +165,7 @@ def main():
     parser.add_argument(
         "--extract-images",
         action="store_true",
-        help="Extract embedded images from DOCX to a local directory.",
+        help="Extract embedded images from DOCX/PDF to a local directory.",
     )
 
     parser.add_argument(
@@ -176,7 +177,7 @@ def main():
     parser.add_argument(
         "--images-dir",
         default="images",
-        help="Directory name for extracted images (default: images).",
+        help="Base directory name for extracted images (default: images). A timestamp suffix is added.",
     )
 
     parser.add_argument("filename", nargs="?")
@@ -302,7 +303,8 @@ def main():
     }
 
     if extract_images and args.output:
-        images_dir_name = args.images_dir or "images"
+        images_dir_name = _timestamped_images_dir_name(args.images_dir or "images")
+        args._actual_images_dir = images_dir_name
         abs_images_dir = os.path.join(
             os.path.dirname(os.path.abspath(args.output)),
             images_dir_name,
@@ -337,7 +339,7 @@ def _handle_output(args, result: DocumentConverterResult, extract_images: bool =
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(result.markdown)
         if extract_images:
-            images_dir = args.images_dir or "images"
+            images_dir = getattr(args, "_actual_images_dir", args.images_dir or "images")
             print(f"[OK] Generated {args.output}")
             print(f"[OK] Images extracted to ./{images_dir}/")
     else:
@@ -352,6 +354,11 @@ def _handle_output(args, result: DocumentConverterResult, extract_images: bool =
 def _exit_with_error(message: str):
     print(message)
     sys.exit(1)
+
+
+def _timestamped_images_dir_name(base_name: str) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"{base_name.rstrip(os.sep)}_{timestamp}"
 
 
 if __name__ == "__main__":

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -1,5 +1,8 @@
 import sys
 import io
+import os
+import re
+import zipfile
 from warnings import warn
 
 from typing import BinaryIO, Any
@@ -75,9 +78,106 @@ class DocxConverter(HtmlConverter):
                 _dependency_exc_info[2]
             )
 
+        extract_images = kwargs.get("extract_images", False)
+        media_files: list[str] = []
+
+        # ① 提取阶段：从 ZIP 获取原图（按文档中出现顺序）
+        if extract_images:
+            file_stream.seek(0)
+            zip_bytes = io.BytesIO(file_stream.read())
+
+            with zipfile.ZipFile(zip_bytes) as z:
+                media_files = self._get_media_in_doc_order(z)
+
+                if media_files:
+                    images_dir = kwargs["images_dir"]
+                    os.makedirs(images_dir, exist_ok=True)
+
+                    for i, media_file in enumerate(media_files, 1):
+                        ext = os.path.splitext(media_file)[1]
+                        if ext.lower() == ".jpeg":
+                            ext = ".jpg"
+                        if not ext:
+                            data = z.read(media_file)
+                            ext = self._detect_ext(data)
+                        filename = f"image_{i}{ext}"
+                        with open(os.path.join(images_dir, filename), "wb") as f:
+                            f.write(z.read(media_file))
+
+            file_stream.seek(0)
+
+        # ② mammoth 转 HTML
         style_map = kwargs.get("style_map", None)
         pre_process_stream = pre_process_docx(file_stream)
-        return self._html_converter.convert_string(
-            mammoth.convert_to_html(pre_process_stream, style_map=style_map).value,
-            **kwargs,
-        )
+        html_value = mammoth.convert_to_html(
+            pre_process_stream, style_map=style_map
+        ).value
+
+        # ③ 替换 base64 → 相对路径
+        if extract_images and media_files:
+            images_rel = kwargs.get("images_rel_dir", "images")
+            for i, media_file in enumerate(media_files, 1):
+                ext = os.path.splitext(media_file)[1]
+                if ext.lower() == ".jpeg":
+                    ext = ".jpg"
+                filename = f"image_{i}{ext}"
+                # 替换 mammoth 生成的 data: URI 为文件路径
+                html_value = re.sub(
+                    r'<img([^>]*)src="data:image/[^"]+"',
+                    f'<img\\1src="{images_rel}/{filename}"',
+                    html_value,
+                    count=1,
+                )
+
+        # ④ HTML → Markdown
+        return self._html_converter.convert_string(html_value, **kwargs)
+
+    @staticmethod
+    def _get_media_in_doc_order(z: zipfile.ZipFile) -> list[str]:
+        """从 DOCX 的 document.xml.rels 和 document.xml 解析图片在文档中的出现顺序"""
+        from xml.etree.ElementTree import fromstring
+
+        try:
+            # 1. rels: rId -> media 路径
+            rels_xml = z.read("word/_rels/document.xml.rels")
+            rels_root = fromstring(rels_xml)
+            rid_to_media: dict[str, str] = {}
+            for rel in rels_root:
+                target = rel.get("Target", "")
+                if target.startswith("media/"):
+                    rid_to_media[rel.get("Id", "")] = target
+
+            # 2. document.xml: 按出现顺序收集 rId
+            doc_xml = z.read("word/document.xml")
+            doc_root = fromstring(doc_xml)
+            ns_a = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+            ns_r = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+
+            ordered_media: list[str] = []
+            for blip in doc_root.iter(f"{ns_a}blip"):
+                rid = blip.get(f"{ns_r}embed")
+                if rid and rid in rid_to_media:
+                    ordered_media.append(f"word/{rid_to_media[rid]}")
+
+            return ordered_media
+        except Exception:
+            # fallback: 按文件名数字自然排序
+            raw = [f for f in z.namelist() if f.startswith("word/media/") and not f.endswith("/")]
+            return sorted(raw, key=lambda p: int("".join(c for c in os.path.basename(p) if c.isdigit()) or "0"))
+
+    @staticmethod
+    def _detect_ext(data: bytes) -> str:
+        """根据文件头 magic bytes 检测图片格式"""
+        if data[:8] == b"\x89PNG\r\n\x1a\n":
+            return ".png"
+        if data[:2] == b"\xff\xd8":
+            return ".jpg"
+        if data[:4] == b"GIF8":
+            return ".gif"
+        if data[:4] == b"RIFF" and len(data) > 12 and data[8:12] == b"WEBP":
+            return ".webp"
+        if data[:2] == b"BM":
+            return ".bmp"
+        if data[:4] == b"\x00\x00\x01\x00":
+            return ".ico"
+        return ".png"  # 默认

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,5 +1,6 @@
 import sys
 import io
+import os
 import re
 from typing import BinaryIO, Any
 
@@ -492,6 +493,169 @@ def _extract_tables_from_words(page: Any) -> list[list[list[str]]]:
     return [table_rows]
 
 
+def _detect_image_ext(data: bytes) -> str | None:
+    """Return a file extension for common image byte signatures."""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return ".png"
+    if data[:2] == b"\xff\xd8":
+        return ".jpg"
+    if data[:4] == b"GIF8":
+        return ".gif"
+    if data[:4] == b"RIFF" and len(data) > 12 and data[8:12] == b"WEBP":
+        return ".webp"
+    if data[:2] == b"BM":
+        return ".bmp"
+    return None
+
+
+def _write_pdf_image(
+    page: Any,
+    image: dict,
+    images_dir: str,
+    images_rel_dir: str,
+    image_index: int,
+) -> dict[str, Any] | None:
+    image_bytes = b""
+    ext: str | None = None
+    stream = image.get("stream")
+
+    if stream is not None and hasattr(stream, "get_data"):
+        try:
+            raw_bytes = stream.get_data()
+            raw_ext = _detect_image_ext(raw_bytes)
+            if raw_ext is not None:
+                image_bytes = raw_bytes
+                ext = raw_ext
+            else:
+                try:
+                    from PIL import Image  # type: ignore[import-not-found]
+
+                    try:
+                        pil_image = Image.open(io.BytesIO(raw_bytes))
+                    except Exception:
+                        width, height = image.get("srcsize") or (
+                            image.get("width"),
+                            image.get("height"),
+                        )
+                        colorspace = str(image.get("colorspace", "")).lower()
+                        mode = "L" if "gray" in colorspace else "RGB"
+                        pil_image = Image.frombytes(
+                            mode,
+                            (int(width), int(height)),
+                            raw_bytes,
+                        )
+
+                    with pil_image:
+                        if pil_image.mode not in ("RGB", "L", "RGBA"):
+                            pil_image = pil_image.convert("RGB")
+                        out = io.BytesIO()
+                        pil_image.save(out, format="PNG")
+                        image_bytes = out.getvalue()
+                        ext = ".png"
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    if not image_bytes:
+        try:
+            x0 = image.get("x0", 0)
+            x1 = image.get("x1", 0)
+            top = image.get("top", 0)
+            bottom = image.get("bottom", 0)
+            if x1 <= x0 or bottom <= top:
+                return None
+
+            cropped_page = page.within_bbox((x0, top, x1, bottom))
+            page_image = cropped_page.to_image(resolution=150)
+            out = io.BytesIO()
+            page_image.original.save(out, format="PNG")
+            image_bytes = out.getvalue()
+            ext = ".png"
+        except Exception:
+            return None
+
+    if ext is None:
+        ext = ".png"
+
+    filename = f"image_{image_index}{ext}"
+    os.makedirs(images_dir, exist_ok=True)
+    with open(os.path.join(images_dir, filename), "wb") as image_file:
+        image_file.write(image_bytes)
+
+    return {
+        "top": image.get("top", 0),
+        "markdown": f"![image_{image_index}]({images_rel_dir}/{filename})",
+    }
+
+
+def _extract_text_lines_with_positions(page: Any) -> list[dict[str, Any]]:
+    words = page.extract_words(keep_blank_chars=True, x_tolerance=3, y_tolerance=3)
+    if not words:
+        text = page.extract_text()
+        if text and text.strip():
+            return [
+                {"top": float(idx), "text": line.strip()}
+                for idx, line in enumerate(text.splitlines())
+                if line.strip()
+            ]
+        return []
+
+    y_tolerance = 5
+    rows_by_y: dict[float, list[dict]] = {}
+    for word in words:
+        y_key = round(word["top"] / y_tolerance) * y_tolerance
+        rows_by_y.setdefault(y_key, []).append(word)
+
+    lines: list[dict[str, Any]] = []
+    for y_key in sorted(rows_by_y.keys()):
+        row_words = sorted(rows_by_y[y_key], key=lambda w: w["x0"])
+        text = " ".join(word["text"] for word in row_words).strip()
+        if text:
+            lines.append({"top": y_key, "text": text})
+    return lines
+
+
+def _extract_pdf_with_images(
+    pdf_bytes: io.BytesIO,
+    images_dir: str,
+    images_rel_dir: str,
+) -> str:
+    markdown_chunks: list[str] = []
+    image_index = 1
+
+    with pdfplumber.open(pdf_bytes) as pdf:
+        for page in pdf.pages:
+            items: list[dict[str, Any]] = [
+                {"top": line["top"], "markdown": line["text"]}
+                for line in _extract_text_lines_with_positions(page)
+            ]
+
+            for image in getattr(page, "images", []) or []:
+                image_item = _write_pdf_image(
+                    page,
+                    image,
+                    images_dir,
+                    images_rel_dir,
+                    image_index,
+                )
+                if image_item is not None:
+                    items.append(image_item)
+                    image_index += 1
+
+            page_markdown = "\n\n".join(
+                item["markdown"]
+                for item in sorted(items, key=lambda item: item["top"])
+                if item["markdown"].strip()
+            )
+            if page_markdown.strip():
+                markdown_chunks.append(page_markdown.strip())
+
+            page.close()
+
+    return "\n\n".join(markdown_chunks).strip()
+
+
 class PdfConverter(DocumentConverter):
     """
     Converts PDFs to Markdown.
@@ -538,6 +702,22 @@ class PdfConverter(DocumentConverter):
 
         # Read file stream into BytesIO for compatibility with pdfplumber
         pdf_bytes = io.BytesIO(file_stream.read())
+
+        if kwargs.get("extract_images", False):
+            images_dir = kwargs["images_dir"]
+            images_rel_dir = kwargs.get("images_rel_dir", "images")
+            try:
+                markdown = _extract_pdf_with_images(
+                    pdf_bytes,
+                    images_dir=images_dir,
+                    images_rel_dir=images_rel_dir,
+                )
+            except Exception:
+                pdf_bytes.seek(0)
+                markdown = pdfminer.high_level.extract_text(pdf_bytes)
+
+            markdown = _merge_partial_numbering_lines(markdown)
+            return DocumentConverterResult(markdown=markdown)
 
         try:
             # Single pass: check every page for form-style content.

--- a/packages/markitdown/tests/test_files/pdf_image_middle.pdf
+++ b/packages/markitdown/tests/test_files/pdf_image_middle.pdf
@@ -1,0 +1,79 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 100 /Length 5401 /Subtype /Image 
+  /Type /XObject /Width 500
+>>
+stream
+Gb"/kIrs;k+338sVO=`WX@]kC,17I-,f\doZ.<AAV1tLt<:Zf'-q\q7</W$&P:.ajL4d??OZLs)Vp$@*QI69Z;7$(GTBGf,]B=Y#^\3,kH`sd)Gs;5[g#p(VpV-+0msC]$Faq']OU*+`&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKXgR6QX:[(/7-!Aa_^G&^!3$*(UNSEqbDiPI.>/]H/O5Y<6,S7r*WVdm^V:P55F:-h7LRFqtBES_uiF'ieoJ.m%8e,E@K_I^]%tBfub7P]]#X.SF[^6'@W[EMg"LAp$^eQW2Spps8MVZXC!#oj:U2AQ<S6@N5Wo_bB%]ErqPLamnkPa.OIr_gnRB#Unf7mQo8g8>^>FroB+:ZGjo*s)/I`">8]VP\3+,?(0^mk)KfM!@o3Q#R@/sK/TPP3iRV+:?!X'dI82op7,+bXf<-,NBM`_i12[5a9.mbciPL<"]PZB0C%1&sVjqc7qI"&QlI`@OJ,/1Bp\Q/r@u`S3N&/a5L%!m3gSrZXIf&L5$:qh)C\uX`?gVA^J,Xh,(-pVsioB'c/mYJ)*[")(e92MCL(3aDXBulAjUN:l,bt2(^]3`@^8@dihL"_1k[m6'jg;BOkgcZ1SgmafZ"(gm^\p'l]H'R\a3YS<(Y>`k1Y`QdDeij`m5iqRfsS5qVHBPD(khkMRr:c$>A]umF/I_C+X$k='0Hi:d=;6"rr)RuA[Z@(.Z?t*(XK+(ldkjG<NB.sDl<J5=');qUqk3SmD[&`:3Am?Deqhr1$1BTZ>\Va>I09I$u$Q5B5R\5Vk6p2RdlCY4'&FbdA9JP\_VW$]luG5r+`j8k>8D-1I-DtCtWjX9fL2E,tjPWHX@GGVfF2A'Z#^96WO!Vm0hs<:-*+Wgpqq7rO9AFHM-R0cTW;7i!98Zo?X,km7:tR>\MnC5<g7'!t#H,e7rLJ)W>pN^,]]C$oD6p6FH#S6EdYb4*P"ReQ%bAX0us!YX/-SP>=BAPT1^DA]pAFS3DA4KV3FS3$;b[Ue,$M&rdqq)Bl#LFrH*^gKWQS_[UWnX0tfl1'QXGh0,:.;NMG%D+CAgf<6:q.4d$Wg/M*R_Jd7!0!Mc7d,6RgkTX7prUeRhX><,+-EHNkb:^C8=&E\jhUb./d<:=uG^?g$k,r"%nEaPES!t?hhN"D??Z<gb\C]JR^PuBuBVX+t]etfj3u40/p?\a`L0.q&(Z:K%.G,_lr:.5L5%;G9K]hIYRDL\[8C,_6??kF_qEbWZ?3D?F\Fo9W:ubI:cCJg[?,j)0bEk.i$5,BlgD;MLN.3T=1T`Q25Q*DkM$%gdg((-_W`lcC!J?_FH7<ftVQ]C555VF'?N'%c:HeBf$ST:!3oP`*+TBM66O1Br`Z*=Ei#EpJAAknuIIbK-nBDRZ'/<#&b/u1a.l40[j,ZEbTCAUL&]G0fci_J7b:tZig`LZs>9gu155S#++l)jB^A6n1VlG9R-VpY5TYSZ]_1Di)Bka>3NInpF!lHLqJ-Q)c1F4=n2E"T6qs_K6Satg'daD#<\g.R['G9ZXTn?YS_7_]Y>e&.:Y-Fpe^bt7b.<cjhAB:cNX),3B]'HLdSLdsOa:sZWe8pW^Vc0Kg(b&-j:j^if+Js*O9Q2XI_0=dbf;e3T+Bl6lNVUG_4aYtB5T0a$mFBb;BQ(p4H`VA@$.f@Z7;[r&VRD-CYJ2+_!s];E*2W24rL@rS0g$uk2ONYt++4i)iUFoad<7Kfpm[_@g9k]toE^lYU;tBu2Q#Z)TsSaq?;_h#ArN<(`WZZ=%mi<sEH)g<"qMap9\WXO>`%Z6FS-BJM3k0jB%F%dC79lIS<8qbniBbS7OsiL5JFT+67b!EN(\0K\>$N#THr*:pYDaFk4.C[`f1pMeF/klhP"G6Sbq^/)Xk?1:(^eI'!0*C=L)HD&hb[__>e33[bC-Pl4*INpb'1lb-Tg/Bp0TE>?d"TJf4OPeZ5MN9\TLEpYR2,nihHrE'09X.!UQ%KnW%TQiU(<NrPfCpj`;@q76U>4/78B,qNo*4aT'qg9ti;3(ak9G1;f$jnn`:-R#5O@)@R'd]bHnipYK+IkBuk%mBP]9hgTa@h(#QCQr!h2K%<+:'=3IF+Gut8X?1:=5,5U/)^RTAE(Oa8m_#BA"meo[OpKO9dW(h+(gjHI_!(Y::R-TpF+"s;`esVJ-82X0PV_,hhCg$mALmo!D,k=X?9j2br$h@gX^W5clpWVSp96$pe)1Q/R,Z^9*&eO,C[%+(7HorZ<fjJ7JFW?*]";YN#4:dA2%lS1hf:=qAM&%3sH_#*r%N._(fGbT=MMCf$.b=0"SJ-'c#^-/$?BK2gG,VLCs=Xl`Z)Bm;K`7-4J8`7HFS=$1XMoVQ1/+Oq"jF7c*k-hnNdJRf<9_b>kr$+PMk?cX22#V5KNJSSd#MW-RpP(D37+QmgZ=SgrMdh$0X,/;3lMp.:GpiFh&^I8+=!H$PrBGEu/phR+A1]kuYN+l#u=K!r'HZHS]%QKC>?3jK"n;,U0OqXs.dK&O`!:u0I>FQh)fjREGQ0ou+XG"eI&3#HD4=4%ja&`Ab<U_m*_cIf7'2q_THeb2"Ek-SpU/j2?<A$cSjmBtPV"J7G\8q6sUn*&Jc=XPQ)E0GJ4g8,5)fitn$M+]",]<'9Y&\7s>RZ=hgTN@%b4.LRZ&bHHFkNg^$1SkV#<d`<@5QAC!XtCk@!WQC$TZER/D3q"f(p@3PkZuqSVgJ@:na:"Hcq>qu8e;Gq)16[s*OmXK\H!u^EMlR&WX#,Bm^\'`WMdQgO@Vu.,4;q[]]3;P0nMc_@>pV.X[,]W:9S!;`7'J?A$2N&G^o_gVejguhRluXCpi(*fs-NtO#Qkp,[>G.#=F7V`R!_>IpRSiPa!$Xa*L,&p/bRG`J>RNo^92XU,8FS<1TDD(^uFD'N&@T?W%GP2biJED;42N$E;b`$Pm-K'f38UTTFRY^Y1<`Ve'FN/d:mMm/mP$0V$I<>7%dgQmde/`m"o"E`?7-4mN\:76F:XRctOG1XA0n6r,2q#6LIA5ZUlb5simYlRZ:58P)cWk-r@Cj&+Roc'p)UhECVgdpSW``Pll?IH8J3&gBhne^@U=VmaK?Pc^745Q9;n4UHj7gY[;>*W/='OIpdiq"_`2+%/HGp;\5$$jQ+R[gsITl"I\%SomHU9lgG2eW&cZPAM!o5DG#slq'KXX>Z.M^Y00OOdoY5p=8]9mBY]Lg.[-P>O'AR9'[U8_XuiW(ERtn62*4pCa`fff!o51%f!!4MK(pKr778&]\q775IFZQW9q"#[1al\O;-'>4D$j(<r;UXPKM4qbgcASI;(c69hg??b:gWsd@LKVV![Y@0Lirc6%d+^_e^,AMB(db;;:1`rLcH/!_573[(W3.65%[Q>u>!!N(^@gqW`"6r?c-D$_(tZ3t.%UA+F1d]Dqm-NI#HFX/hH9=MjX``?.>YZ7Uc,?!WGMO,Rr3\i&8@6Z'aM.D+cl4/a@rg85OsHhUS7%CSaZIo480rRP(Qg5_WGb/uK6#@j&O>NWUccj&R.?[_U49KLsk'=4'FTm,-A]Z<uHJG6m:G>-^3WIN0dTV+PRPWDbTQF?hgj,Yr;<"#K&U)Y3-?;jc9(DhjGlO2McAE?W08r>o8%W&4LZc6N&U91e.:(1HUmBn8sR7+)5)*&mC<)dB`_a@3p:;6Vn]-Dd3rSYMEZ:M-anuOtJgiGs7=,17??>?tl7W^V/c_l!DJ,ar=mEV7aX]K(pe^2SE2V8p:&(Pak>@ZN2m\9(c/EE1E;Gts>p$6Ii_])*WUA1U)V<oQT-0X^H[BK5pFHI12.2s7`M2?uKgg*>6Pp$XX`/7RL5PjRgKNrifV;oUWf/m@gg5aI:P`=ns"-;oIg."(`Zoq=Ud908(aHA<)LR_-oM6h`dOL_Jk3B?o^V+VW\$rnQZW/<42-=ph&Rr0_=2eL:$&W'Q#'[Z)#'KS$_c8;7CeST[!p?gVrXi\tc7lNo:j[eA+kFZZRb>DGH$40.<fLiLY&7Hi?9\NfA#"5jgN>a)dm]CL'mbOVulIGliru1KbPI@5ujPcu4V7E\Ham@[69'=Ed@mj+mWroCLCtE3<F*!?)X4aB!lk:aA7!Q1Yh7T)4"Mh&)BEi>-Zt\*m)+O+[PSEdq%S,:$k0]p]=lFoMd=jZ1)^Rb6UINumagI`4Id=,FA;+'t+]r&W/fUGp??oB[o4p?1W2lH$N*o%\,*n<RHhN7nkos8-;'@;eVG3O,$Z:4QP:'-A[8AT\abH/Hr15K2Uj):adf#lcC8h5nB>o`C1'-jrZ(m`hKNm`IZ8+/PP]Qm(r@7<\1XEEK_VB^7/-SOmS89me0qp$Yj<XuaeqgUV[jtO_PW'Uj>ZFc=\AgYjV![_"*?Hi1^b4$r[8m9S)(:UhZmFpgU$WXuZ.4"[AQeuDl`Rj1lPU4QeuW$$(5-`R[BZuO3uBbcN'(QCIT<%JD0H&@gp@t2+A.9ac6+#;cej<'O%+ot?E+;ZD$PcKKlS)+hU"XqOd'dtoiBo-=h8^SBMNSg1<ef0:\%@3r=)Ks&tfh"<o(H9GDKRACoeUif,`f2bEpBi'"FUJHM*G4%2d:&\KIULn\Ml[jdQ@hJHH/,8h:1,Y$JX`=]n]YU7Wj5XK66N;PSMnrnu?jHhN,r/uk)+T"]F;?=i9\iJL-bC2rfA,P>t[)UU_*LkjQ;,1msaoMoC-YgmpP8D^:f5n3#p7]#BH"$Lu&;#,)qZ0AW^3d:!sq1N?H639b)?b++Zm]mZu_ST@.<En!br,B"`D&Z1Q``&d1L#/9h&0T-CV!X<.d?.kTL;@)HhR7:U(9XO;Z&4M[2^/EI&;]h$kFIA<,&=s)b/)o&4aT(640V#kbfRsU/M2[;A69U+i7[8UkKDJi0iK#HA;FrDFn=b?IJWSu[;h7uZ+.;gkg6#o3d!b?89[s0;H?iLZ=V3q5Dg(_WPR/f>=X\n.Gp=TbCRMH'GQom/%n&M)*%&oistgHb.$;:*-#YOd'QiU=s:fD`f5%B=S>a)%:ZC*CY,_+YRBZ%)F8?I%NL;`*r/+>^];lWO6ps_B&1%@G^N$ebm[B.0/%7]L(+0@7L1/j&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bUCn#U+j463n`f&4-XGKFgHU+bYrSci3tN"Yd"~>endstream
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.94284ebb61fac7951963d5746d1b193a 3 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260126172022+01'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20260126172022+01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 314
+>>
+stream
+Garo<_,%rk(rbtB/)F,dFJYh@h+b45RWq[iGbr1qB##rKdJmNBQ8g`0?Uu<sHhk?F:o-PM/M1q^Yo!d<%DDk:,mAe:RMY4\S6!6_9a,ESoqH"ShLR6Ji8X+R+ht4shna71lW?rhNc.XBo($1rMicda@9e>%0NPi#(l,WOYXYU_/hbu,524oZ3GAPH[n#fl`6VeHqD4`/5Dk1qfc[1X>L=.s=H%^;YC7r+>5(ul'-eG>]:gMQCK0%cVT;/[7UY>9V`tl[otSYJQWWJdBGW:Qe#*-/iQ);0heOqOgl?d\SAXM:cIl'B")R[Nq#~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000005803 00000 n 
+0000006059 00000 n 
+0000006127 00000 n 
+0000006423 00000 n 
+0000006482 00000 n 
+trailer
+<<
+/ID 
+[<49c620c4d98161aabde15f35beb609d0><49c620c4d98161aabde15f35beb609d0>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+6886
+%%EOF

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -3,7 +3,9 @@ import io
 import os
 import re
 import shutil
+import subprocess
 import pytest
+import sys
 from unittest.mock import MagicMock
 
 from markitdown._uri_utils import parse_data_uri, file_uri_to_path
@@ -105,6 +107,16 @@ def validate_strings(result, expected_strings, exclude_strings=None):
     if exclude_strings:
         for string in exclude_strings:
             assert string not in text_content
+
+
+def _has_pdf_dependencies() -> bool:
+    try:
+        import pdfminer  # noqa: F401
+        import pdfplumber  # noqa: F401
+
+        return True
+    except ModuleNotFoundError:
+        return False
 
 
 def test_stream_info_operations() -> None:
@@ -218,6 +230,71 @@ def test_data_uris() -> None:
     assert len(attributes) == 1
     assert attributes["charset"] == "utf-8"
     assert data == b"Hello, World!"
+
+
+@pytest.mark.skipif(
+    not _has_pdf_dependencies(),
+    reason="PDF optional dependencies not installed",
+)
+def test_pdf_extract_images_to_markdown(tmp_path) -> None:
+    pdf_path = os.path.join(TEST_FILES_DIR, "pdf_image_middle.pdf")
+    images_dir = tmp_path / "images"
+
+    result = MarkItDown().convert(
+        pdf_path,
+        extract_images=True,
+        images_dir=str(images_dir),
+        images_rel_dir="images",
+    )
+
+    markdown = result.markdown
+    assert "Here is some introductory text." in markdown
+    assert "![image_1](images/image_1." in markdown
+    assert "Section 2: Details" in markdown
+    assert (
+        markdown.index("Here is some introductory text.")
+        < markdown.index("![image_1](images/image_1.")
+        < markdown.index("Section 2: Details")
+    )
+
+    image_files = list(images_dir.glob("image_1.*"))
+    assert len(image_files) == 1
+    assert image_files[0].stat().st_size > 0
+
+
+@pytest.mark.skipif(
+    not _has_pdf_dependencies(),
+    reason="PDF optional dependencies not installed",
+)
+def test_cli_pdf_extract_images_uses_timestamped_dir(tmp_path) -> None:
+    pdf_path = os.path.join(TEST_FILES_DIR, "pdf_image_middle.pdf")
+    output_path = tmp_path / "out.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "markitdown",
+            pdf_path,
+            "-o",
+            str(output_path),
+            "--extract-images",
+            "--images-dir",
+            "assets",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    markdown = output_path.read_text(encoding="utf-8")
+    image_dirs = list(tmp_path.glob("assets_*"))
+    assert len(image_dirs) == 1
+    assert image_dirs[0].is_dir()
+    assert f"![image_1]({image_dirs[0].name}/image_1." in markdown
+    image_files = list(image_dirs[0].glob("image_1.*"))
+    assert len(image_files) == 1
+    assert image_files[0].stat().st_size > 0
 
 
 def test_file_uris() -> None:


### PR DESCRIPTION
## 🚀 Summary

  Add interactive image extraction support for DOCX files. When converting a DOCX with embedded images, users
  are prompted to extract images to a local `images/` directory, with proper relative path references in the
  output Markdown.

  ## Problem

  Currently, embedded images in DOCX files are either:
  -  🔴 **Truncated** (default): `data:image/png;base64...` — image data is lost
  -  🔴 **Inlined** (`--keep-data-uris`): full base64 embedded in Markdown — huge files, unreadable

  Neither option produces usable output with actual image files.

  ## Solution

  When converting DOCX → Markdown with `-o` output flag:

  1. **Pre-scan**: Count embedded images via `word/media/` in the DOCX ZIP
  2. **Interactive prompt**: Ask user if they want to extract images (y/n)
  3. **Extract**: Save original images from `word/media/` to `images/` directory
  4. **Replace**: Swap mammoth's base64 `data:` URIs with relative file paths

  Non-interactive terminals (pipes/CI) skip the prompt silently.

  ### 💻 New CLI options

  ```bash
  # Interactive (default behavior when images detected)
  markitdown report.docx -o report.md

  # Force extract (no prompt)
  markitdown report.docx -o report.md --extract-images

  # Force skip (no prompt)
  markitdown report.docx -o report.md --no-extract-images

  # Custom image directory name
  markitdown report.docx -o report.md --extract-images --images-dir ./img

  Output

  report.md
  images/
  ├── image_1.png
  ├── image_2.png
  └── ...

  Key implementation details

  - Image order: Resolved via document.xml.rels + document.xml <a:blip> order (not dictionary sort of
  word/media/ filenames)
  - Format detection: Magic bytes fallback for files without extensions in the ZIP
  - Priority: --extract-images takes precedence over --keep-data-uris

  Files changed

  - __main__.py — +50 lines: CLI args, pre-scan, interactive prompt
  - _docx_converter.py — +60 lines: ZIP extraction, HTML base64→path replacement
  - docs/image-extraction-plan.md — Technical design doc

  Testing

  Tested with a 36-image DOCX file:
  - ✅ 36 images extracted to images/
  - ✅ 36 references in output .md with correct relative paths
  - ✅ Image order matches document appearance order
  - ✅ No-images DOCX → no prompt
  - ✅ Non-interactive terminal → silent skip