### PR TITLE
fix(docx): ignore malformed styles missing type

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -117,19 +117,24 @@ def _pre_process_math(content: bytes) -> bytes:
 
 def _pre_process_styles(content: bytes) -> bytes:
     """
-    Removes malformed DOCX style definitions that are missing required attributes.
+    Repairs DOCX style definitions that Mammoth cannot read.
 
-    Mammoth expects every ``w:style`` element to include ``w:type`` and
-    ``w:styleId``. Some DOCX producers emit malformed style entries without
-    those attributes, which otherwise causes conversion to fail with a
-    ``KeyError`` before any document text can be extracted. Dropping only the
-    malformed style definition allows Mammoth to continue and preserves the
-    document body content.
+    Mammoth indexes ``w:type`` and ``w:styleId`` directly, so a ``w:style``
+    element missing either attribute causes conversion to fail with a
+    ``KeyError`` before any document text can be extracted.
+
+    ``w:type`` is optional in OOXML: when it is absent the style type defaults
+    to ``paragraph``, so the attribute is filled in rather than dropping the
+    style, which would discard its formatting (a heading would be emitted as
+    plain body text). A style with no ``w:styleId`` cannot be referenced by the
+    document body, so it is removed.
     """
     soup = BeautifulSoup(content.decode(), features="xml")
     for tag in soup.find_all("w:style"):
-        if not tag.has_attr("w:type") or not tag.has_attr("w:styleId"):
+        if not tag.has_attr("w:styleId"):
             tag.decompose()
+        elif not tag.has_attr("w:type"):
+            tag["w:type"] = "paragraph"
     return str(soup).encode()
 
 

--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -129,7 +129,7 @@ def _pre_process_styles(content: bytes) -> bytes:
     plain body text). A style with no ``w:styleId`` cannot be referenced by the
     document body, so it is removed.
     """
-    soup = BeautifulSoup(content.decode(), features="xml")
+    soup = BeautifulSoup(content, features="xml")
     for tag in soup.find_all("w:style"):
         if not tag.has_attr("w:styleId"):
             tag.decompose()

--- a/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py
@@ -115,6 +115,24 @@ def _pre_process_math(content: bytes) -> bytes:
     return str(soup).encode()
 
 
+def _pre_process_styles(content: bytes) -> bytes:
+    """
+    Removes malformed DOCX style definitions that are missing required attributes.
+
+    Mammoth expects every ``w:style`` element to include ``w:type`` and
+    ``w:styleId``. Some DOCX producers emit malformed style entries without
+    those attributes, which otherwise causes conversion to fail with a
+    ``KeyError`` before any document text can be extracted. Dropping only the
+    malformed style definition allows Mammoth to continue and preserves the
+    document body content.
+    """
+    soup = BeautifulSoup(content.decode(), features="xml")
+    for tag in soup.find_all("w:style"):
+        if not tag.has_attr("w:type") or not tag.has_attr("w:styleId"):
+            tag.decompose()
+    return str(soup).encode()
+
+
 def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
     """
     Pre-processes a DOCX file with provided steps.
