### PR TITLE
docs: add non-Docker Claude Desktop config for MCP

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -56,11 +56,42 @@ Once mounted, all files under data will be accessible under `/workdir` in the co
 
 ## Accessing from Claude Desktop
 
-It is recommended to use the Docker image when running the MCP server for Claude Desktop.
-
 Follow [these instructions](https://modelcontextprotocol.io/quickstart/user#for-claude-desktop-users) to access Claude's `claude_desktop_config.json` file.
 
-Edit it to include the following JSON entry:
+If you installed `markitdown-mcp` with `uvx`, edit it to include the following JSON entry:
+
+```json
+{
+  "mcpServers": {
+    "markitdown": {
+      "command": "uvx",
+      "args": [
+        "markitdown-mcp"
+      ]
+    }
+  }
+}
+```
+
+If you installed `markitdown-mcp` with `pip` in a virtual environment, use that environment's Python executable:
+
+```json
+{
+  "mcpServers": {
+    "markitdown": {
+      "command": "/path/to/.venv/bin/python",
+      "args": [
+        "-m",
+        "markitdown_mcp"
+      ]
+    }
+  }
+}
+```
+
+Replace `/path/to/.venv/bin/python` with the absolute path to your virtual environment's Python executable. Using the absolute path avoids issues where Claude Desktop cannot find commands installed in a shell-specific `PATH`.
+
+It is also possible to use the Docker image when running the MCP server for Claude Desktop. Edit `claude_desktop_config.json` to include the following JSON entry:
 
 ```json
 {


### PR DESCRIPTION
## Summary

Adds Claude Desktop configuration examples for running `markitdown-mcp` without Docker, covering both `uvx markitdown-mcp` and a `pip`/virtualenv install using `python -m markitdown_mcp`.

Fixes #2128.

## Validation

- README sanity check confirmed the new `uvx`, `markitdown_mcp`, and virtualenv Python path examples are present.
- Docs-only change.