### PR TITLE
fix: propagate zip converter options to nested files

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -104,6 +104,7 @@ class ZipConverter(DocumentConverter):
                     result = self._markitdown.convert_stream(
                         stream=z_file_stream,
                         stream_info=z_file_stream_info,
+                        **kwargs,
                     )
                     if result is not None:
                         md_content += f"## File: {name}\n\n"

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -3,6 +3,7 @@ import io
 import os
 import re
 import shutil
+import zipfile
 import pytest
 from unittest.mock import MagicMock
 
@@ -218,6 +219,25 @@ def test_data_uris() -> None:
     assert len(attributes) == 1
     assert attributes["charset"] == "utf-8"
     assert data == b"Hello, World!"
+
+
+def test_zip_conversion_propagates_keep_data_uris() -> None:
+    archive = io.BytesIO()
+    html = (
+        "<html><body><img alt='example' "
+        "src='data:image/png;base64,SGVsbG8='></body></html>"
+    )
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("index.html", html)
+    archive.seek(0)
+
+    result = MarkItDown().convert_stream(
+        archive,
+        stream_info=StreamInfo(extension=".zip", mimetype="application/zip"),
+        keep_data_uris=True,
+    )
+
+    assert "data:image/png;base64,SGVsbG8=" in result.markdown
 
 
 def test_file_uris() -> None:


### PR DESCRIPTION
## Summary

Propagates keyword options from `ZipConverter.convert()` into nested `convert_stream()` calls for files inside archives. This preserves per-call options such as `keep_data_uris=True` when the converted file is inside a `.zip`.

This is complementary to #1977, which discusses storing/injecting `keep_data_uris` as a global option; this PR covers kwargs supplied on the ZIP conversion call itself.

## Validation

- `uv run --project packages/markitdown --extra all --with pytest python -m pytest packages/markitdown/tests/test_module_misc.py -k zip_conversion_propagates_keep_data_uris`