@@ -131,11 +149,12 @@ def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
     """
     output_docx = BytesIO()
     # The files that need to be pre-processed from .docx
-    pre_process_enable_files = [
-        "word/document.xml",
-        "word/footnotes.xml",
-        "word/endnotes.xml",
-    ]
+    pre_process_enable_files = {
+        "word/document.xml": _pre_process_math,
+        "word/footnotes.xml": _pre_process_math,
+        "word/endnotes.xml": _pre_process_math,
+        "word/styles.xml": _pre_process_styles,
+    }
     with zipfile.ZipFile(input_docx, mode="r") as zip_input:
         files = {name: zip_input.read(name) for name in zip_input.namelist()}
         with zipfile.ZipFile(output_docx, mode="w") as zip_output:
@@ -144,7 +163,7 @@ def pre_process_docx(input_docx: BinaryIO) -> BinaryIO:
                 if name in pre_process_enable_files:
                     try:
                         # Pre-process the content
-                        updated_content = _pre_process_math(content)
+                        updated_content = pre_process_enable_files[name](content)
                         # In the future, if there are more pre-processing steps, they can be added here
                         zip_output.writestr(name, updated_content)
                     except Exception:

--- a/packages/markitdown/tests/test_module_vectors.py
+++ b/packages/markitdown/tests/test_module_vectors.py
@@ -212,12 +212,14 @@ def test_convert_docx_with_style_missing_type(tmp_path):
                 content = zip_input.read(item.filename)
                 if item.filename == "word/styles.xml":
                     styles_xml = content.decode("utf-8")
-                    styles_xml = re.sub(
-                        r'<w:style\s+w:type="[^"]+"',
-                        "<w:style",
+                    styles_xml, count = re.subn(
+                        r'<w:style\s+w:type="[^"]+"(\s+w:styleId="1")',
+                        r"<w:style\1",
                         styles_xml,
-                        count=1,
                     )
+                    # Guard against a future fixture change silently
+                    # neutralizing this test.
+                    assert count == 1
                     content = styles_xml.encode("utf-8")
                 zip_output.writestr(item, content)
 
@@ -227,6 +229,7 @@ def test_convert_docx_with_style_missing_type(tmp_path):
         "AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation"
         in result.markdown
     )
+    assert "# Abstract" in result.markdown
 
 
 if __name__ == "__main__":

--- a/packages/markitdown/tests/test_module_vectors.py
+++ b/packages/markitdown/tests/test_module_vectors.py
@@ -3,6 +3,8 @@ import os
 import time
 import pytest
 import base64
+import re
+import zipfile
 
 from pathlib import Path
 
@@ -197,6 +199,34 @@ def test_convert_stream_keep_data_uris(test_vector):
             assert string in result.markdown
         for string in test_vector.must_not_include:
             assert string not in result.markdown
+
+
+def test_convert_docx_with_style_missing_type(tmp_path):
+    """DOCX conversion should not fail when a style entry is missing w:type."""
+    source_path = os.path.join(TEST_FILES_DIR, "test.docx")
+    malformed_path = tmp_path / "missing_style_type.docx"
+
+    with zipfile.ZipFile(source_path, mode="r") as zip_input:
+        with zipfile.ZipFile(malformed_path, mode="w") as zip_output:
+            for item in zip_input.infolist():
+                content = zip_input.read(item.filename)
+                if item.filename == "word/styles.xml":
+                    styles_xml = content.decode("utf-8")
+                    styles_xml = re.sub(
+                        r'<w:style\s+w:type="[^"]+"',
+                        "<w:style",
+                        styles_xml,
+                        count=1,
+                    )
+                    content = styles_xml.encode("utf-8")
+                zip_output.writestr(item, content)
+
+    result = MarkItDown().convert(str(malformed_path))
+
+    assert (
+        "AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation"
+        in result.markdown
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes a DOCX conversion crash when `word/styles.xml` contains a malformed `w:style` entry without the required `w:type` attribute.

Mammoth indexes `style_element.attributes["w:type"]`, so these malformed style records currently bubble up as:

```text
DocxConverter threw KeyError with message: 'w:type'
```

This patch extends DOCX preprocessing to remove only malformed style definitions missing `w:type` or `w:styleId`, allowing body text conversion to continue instead of failing the whole document.

Fixes #2166.

## Verification

```text
pytest packages/markitdown/tests/test_module_vectors.py::test_convert_docx_with_style_missing_type -q
# 1 passed

pytest 'packages/markitdown/tests/test_module_vectors.py::test_convert_local[test_vector0]' \
  'packages/markitdown/tests/test_module_vectors.py::test_convert_stream_with_hints[test_vector0]' \
  'packages/markitdown/tests/test_module_vectors.py::test_convert_stream_without_hints[test_vector0]' \
  'packages/markitdown/tests/test_module_vectors.py::test_convert_file_uri[test_vector0]' \
  'packages/markitdown/tests/test_module_vectors.py::test_convert_data_uri[test_vector0]' \
  packages/markitdown/tests/test_module_vectors.py::test_convert_docx_with_style_missing_type -q
# 6 passed

pre-commit run --files packages/markitdown/src/markitdown/converter_utils/docx/pre_process.py packages/markitdown/tests/test_module_vectors.py
# black Passed

python -m compileall -q packages/markitdown/src packages/markitdown/tests
# passed
```

I also ran `hatch test`; it reached `332 passed, 4 skipped` with one local environment failure unrelated to this change because `ffprobe` is not installed for `tests/test_module_misc.py::test_speech_transcription`.
