### PR TITLE
fix(csv): skip leading blank lines so they don't wipe the whole table

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -51,6 +51,13 @@ class CsvConverter(DocumentConverter):
         reader = csv.reader(io.StringIO(content))
         rows = list(reader)
 
+        # A leading blank line (or any empty rows before the header) parses as an
+        # empty list. If that becomes the header its column count is 0, and every
+        # data row then gets truncated to nothing -- silent total data loss.
+        # Skip leading empty rows so the first real row becomes the header.
+        while rows and len(rows[0]) == 0:
+            rows.pop(0)
+
         if not rows:
             return DocumentConverterResult(markdown="")
 

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -153,6 +153,20 @@ GENERAL_TEST_VECTORS = [
         must_not_include=[],
     ),
     FileTestVector(
+        filename="test_blank_first_line.csv",
+        mimetype="text/csv",
+        charset="utf-8",
+        url=None,
+        must_include=[
+            "| name | age |",
+            "| bob | 3 |",
+            "| alice | 7 |",
+        ],
+        must_not_include=[
+            "|  |",
+        ],
+    ),
+    FileTestVector(
         filename="test.json",
         mimetype="application/json",
         charset="ascii",

--- a/packages/markitdown/tests/test_files/test_blank_first_line.csv
+++ b/packages/markitdown/tests/test_files/test_blank_first_line.csv
@@ -1,0 +1,4 @@
+
+name,age
+bob,3
+alice,7


### PR DESCRIPTION
Fixes #2136.

A CSV whose first line is blank converts to an all-empty markdown table. Every row comes out as `|  |` and the data is silently lost.

Cause: `csv.reader` yields `[]` for the blank first line, so `rows[0]` is empty. The converter treats `rows[0]` as the header (column count 0), then truncates every data row with `row[: len(rows[0])]` -> `row[:0]`, dropping all the cells.

Fix: drop leading empty rows before choosing the header row, so the first real row becomes the header. Added a test fixture with a leading blank line (`must_not_include` checks the `|  |` empty-cell output no longer appears).

Before:
```
|  |
|  |
|  |
|  |
```

After:
```
| name | age |
| --- | --- |
| bob | 3 |
| alice | 7 |
```
