### PR TITLE
Improve invalid source type error

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -319,7 +319,7 @@ class MarkItDown:
             return self.convert_stream(source, stream_info=stream_info, **kwargs)
         else:
             raise TypeError(
-                f"Invalid source type: {type(source)}. Expected str, requests.Response, BinaryIO."
+                f"Invalid source type: {type(source)}. Expected str, pathlib.Path, requests.Response, or BinaryIO."
             )
 
     def convert_local(

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -432,6 +432,19 @@ def test_exceptions() -> None:
     assert type(exc_info.value.attempts[0].converter).__name__ == "PptxConverter"
 
 
+def test_invalid_source_type_error_lists_supported_types() -> None:
+    markitdown = MarkItDown()
+
+    with pytest.raises(TypeError) as exc_info:
+        markitdown.convert(None)
+
+    message = str(exc_info.value)
+    assert "str" in message
+    assert "pathlib.Path" in message
+    assert "requests.Response" in message
+    assert "BinaryIO" in message
+
+
 @pytest.mark.skipif(
     skip_exiftool,
     reason="do not run if exiftool is not installed",


### PR DESCRIPTION
## Summary

- Update the `MarkItDown.convert()` unsupported-source `TypeError` to list `pathlib.Path`, which is already accepted by the API.
- Add a focused regression test that checks the error message lists the supported source types.

## Validation

- `python -m pytest packages/markitdown/tests/test_module_misc.py::test_invalid_source_type_error_lists_supported_types packages/markitdown/tests/test_module_misc.py::test_exceptions`
- `python -m black --check packages/markitdown/src/markitdown/_markitdown.py packages/markitdown/tests/test_module_misc.py`