### PR TITLE
Fix: skip leading empty rows in CsvConverter to avoid data loss

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -51,6 +51,14 @@ class CsvConverter(DocumentConverter):
         reader = csv.reader(io.StringIO(content))
         rows = list(reader)
 
+        # Skip leading empty rows
+        start_idx = 0
+        while start_idx < len(rows) and (
+            not rows[start_idx] or all(cell.strip() == "" for cell in rows[start_idx])
+        ):
+            start_idx += 1
+        rows = rows[start_idx:]
+
         if not rows:
             return DocumentConverterResult(markdown="")
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -532,6 +532,21 @@ def test_markitdown_llm() -> None:
     validate_strings(result, PPTX_TEST_STRINGS)
 
 
+def test_csv_with_blank_first_line() -> None:
+    markitdown = MarkItDown()
+    csv_content = "\n\nname,age\nbob,3\nalice,7\n"
+    result = markitdown.convert_stream(
+        io.BytesIO(csv_content.encode("utf-8")),
+        file_extension=".csv",
+    )
+    assert "name" in result.text_content
+    assert "age" in result.text_content
+    assert "bob" in result.text_content
+    assert "3" in result.text_content
+    assert "alice" in result.text_content
+    assert "7" in result.text_content
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     for test in [
@@ -547,6 +562,7 @@ if __name__ == "__main__":
         test_markitdown_exiftool,
         test_markitdown_llm_parameters,
         test_markitdown_llm,
+        test_csv_with_blank_first_line,
     ]:
         print(f"Running {test.__name__}...", end="")
         test()


### PR DESCRIPTION
Resolves #2136. When converting a CSV that starts with a blank line (or a row containing only empty cells), the parser treats it as a zero-column header. This leads to truncating all subsequent data rows to zero columns. By skipping leading empty rows before selecting the header row, we prevent this silent truncation and correctly convert the table. Added test_csv_with_blank_first_line to test_module_misc.py.