### PR TITLE
## Summaryfeat(mcp): add local LLM support for Ollama and LM Studio

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -35,6 +35,66 @@ To run the MCP server, using Streamable HTTP and SSE, use the following command:
 markitdown-mcp --http --host 127.0.0.1 --port 3001
 ```
 
+## LLM / OCR Support (Optional)
+
+The MCP server can be configured to use a local or remote LLM for image
+descriptions and OCR (via the `markitdown-ocr` plugin).  Set the following
+environment variables:
+
+| Variable | Description |
+|---|---|
+| `MARKITDOWN_LLM_BASE_URL` | OpenAI-compatible API base URL (e.g. `http://localhost:11434/v1` for Ollama, `http://localhost:1234/v1` for LM Studio) |
+| `MARKITDOWN_LLM_MODEL` | Model name (e.g. `llama3.2-vision`, `gpt-4o`) |
+| `MARKITDOWN_LLM_API_KEY` | API key (optional; defaults to `ollama` for local servers) |
+| `MARKITDOWN_ENABLE_PLUGINS` | Set to `true` to enable the OCR plugin |
+
+### Ollama
+
+Ollama is auto-detected (port 11434 or hostname containing "ollama") and
+uses a lightweight native API adapter — **no `openai` package required**.
+
+```bash
+MARKITDOWN_ENABLE_PLUGINS=true \
+MARKITDOWN_LLM_BASE_URL=http://localhost:11434/v1 \
+MARKITDOWN_LLM_MODEL=llama3.2-vision \
+markitdown-mcp
+```
+
+### LM Studio / vLLM / Other OpenAI-Compatible Servers
+
+These servers expose a standard `/v1/chat/completions` endpoint and work
+with the `openai` Python package.
+
+```bash
+pip install openai
+
+MARKITDOWN_ENABLE_PLUGINS=true \
+MARKITDOWN_LLM_BASE_URL=http://localhost:1234/v1 \
+MARKITDOWN_LLM_MODEL=local-model \
+markitdown-mcp
+```
+
+### MCP Client Configuration
+
+When configuring an MCP client (VS Code, Claude Desktop, etc.), pass the
+environment variables in the server configuration:
+
+```json
+{
+  "servers": {
+    "markitdown": {
+      "command": "markitdown-mcp",
+      "args": [],
+      "env": {
+        "MARKITDOWN_ENABLE_PLUGINS": "true",
+        "MARKITDOWN_LLM_BASE_URL": "http://localhost:11434/v1",
+        "MARKITDOWN_LLM_MODEL": "llama3.2-vision"
+      }
+    }
+  }
+}
+```
+
 ## Running in Docker
 
 To run `markitdown-mcp` in Docker, build the Docker image using the provided Dockerfile:

--- a/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
+++ b/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
@@ -17,10 +17,60 @@ import uvicorn
 mcp = FastMCP("markitdown")
 
 
+def _build_markitdown_kwargs() -> dict:
+    """Build MarkItDown constructor kwargs from environment variables.
+
+    Reads ``MARKITDOWN_LLM_BASE_URL``, ``MARKITDOWN_LLM_MODEL``, and
+    ``MARKITDOWN_LLM_API_KEY`` to configure an OpenAI-compatible LLM
+    client for image descriptions and OCR plugins.
+
+    Supported backends:
+
+    * **Ollama** — detected automatically when the base URL contains
+      ``:11434`` or the hostname ``ollama``.  Uses a lightweight native
+      API adapter (``_ollama_adapter.py``) that does not require the
+      ``openai`` package.
+    * **LM Studio / vLLM / any OpenAI-compatible server** — uses the
+      standard ``openai.OpenAI`` client.  Requires ``pip install openai``.
+    """
+    kwargs: dict = {"enable_plugins": check_plugins_enabled()}
+
+    llm_base_url = os.getenv("MARKITDOWN_LLM_BASE_URL")
+    llm_model = os.getenv("MARKITDOWN_LLM_MODEL")
+
+    if llm_base_url and llm_model:
+        # Auto-detect Ollama so we can use the native adapter
+        if ":11434" in llm_base_url or "ollama" in llm_base_url.lower():
+            from ._ollama_adapter import OllamaClient
+
+            kwargs["llm_client"] = OllamaClient(
+                base_url=llm_base_url.replace("/v1", ""),
+                model=llm_model,
+            )
+            kwargs["llm_model"] = llm_model
+        else:
+            try:
+                from openai import OpenAI
+
+                kwargs["llm_client"] = OpenAI(
+                    base_url=llm_base_url,
+                    api_key=os.getenv("MARKITDOWN_LLM_API_KEY", "ollama"),
+                )
+                kwargs["llm_model"] = llm_model
+            except ImportError:
+                print(
+                    "MARKITDOWN_LLM_BASE_URL/MODEL set but 'openai' package "
+                    "not installed. Install it with: pip install openai",
+                    file=sys.stderr,
+                )
+
+    return kwargs
+
+
 @mcp.tool()
 async def convert_to_markdown(uri: str) -> str:
     """Convert a resource described by an http:, https:, file: or data: URI to markdown"""
