### PR TITLE
fix: consecutive partial numbers wrongly merged + ipynb string source loses title

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -62,7 +62,11 @@ class IpynbConverter(DocumentConverter):
 
             for cell in notebook_content.get("cells", []):
                 cell_type = cell.get("cell_type", "")
-                source_lines = cell.get("source", [])
+                source = cell.get("source", [])
+                # nbformat allows source to be a string or list of strings
+                if isinstance(source, str):
+                    source = source.splitlines(keepends=True)
+                source_lines = source
 
                 if cell_type == "markdown":
                     md_output.append("".join(source_lines))

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -41,7 +41,9 @@ def _merge_partial_numbering_lines(text: str) -> str:
             while j < len(lines) and not lines[j].strip():
                 j += 1
 
-            if j < len(lines):
+            if j < len(lines) and not PARTIAL_NUMBERING_PATTERN.match(
+                lines[j].strip()
+            ):
                 # Merge the partial numbering with the next line
                 next_line = lines[j].strip()
                 result_lines.append(f"{stripped} {next_line}")

--- a/packages/markitdown/tests/test_bug_fixes.py
+++ b/packages/markitdown/tests/test_bug_fixes.py
@@ -1,0 +1,125 @@
+"""
+Tests for two unreported bugs:
+  1. _merge_partial_numbering_lines() merging consecutive partial numbers together
+  2. IpynbConverter failing to extract title when cell source is a string
+"""
+
+import io
+import json
+import pytest
+
+from markitdown import MarkItDown
+from markitdown.converters._pdf_converter import _merge_partial_numbering_lines
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: consecutive partial numbering lines
+# ---------------------------------------------------------------------------
+
+class TestMergePartialNumberingLines:
+
+    def test_consecutive_numbers_not_merged(self):
+        """Two consecutive .N lines must stay separate, not be joined together."""
+        text = ".1\n.2\nContractor shall furnish all materials."
+        result = _merge_partial_numbering_lines(text)
+        assert ".1 .2" not in result, (
+            f"Consecutive partial numbers were wrongly merged: {result!r}"
+        )
+
+    def test_consecutive_numbers_preserved(self):
+        """.1 must stay on its own line; .2 must merge with the text below it."""
+        text = ".1\n.2\nContractor shall furnish all materials."
+        result = _merge_partial_numbering_lines(text)
+        lines = result.splitlines()
+        assert lines[0] == ".1"
+        assert lines[1] == ".2 Contractor shall furnish all materials."
+
+    def test_number_merges_with_text(self):
+        """A lone .N line followed by text (not another number) must still merge."""
+        text = ".1\nContractor shall furnish all materials."
+        result = _merge_partial_numbering_lines(text)
+        assert ".1 Contractor shall furnish all materials." in result
+
+    def test_three_consecutive_numbers(self):
+        """.1, .2, .3 each followed immediately by another number — none merged."""
+        text = ".1\n.2\n.3\nWork shall comply with local codes."
+        result = _merge_partial_numbering_lines(text)
+        assert ".1 .2" not in result
+        assert ".2 .3" not in result
+        lines = result.splitlines()
+        assert lines[0] == ".1"
+        assert lines[1] == ".2"
+
+    def test_number_then_text_then_number(self):
+        """Mixed case: .1 merges with its text, .2 merges with its text."""
+        text = ".1\nFirst clause text.\n.2\nSecond clause text."
+        result = _merge_partial_numbering_lines(text)
+        assert ".1 First clause text." in result
+        assert ".2 Second clause text." in result
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: ipynb cell source as string
+# ---------------------------------------------------------------------------
+
+def _make_notebook(source) -> io.BytesIO:
+    """Build a minimal .ipynb with one markdown cell whose source is `source`."""
+    nb = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3",
+                "language": "python",
+            }
+        },
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": source,
+                "metadata": {},
+            }
+        ],
+    }
+    return io.BytesIO(json.dumps(nb).encode())
+
+
+class TestIpynbSourceAsString:
+
+    @pytest.fixture
+    def md(self):
+        return MarkItDown()
+
+    def test_title_extracted_when_source_is_string(self, md):
+        """Title must be extracted even when cell source is a plain string."""
+        buf = _make_notebook("# My Report\n\nSome content here.")
+        result = md.convert(buf, url="nb.ipynb")
+        assert result.title == "My Report", (
+            f"Title not extracted from string source; got {result.title!r}"
+        )
+
+    def test_title_same_for_list_and_string_source(self, md):
+        """Source as string and source as list must produce the same title."""
+        as_list = _make_notebook(["# My Report\n", "\n", "Some content here."])
+        as_str  = _make_notebook("# My Report\n\nSome content here.")
+
+        r_list = md.convert(as_list, url="a.ipynb")
+        r_str  = md.convert(as_str,  url="b.ipynb")
+
+        assert r_list.title == r_str.title, (
+            f"Title mismatch: list={r_list.title!r}, string={r_str.title!r}"
+        )
+
+    def test_content_correct_when_source_is_string(self, md):
+        """Markdown content must be rendered correctly regardless of source type."""
+        buf = _make_notebook("# My Report\n\nSome content here.")
+        result = md.convert(buf, url="nb.ipynb")
+        assert "My Report" in result.text_content
+        assert "Some content here." in result.text_content
+
+    def test_no_title_when_no_heading(self, md):
+        """A string source with no # heading should still produce no title."""
+        buf = _make_notebook("Just some text without a heading.")
+        result = md.convert(buf, url="nb.ipynb")
+        assert result.title is None


### PR DESCRIPTION
## Summary

Two unreported bugs found by code audit — neither appears in any existing issue or PR.

### Bug 1: `_merge_partial_numbering_lines()` merges consecutive partial numbers together

**File:** `packages/markitdown/src/markitdown/converters/_pdf_converter.py`

When a PDF has two partial numbers on consecutive lines (e.g. `.1` immediately followed by `.2`), the function merges `.1` with `.2`, producing the nonsense token `.1 .2` and assigning all subsequent text to the wrong numbered items.

**Example — input:**
`
.1
.2
Contractor shall furnish all materials.
.3
Work shall comply with local codes.
`
**Buggy output:**
`
.1 .2
Contractor shall furnish all materials.
.3 Work shall comply with local codes.
`

**Root cause:** Line 47 merges the current partial number with the next non-empty line, but never checks if that next line is itself a partial number.

**Fix:** One guard added — skip merging when the next non-empty line also matches `PARTIAL_NUMBERING_PATTERN`.

---

### Bug 2: `IpynbConverter` silently loses document title when cell `source` is a string

**File:** `packages/markitdown/src/markitdown/converters/_ipynb_converter.py`

The [nbformat spec](https://nbformat.readthedocs.io/en/latest/format_description.html) allows cell `source` to be either a **list of strings** or a **plain string**. When `source` is a string, `for line in source_lines` iterates character-by-character, so `line.startswith('# ')` never matches and `result.title` is always `None` — silently, with no error raised.

**Example:**
`python
# source as list → title = 'My Report'  ✓
'source': ['# My Report\n', '\n', 'Content']

# source as string → title = None  ✗  (same content, different format)
'source': '# My Report\n\nContent'
`

**Fix:** Normalise string source to a list via `splitlines(keepends=True)` before processing.

---

## Tests

9 new tests in `tests/test_bug_fixes.py` covering both fixes and edge cases (consecutive numbers, mixed patterns, string vs list source parity, no-heading case).