### PR TITLE
fix: prevent docx math converter crash on math run elements with no text child (#2188)

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -373,7 +373,8 @@ class oMath2Latex(Tag2Method):
         @todo \text (latex pure text support)
         """
         _str = []
-        for s in elm.findtext("./{0}t".format(OMML_NS)):
+        text_content = elm.findtext("./{0}t".format(OMML_NS))
+        for s in (text_content or ""):
             # s = s if isinstance(s,unicode) else unicode(s,'utf-8')
             _str.append(self._t_dict.get(s, s))
         return escape_latex(BLANK.join(_str))

--- a/packages/markitdown/tests/test_docx_math_no_text.py
+++ b/packages/markitdown/tests/test_docx_math_no_text.py
@@ -1,0 +1,43 @@
+import io
+import zipfile
+import pytest
+from markitdown import MarkItDown
+from markitdown.converter_utils.docx.math.omml import OMML_NS
+
+# Minimal Word Document XML structure with a math run having no text child
+# (an <m:r> with formatting tags but no <m:t>)
+# This simulates the math XML structure inside a DOCX document
+DOCUMENT_XML_CONTENT = f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+    <w:body>
+        <w:p>
+            <m:oMath>
+                <m:r>
+                    <m:rPr/>
+                </m:r>
+                <m:r>
+                    <m:t>x</m:t>
+                </m:r>
+            </m:oMath>
+        </w:p>
+    </w:body>
+</w:document>
+"""
+
+def test_math_run_no_text_child():
+    # Build a minimal docx in-memory
+    docx_buffer = io.BytesIO()
+    with zipfile.ZipFile(docx_buffer, "w") as z:
+        # docx needs word/document.xml to be valid
+        z.writestr("word/document.xml", DOCUMENT_XML_CONTENT)
+        # minimal content types
+        z.writestr("[Content_Types].xml", '<?xml version="1.0" encoding="UTF-8"?><Types><Default Extension="xml" ContentType="application/xml"/></Types>')
+        
+    docx_buffer.seek(0)
+    
+    # We should be able to convert this without a TypeError crash,
+    # and the valid math run ('x') should still be preserved/rendered.
+    markitdown = MarkItDown()
+    result = markitdown.convert_stream(docx_buffer, file_extension=".docx")
+    assert "$x$" in result.text_content


### PR DESCRIPTION
Fixes #2188.

In `do_r()` inside `omml.py`, iterating over `elm.findtext(./{0}t.format(OMML_NS))` can crash with `TypeError: 'NoneType' object is not iterable` if there is a math run element (`<m:r>`) with no text child (`<m:t>`). This PR fixes it by using a fallback default of an empty string (`elm.findtext(...) or ""`).

A regression test is included.