### PR TITLE
fix(deps): unpin youtube-transcript-api in [all] extra (broken on current PyPI)

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -45,7 +45,7 @@ all = [
   "olefile",
   "pydub",
   "SpeechRecognition",
-  "youtube-transcript-api~=1.0.0",
+  "youtube-transcript-api>=1.0.0",
   "azure-ai-documentintelligence",
   "azure-ai-contentunderstanding>=1.2.0b1",
   "azure-identity",


### PR DESCRIPTION
## Problem

`pip install "markitdown[all]"` currently fails (or silently downgrades to ancient `markitdown 0.0.2`):

```
ERROR: Could not find a version that satisfies the requirement youtube-transcript-api~=1.0.0; extra == "all"
```

## Root cause

The `[all]` extra pins `youtube-transcript-api~=1.0.0` (i.e. `>=1.0.0,<1.1.0`), but the `1.0.x` releases have been **removed from PyPI** - the package now jumps from `0.6.2` straight to `1.2.3`. The pin is therefore unsatisfiable.

Notably, the standalone `[youtube-transcription]` extra is already **unpinned** and works fine:

```toml
youtube-transcription = ["youtube-transcript-api"]
```

## Fix

Align `[all]` with the existing unpinned `[youtube-transcription]` extra - keep the original "require 1.x+" intent, drop the impossible upper bound:

```diff
-  "youtube-transcript-api~=1.0.0",
+  "youtube-transcript-api>=1.0.0",
```

## Verification

- Before: `pip install "markitdown[all]"` -> `ResolutionImpossible` (or downgrade to 0.0.2).
- After: `pip install "markitdown[all]"` resolves cleanly and stays on the current release (verified on Python 3.14).

One-line change; no runtime code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)