### PR TITLE
fix(xlsx): prune empty rows/cols, strip NaN strings, and clean unnamed headers in Excel conversion

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -83,8 +83,19 @@ class XlsxConverter(DocumentConverter):
         sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
         md_content = ""
         for s in sheets:
+            df = sheets[s]
+            df = df.dropna(how="all", axis=0).dropna(how="all", axis=1)
+            if df.empty:
+                continue
+
+            # Rename Unnamed: columns to empty strings
+            df.columns = [
+                "" if str(col).startswith("Unnamed:") else str(col)
+                for col in df.columns
+            ]
+
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = df.to_html(index=False, na_rep="")
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs
@@ -145,8 +156,19 @@ class XlsConverter(DocumentConverter):
         sheets = pd.read_excel(file_stream, sheet_name=None, engine="xlrd")
         md_content = ""
         for s in sheets:
+            df = sheets[s]
+            df = df.dropna(how="all", axis=0).dropna(how="all", axis=1)
+            if df.empty:
+                continue
+
+            # Rename Unnamed: columns to empty strings
+            df.columns = [
+                "" if str(col).startswith("Unnamed:") else str(col)
+                for col in df.columns
+            ]
+
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = df.to_html(index=False, na_rep="")
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -532,6 +532,41 @@ def test_markitdown_llm() -> None:
     validate_strings(result, PPTX_TEST_STRINGS)
 
 
+def test_xlsx_clean_conversion() -> None:
+    """Test that empty rows/columns, NaN values, and Unnamed headers are cleaned up."""
+    import openpyxl
+    import tempfile
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "PROGRESS"                                   # a title in A1
+    ws["A3"] = "Task"
+    ws["C3"] = "Owner"
+    ws["D3"] = "Status"   # real headers on row 3 (col B blank)
+    ws["A4"] = "Design"
+    ws["C4"] = "Ana"
+    ws["D4"] = "Done"
+
+    temp_dir = tempfile.gettempdir()
+    p = os.path.join(temp_dir, "repro_test.xlsx")
+    try:
+        wb.save(p)
+
+        markitdown = MarkItDown()
+        result = markitdown.convert(p)
+
+        expected_md = (
+            "## Sheet\n"
+            "| PROGRESS |  |  |\n"
+            "| --- | --- | --- |\n"
+            "| Task | Owner | Status |\n"
+            "| Design | Ana | Done |"
+        )
+        assert result.markdown.strip() == expected_md
+    finally:
+        if os.path.exists(p):
+            os.remove(p)
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     for test in [
@@ -547,8 +582,10 @@ if __name__ == "__main__":
         test_markitdown_exiftool,
         test_markitdown_llm_parameters,
         test_markitdown_llm,
+        test_xlsx_clean_conversion,
     ]:
         print(f"Running {test.__name__}...", end="")
         test()
         print("OK")
     print("All tests passed!")
+


### PR DESCRIPTION

### Problem Description

When converting spreadsheets (`.xlsx`, `.xls`) to Markdown, the resulting output was often filled with noise, particularly when sheets had empty rows, empty columns, or header rows that weren't fully populated. 

This noise was caused by three main behaviors of the underlying pandas conversion:
1. **Pandas Placeholder Headers (`Unnamed: N`)**: If a cell in the first row was empty (common in spreadsheets with spacer columns or title blocks), pandas auto-assigned it a header name like `Unnamed: 1`, `Unnamed: 2`, etc. These placeholders were exported directly into the Markdown table.
2. **Literal `"NaN"` Strings**: Empty cells in the spreadsheet were output as literal `"NaN"` strings in the generated HTML table, which then translated directly to `"NaN"` text inside the Markdown table.
3. **Empty Rows and Columns**: Entirely empty rows and columns were preserved in the conversion, inflating the size of the tables and adding useless markup.

---

### What Was Fixed

The Excel converters (`XlsxConverter` and `XlsConverter` in `packages/markitdown/src/markitdown/converters/_xlsx_converter.py`) were modified to clean and preprocess the DataFrame before exporting it to HTML/Markdown:

1. **Empty Row/Column Pruning**:
   - Used `df.dropna(how="all", axis=0).dropna(how="all", axis=1)` to drop rows and columns that are completely blank.
   - If a sheet becomes completely empty after pruning, it is skipped.
2. **Unnamed Header Cleaning**:
   - Replaced any column name starting with `Unnamed:` with an empty string (`""`). This removes the placeholder headers while keeping valid, populated headers (e.g., `| PROGRESS | | |` instead of `| PROGRESS | Unnamed: 1 | Unnamed: 2 |`).
3. **NaN Value Elimination**:
   - Passed `na_rep=""` to the `.to_html()` call so that empty cells render as empty table cells rather than the literal string `"NaN"`.
4. **Testing**:
   - Added `test_xlsx_clean_conversion` to `packages/markitdown/tests/test_module_misc.py` using a dynamically generated workbook matching the reported issue's spreadsheet structure to prevent regressions.

This solution is the fix for #2124 