### PR TITLE
docs: add HTTPS clone option alongside SSH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ git clone git@github.com:microsoft/markitdown.git
 cd markitdown
 pip install -e 'packages/markitdown[all]'
 ```
-cd markitdown
-pip install -e 'packages/markitdown[all]'
-
 ## Usage
 
 ### Command-Line

--- a/README.md
+++ b/README.md
@@ -63,10 +63,15 @@ conda activate markitdown
 To install MarkItDown, use pip: `pip install 'markitdown[all]'`. Alternatively, you can install it from the source:
 
 ```bash
+# HTTPS 
+git clone https://github.com/microsoft/markitdown.git
+# SSH 
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
 pip install -e 'packages/markitdown[all]'
 ```
+cd markitdown
+pip install -e 'packages/markitdown[all]'
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Adds the HTTPS clone URL as an alternative to the existing SSH clone command in the installation instructions.

## Motivation

The README's "Installation" section only shows the SSH clone command (`git@github.com:microsoft/markitdown.git`). This works fine for contributors who already have an SSH key configured with GitHub, but new users without SSH keys set up hit a confusing error:

    git@github.com: Permission denied (publickey).
    fatal: Could not read from remote repository.

Since this is a public repo, HTTPS cloning works with no setup at all. Adding it alongside SSH makes the "Installation" section easier to follow for first-time users, while keeping the SSH option for those who prefer it.

## Change

```bash
# HTTPS 
git clone https://github.com/microsoft/markitdown.git
# SSH 
git clone git@github.com:microsoft/markitdown.git
cd markitdown
pip install -e 'packages/markitdown[all]'
```

## Checklist

- [x] Documentation-only change, no code affected
- [x] Verified both clone commands work as expected