### PR TITLE
Handle YouTube transcript errors and improve metadata extraction

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -151,40 +151,44 @@ class YouTubeConverter(DocumentConverter):
             params = parse_qs(parsed_url.query)  # type: ignore
             if "v" in params and params["v"][0]:
                 video_id = str(params["v"][0])
-                transcript_list = ytt_api.list(video_id)
-                languages = ["en"]
-                for transcript in transcript_list:
-                    languages.append(transcript.language_code)
-                    break
                 try:
-                    youtube_transcript_languages = kwargs.get(
-                        "youtube_transcript_languages", languages
-                    )
-                    # Retry the transcript fetching operation
-                    transcript = self._retry_operation(
-                        lambda: ytt_api.fetch(
-                            video_id, languages=youtube_transcript_languages
-                        ),
-                        retries=3,  # Retry 3 times
-                        delay=2,  # 2 seconds delay between retries
-                    )
-
-                    if transcript:
-                        transcript_text = " ".join(
-                            [part.text for part in transcript]
-                        )  # type: ignore
-                except Exception as e:
-                    # No transcript available
-                    if len(languages) == 1:
-                        print(f"Error fetching transcript: {e}")
-                    else:
-                        # Translate transcript into first kwarg
-                        transcript = (
-                            transcript_list.find_transcript(languages)
-                            .translate(youtube_transcript_languages[0])
-                            .fetch()
+                    transcript_list = ytt_api.list(video_id)
+                    languages = ["en"]
+                    for transcript in transcript_list:
+                        languages.append(transcript.language_code)
+                        break
+                    try:
+                        youtube_transcript_languages = kwargs.get(
+                            "youtube_transcript_languages", languages
                         )
-                        transcript_text = " ".join([part.text for part in transcript])
+                        # Retry the transcript fetching operation
+                        transcript = self._retry_operation(
+                            lambda: ytt_api.fetch(
+                                video_id, languages=youtube_transcript_languages
+                            ),
+                            retries=3,  # Retry 3 times
+                            delay=2,  # 2 seconds delay between retries
+                        )
+
+                        if transcript:
+                            transcript_text = " ".join(
+                                [part.text for part in transcript]
+                            )  # type: ignore
+                    except Exception as e:
+                        # No transcript available
+                        if len(languages) == 1:
+                            print(f"Error fetching transcript: {e}")
+                        else:
+                            # Translate transcript into first kwarg
+                            transcript = (
+                                transcript_list.find_transcript(languages)
+                                .translate(youtube_transcript_languages[0])
+                                .fetch()
+                            )
+                            transcript_text = " ".join([part.text for part in transcript])
+                except Exception as e:
+                    print(f"YouTube transcript extraction failed: {e}")
+                    transcript_text = "*(Transcript unavailable)*"
             if transcript_text:
                 webpage_text += f"\n### Transcript\n{transcript_text}\n"
 


### PR DESCRIPTION
# Description

This Pull Request addresses an issue in `YouTubeConverter` where transcript listing failures crash the entire converter, causing it to fall back to `HtmlConverter` and output raw, unreadable scraping HTML (such as cookie walls) instead of clean video details.

## Problem

In `markitdown/converters/_youtube_converter.py`, the initial call to retrieve the transcripts list (`ytt_api.list(video_id)`) was executed outside of the safety `try/except` block. 

Transcript listing and fetching commonly fail due to:
1. **IP Blocking / Rate Limiting:** Datacenter/CI IP addresses are regularly blocked or rate-limited by YouTube.
2. **Subtitles Disabled:** The target video does not have any manual or auto-generated captions.
3. **Age Gate / Region Restrictions:** The video requires authentication cookies.

When `list()` raises an exception under these conditions, the entire `YouTubeConverter.convert` method crashes. The orchestrator catches the crash and falls back to `HtmlConverter`, which yields a bad user experience (raw HTML of the YouTube sign-in page / cookie consent banner) instead of the successfully extracted video metadata (title, views, runtime, description).

## Solution

1. Wrapped the transcript listing operations (`list()` and language extraction) in the outer `try/except` block.
2. If listing or fetching the transcript fails, the converter now gracefully handles the exception, prints the failure, sets a fallback string `*(Transcript unavailable)*`, and **continues** execution.
3. This ensures the output Markdown still contains the successfully parsed video title, views, keywords, runtime, and description.

