### PR TITLE
feat: add RTF (Rich Text Format) converter

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -49,12 +49,14 @@ all = [
   "azure-ai-documentintelligence",
   "azure-ai-contentunderstanding>=1.2.0b1",
   "azure-identity",
+  "striprtf",
 ]
 pptx = ["python-pptx"]
 docx = ["mammoth~=1.11.0", "lxml"]
 xlsx = ["pandas", "openpyxl"]
 xls = ["pandas", "xlrd"]
 pdf = ["pdfminer.six>=20251230", "pdfplumber>=0.11.9"]
+rtf = ["striprtf"]
 outlook = ["olefile"]
 audio-transcription = ["pydub", "SpeechRecognition"]
 youtube-transcription = ["youtube-transcript-api"]

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -40,6 +40,7 @@ from .converters import (
     DocumentIntelligenceConverter,
     ContentUnderstandingConverter,
     CsvConverter,
+    RtfConverter,
 )
 
 from ._base_converter import DocumentConverter, DocumentConverterResult
@@ -203,6 +204,7 @@ class MarkItDown:
             self.register_converter(OutlookMsgConverter())
             self.register_converter(EpubConverter())
             self.register_converter(CsvConverter())
+            self.register_converter(RtfConverter())
 
             # Register Document Intelligence converter at the top of the stack if endpoint is provided
             docintel_endpoint = kwargs.get("docintel_endpoint")

--- a/packages/markitdown/src/markitdown/converters/__init__.py
+++ b/packages/markitdown/src/markitdown/converters/__init__.py
@@ -27,6 +27,7 @@ from ._cu_converter import (
 )
 from ._epub_converter import EpubConverter
 from ._csv_converter import CsvConverter