-    return MarkItDown(enable_plugins=check_plugins_enabled()).convert_uri(uri).markdown
+    return MarkItDown(**_build_markitdown_kwargs()).convert_uri(uri).markdown
 
 
 def check_plugins_enabled() -> bool:

--- a/packages/markitdown-mcp/src/markitdown_mcp/_ollama_adapter.py
+++ b/packages/markitdown-mcp/src/markitdown_mcp/_ollama_adapter.py
@@ -1,0 +1,125 @@
+"""
+Ollama native API adapter.
+
+Provides an OpenAI-client-compatible wrapper around Ollama's native
+/api/generate and /api/chat endpoints.  This is used as a fallback when
+Ollama's built-in /v1/chat/completions endpoint is unavailable or
+returns errors (e.g. 502 on certain Ollama versions).
+
+LM Studio, vLLM, and other OpenAI-compatible servers do NOT need this
+adapter — they work directly with the standard ``openai.OpenAI`` client.
+"""
+
+import json
+import urllib.request
+from typing import Any
+
+
+class OllamaChatCompletion:
+    """Minimal stand-in for ``openai.types.chat.ChatCompletion``."""
+
+    def __init__(self, content: str) -> None:
+        self.choices = [self._Choice(content)]
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.message = self._Message(content)
+
+        class _Message:
+            def __init__(self, content: str) -> None:
+                self.content = content
+
+
+class OllamaCompletions:
+    """Minimal stand-in for ``openai.resources.chat.Completions``."""
+
+    def __init__(self, base_url: str, model: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+
+    def create(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> OllamaChatCompletion:
+        """Send a chat-completion request to Ollama's native API.
+
+        Routes vision requests (messages containing ``image_url`` parts)
+        to ``/api/generate`` and text-only requests to ``/api/chat``.
+        """
+        actual_model = model or self._model
+
+        # Unpack OpenAI-format messages into prompt text + images
+        images: list[str] = []
+        prompt_text = ""
+
+        for msg in messages:
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                for part in content:
+                    if part.get("type") == "text":
+                        prompt_text += part.get("text", "")
+                    elif part.get("type") == "image_url":
+                        data_uri = part.get("image_url", {}).get("url", "")
+                        if "," in data_uri:
+                            images.append(data_uri.split(",", 1)[1])
+                        else:
+                            images.append(data_uri)
+            else:
+                prompt_text += str(content)
+
+        if images:
+            payload: dict[str, Any] = {
+                "model": actual_model,
+                "prompt": prompt_text,
+                "images": images,
+                "stream": False,
+            }
+            endpoint = f"{self._base_url}/api/generate"
+        else:
+            payload = {
+                "model": actual_model,
+                "messages": [{"role": "user", "content": prompt_text}],
+                "stream": False,
+            }
+            endpoint = f"{self._base_url}/api/chat"
+
+        req = urllib.request.Request(
+            endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=300) as resp:
+                result = json.loads(resp.read())
+        except Exception as exc:
+            raise RuntimeError(
+                f"Ollama API call to {endpoint} failed: {exc}"
+            ) from exc
+
+        # /api/generate returns "response"; /api/chat returns "message"
+        content: str = result.get("response") or result.get(
+            "message", {}
+        ).get("content", "")
+        return OllamaChatCompletion(content)
+
+
+class OllamaClient:
+    """Minimal stand-in for ``openai.OpenAI``.
+
+    Can be passed directly as ``llm_client`` to ``MarkItDown``.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        model: str = "",
+    ) -> None:
+        self.chat = type(
+            "_Chat",
+            (),
+            {"completions": OllamaCompletions(base_url, model)},
+        )()


### PR DESCRIPTION
Add environment-variable-based LLM configuration to the MCP server, enabling image descriptions and OCR (via markitdown-ocr plugin) with locally hosted models.

- MARKITDOWN_LLM_BASE_URL: OpenAI-compatible API base URL
- MARKITDOWN_LLM_MODEL: model name
- MARKITDOWN_LLM_API_KEY: optional API key (defaults to 'ollama')

Ollama is auto-detected (port 11434 or hostname) and uses a lightweight native API adapter (_ollama_adapter.py) that requires no extra dependencies. LM Studio, vLLM, and other OpenAI-compatible servers use the standard openai package.

When no LLM env vars are set, behavior is unchanged.