### PR TITLE
fix: escape pipes in Excel markdown tables

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -33,6 +33,22 @@ ACCEPTED_XLS_MIME_TYPE_PREFIXES = [
 ACCEPTED_XLS_FILE_EXTENSIONS = [".xls"]
 
 
+def _escape_markdown_table_pipe(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.replace("|", "\\|")
+    return value
+
+
+def _escape_dataframe_markdown_table_pipes(dataframe: "pd.DataFrame") -> "pd.DataFrame":
+    escaped = dataframe.copy()
+    escaped.columns = [
+        _escape_markdown_table_pipe(column) for column in escaped.columns
+    ]
+    if hasattr(escaped, "map"):
+        return escaped.map(_escape_markdown_table_pipe)
+    return escaped.applymap(_escape_markdown_table_pipe)
+
+
 class XlsxConverter(DocumentConverter):
     """
     Converts XLSX files to Markdown, with each sheet presented as a separate Markdown table.
@@ -84,7 +100,9 @@ class XlsxConverter(DocumentConverter):
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = _escape_dataframe_markdown_table_pipes(sheets[s]).to_html(
+                index=False
+            )
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs
@@ -146,7 +164,9 @@ class XlsConverter(DocumentConverter):
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = _escape_dataframe_markdown_table_pipes(sheets[s]).to_html(
+                index=False
+            )
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -220,6 +220,25 @@ def test_data_uris() -> None:
     assert data == b"Hello, World!"
 
 
+def test_xlsx_conversion_escapes_markdown_table_pipes() -> None:
+    import pandas as pd
+
+    stream = io.BytesIO()
+    pd.DataFrame({"A|B": ["x|y"], "C": ["z"]}).to_excel(stream, index=False)
+    stream.seek(0)
+
+    result = MarkItDown().convert_stream(
+        stream,
+        stream_info=StreamInfo(
+            extension=".xlsx",
+            mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+    )
+
+    assert "A\\|B" in result.markdown
+    assert "x\\|y" in result.markdown
+
+
 def test_file_uris() -> None:
     # Test file URI with an empty host
     file_uri = "file:///path/to/file.txt"


### PR DESCRIPTION
## Summary

Escapes literal pipe characters in Excel string headers and cell values before converting dataframe HTML into Markdown tables. Without this, values like `A|B` or `x|y` are emitted as raw pipes and can be parsed as extra Markdown table columns.

The helper is shared by the `.xlsx` and `.xls` converters and leaves non-string values unchanged.

## Validation

- `uv run --project packages/markitdown --extra all --with pytest python -m pytest packages/markitdown/tests/test_module_misc.py -k xlsx_conversion_escapes_markdown_table_pipes`