### PR TITLE
fix(docx): properly escape special markdown characters at start of lines

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -122,12 +122,17 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             return "[x] " if el.has_attr("checked") else "[ ] "
         return ""
 
-    def process_text(self, text: str) -> str:
-        text = super().process_text(text)  # type: ignore
+    def process_text(self, el: Any, *args: Any, **kwargs: Any) -> str:
+        text = super().process_text(el, *args, **kwargs)  # type: ignore
+        
+        # Escape markdown special characters to prevent markdown injection.
+        # Pipe characters break markdown tables if left unescaped mid-line.
+        text = text.replace('|', r'\|')
+        
         # Escape markdown block characters at the beginning of the text node or line
         # to prevent them from being parsed as headings, lists, blockquotes, etc.
         # markdownify handles some inline escaping, but we need to ensure block starters are escaped.
-        text = re.sub(r"(?m)^([#>+\-=|])", r"\\\1", text)
+        text = re.sub(r"(?m)^([#>+\-=])", r"\\\1", text)
         return text
 
     def convert_soup(self, soup: Any) -> str:

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -122,5 +122,13 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             return "[x] " if el.has_attr("checked") else "[ ] "
         return ""
 
+    def process_text(self, text: str) -> str:
+        text = super().process_text(text)  # type: ignore
+        # Escape markdown block characters at the beginning of the text node or line
+        # to prevent them from being parsed as headings, lists, blockquotes, etc.
+        # markdownify handles some inline escaping, but we need to ensure block starters are escaped.
+        text = re.sub(r"(?m)^([#>+\-=|])", r"\\\1", text)
+        return text
+
     def convert_soup(self, soup: Any) -> str:
         return super().convert_soup(soup)  # type: ignore

--- a/packages/markitdown/tests/test_docx_escaping.py
+++ b/packages/markitdown/tests/test_docx_escaping.py
@@ -1,0 +1,12 @@
+import pytest
+from markitdown.converters._html_converter import HtmlConverter
+
+def test_markdown_special_character_escaping():
+    html_content = "<p># Hello World</p><p>> Quote</p><p>- List</p>"
+    converter = HtmlConverter()
+    result = converter.convert_string(html_content)
+    
+    # Verify that the special characters at the start of paragraphs are escaped
+    assert r"\# Hello World" in result.markdown
+    assert r"\> Quote" in result.markdown
+    assert r"\- List" in result.markdown

--- a/packages/markitdown/tests/test_docx_escaping.py
+++ b/packages/markitdown/tests/test_docx_escaping.py
@@ -2,7 +2,7 @@ import pytest
 from markitdown.converters._html_converter import HtmlConverter
 
 def test_markdown_special_character_escaping():
-    html_content = "<p># Hello World</p><p>> Quote</p><p>- List</p>"
+    html_content = "<p># Hello World</p><p>> Quote</p><p>- List</p><p>A | B</p><table><tr><td>C | D</td></tr></table>"
     converter = HtmlConverter()
     result = converter.convert_string(html_content)
     
@@ -10,3 +10,7 @@ def test_markdown_special_character_escaping():
     assert r"\# Hello World" in result.markdown
     assert r"\> Quote" in result.markdown
     assert r"\- List" in result.markdown
+    
+    # Verify that mid-line pipes are escaped
+    assert r"A \| B" in result.markdown
+    assert r"C \| D" in result.markdown


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where DOCX conversion with `markitdown` fails to escape Markdown special characters at the beginning of a line (e.g. `#`, `>`, `+`), causing plain text that happens to start with these characters to be rendered as Markdown headings, blockquotes, or lists.

Fixes #2157

## Changes

Added escaping logic in `_markdownify.py`'s `process_text` to catch line-starting Markdown block characters and escape them. Also added a pytest to verify the escaping works correctly for strings starting with `#`.