+from ._rtf_converter import RtfConverter
 
 __all__ = [
     "PlainTextConverter",
@@ -51,4 +52,5 @@ __all__ = [
     "ContentUnderstandingFileType",
     "EpubConverter",
     "CsvConverter",
+    "RtfConverter",
 ]

--- a/packages/markitdown/src/markitdown/converters/_rtf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rtf_converter.py
@@ -1,0 +1,86 @@
+import sys
+
+from typing import BinaryIO, Any
+
+from charset_normalizer import from_bytes
+
+from .._base_converter import DocumentConverter, DocumentConverterResult
+from .._stream_info import StreamInfo
+from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
+
+# Try loading optional (but in this case, required) dependencies
+# Save reporting of any exceptions for later
+_dependency_exc_info = None
+try:
+    from striprtf.striprtf import rtf_to_text
+except ImportError:
+    # Preserve the error and stack trace for later
+    _dependency_exc_info = sys.exc_info()
+
+
+ACCEPTED_MIME_TYPE_PREFIXES = [
+    "application/rtf",
+    "application/x-rtf",
+    "text/rtf",
+    "text/richtext",
+]
+
+ACCEPTED_FILE_EXTENSIONS = [".rtf"]
+
+
+class RtfConverter(DocumentConverter):
+    """
+    Converts RTF (Rich Text Format) files to Markdown. RTF formatting control
+    words are stripped and the underlying text content is preserved.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def accepts(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,  # Options to pass to the converter
+    ) -> bool:
+        mimetype = (stream_info.mimetype or "").lower()
+        extension = (stream_info.extension or "").lower()
+
+        if extension in ACCEPTED_FILE_EXTENSIONS:
+            return True
+
+        for prefix in ACCEPTED_MIME_TYPE_PREFIXES:
+            if mimetype.startswith(prefix):
+                return True
+
+        return False
+
+    def convert(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,  # Options to pass to the converter
+    ) -> DocumentConverterResult:
+        # Check: the dependencies
+        if _dependency_exc_info is not None:
+            raise MissingDependencyException(
+                MISSING_DEPENDENCY_MESSAGE.format(
+                    converter=type(self).__name__,
+                    extension=".rtf",
+                    feature="rtf",
+                )
+            ) from _dependency_exc_info[1].with_traceback(  # type: ignore[union-attr]
+                _dependency_exc_info[2]
+            )
+
+        # RTF is an ASCII-based format, but may declare a code page for any
+        # non-ASCII bytes. Decode defensively so we always hand a str to
+        # striprtf, which performs the actual control-word stripping.
+        if stream_info.charset:
+            rtf_content = file_stream.read().decode(stream_info.charset)
+        else:
+            rtf_content = str(from_bytes(file_stream.read()).best())
+
+        text = rtf_to_text(rtf_content)
+
+        return DocumentConverterResult(markdown=text.strip())

--- a/packages/markitdown/tests/test_files/test.rtf
+++ b/packages/markitdown/tests/test_files/test.rtf
@@ -1,0 +1,8 @@
+{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0 Helvetica;}}
+{\b\fs36 RTF Test Document 8f14e45f}\par
+\par
+This is a plain paragraph c4ca4238 with some {\b bold a87ff679} text.\par
+\par
+{\i Italic line e4da3b7f} appears here.\par
+A second paragraph 1679091c with more content.\par
+}

--- a/packages/markitdown/tests/test_rtf_converter.py
+++ b/packages/markitdown/tests/test_rtf_converter.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3 -m pytest
+import os
+
+from markitdown import MarkItDown, StreamInfo
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+RTF_TEST_STRINGS = [
+    "RTF Test Document 8f14e45f",
+    "This is a plain paragraph c4ca4238 with some bold a87ff679 text.",
+    "Italic line e4da3b7f appears here.",
+    "A second paragraph 1679091c with more content.",
+]
+
+
+def test_rtf_converter_local() -> None:
+    """RTF files convert to Markdown with control words stripped."""
+    markitdown = MarkItDown()
+    result = markitdown.convert(os.path.join(TEST_FILES_DIR, "test.rtf"))
+    for s in RTF_TEST_STRINGS:
+        assert s in result.markdown
+    # Control words must not leak into the output.
+    assert "\\rtf1" not in result.markdown
+    assert "\\par" not in result.markdown
+
+
+def test_rtf_converter_stream() -> None:
+    """RTF conversion works from a binary stream with explicit StreamInfo."""
+    markitdown = MarkItDown()
+    with open(os.path.join(TEST_FILES_DIR, "test.rtf"), "rb") as stream:
+        result = markitdown.convert(
+            stream, stream_info=StreamInfo(extension=".rtf", mimetype="application/rtf")
+        )
+    for s in RTF_TEST_STRINGS:
+        assert s in result.markdown
+
+
+if __name__ == "__main__":
+    test_rtf_converter_local()
+    test_rtf_converter_stream()
+    print("All RTF converter tests passed.")


### PR DESCRIPTION
## Summary

Adds a converter for RTF (Rich Text Format) files, which MarkItDown did not previously support. RTF is a common interchange format (WordPad, TextEdit, legacy office exports), so this fills a real gap in the supported file types.

`RtfConverter` accepts `.rtf` files (the file extension and the `application/rtf`, `application/x-rtf`, `text/rtf`, `text/richtext` mimetypes), strips RTF control words, and returns the underlying text content as Markdown.

## Implementation

- New `converters/_rtf_converter.py`: `RtfConverter(DocumentConverter)` following the same `accepts()` / `convert()` shape as the existing converters. It uses the lightweight, pure-Python `striprtf` library, imported lazily and gated behind the standard `MissingDependencyException` (matching the docx/pptx/pdf pattern), so the base install is unaffected.
- Registered in `_markitdown.py` and exported from `converters/__init__.py`.
- Added an `rtf = ["striprtf"]` optional-dependency extra in `pyproject.toml` and folded `striprtf` into `[all]`.
- Charset handling mirrors the CSV converter (`stream_info.charset` with a `charset-normalizer` fallback).

## Scope

This is a v1 text-extraction converter: it preserves the document's textual content with control words removed (the same altitude as the plain-text and CSV converters). It does not attempt to map RTF bold/heading runs onto Markdown syntax, which would require a substantially heavier dependency.

## Testing

- Added `tests/test_files/test.rtf` (a small fixture with heading, bold, italic, and paragraph content) and `tests/test_rtf_converter.py` (local-path and binary-stream conversion).
- New RTF tests pass, and the full existing offline suite passes with `[all]` installed (no regressions).
- `python -m markitdown test.rtf` produces the expected Markdown.
- `ruff check` and `ruff format` are clean.
