### PR TITLE
fix(docx): resolve math converter crash on empty runs in OMML to LaTeX

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -373,9 +373,11 @@ class oMath2Latex(Tag2Method):
         @todo \text (latex pure text support)
         """
         _str = []
-        for s in elm.findtext("./{0}t".format(OMML_NS)):
-            # s = s if isinstance(s,unicode) else unicode(s,'utf-8')
-            _str.append(self._t_dict.get(s, s))
+        text = elm.findtext("./{0}t".format(OMML_NS))
+        if text is not None:
+            for s in text:
+                # s = s if isinstance(s,unicode) else unicode(s,'utf-8')
+                _str.append(self._t_dict.get(s, s))
         return escape_latex(BLANK.join(_str))
 
     tag2meth = {

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -532,6 +532,28 @@ def test_markitdown_llm() -> None:
     validate_strings(result, PPTX_TEST_STRINGS)
 
 
+def test_docx_empty_math_run() -> None:
+    from xml.etree import ElementTree as ET
+    from markitdown.converter_utils.docx.math.omml import oMath2Latex
+    
+    # Create OMML XML string containing an empty run with no text child
+    omml_str = """
+    <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+        <m:r>
+            <m:rPr/>
+        </m:r>
+        <m:r>
+            <m:t>x</m:t>
+        </m:r>
+    </m:oMath>
+    """
+    
+    math_element = ET.fromstring(omml_str)
+    # This should not raise a TypeError: 'NoneType' object is not iterable
+    latex_converter = oMath2Latex(math_element)
+    assert latex_converter.latex == "x"
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     for test in [
@@ -547,6 +569,7 @@ if __name__ == "__main__":
         test_markitdown_exiftool,
         test_markitdown_llm_parameters,
         test_markitdown_llm,
+        test_docx_empty_math_run,
     ]:
         print(f"Running {test.__name__}...", end="")
         test()


### PR DESCRIPTION
## Summary

Resolves #2188.

### Root Cause
In `omml.py`, the `do_r` function retrieves text from a math run element via `elm.findtext("./{0}t".format(OMML_NS))`. If a math run (`<m:r>`) has formatting properties (`<m:rPr/>`) but no `<m:t>` text child (which some Word editors or copy-pasted equations produce), `findtext()` returns `None`. 
Attempting to iterate over `None` (`for s in None`) raises `TypeError: 'NoneType' object is not iterable`.

Because math preprocessing in `pre_process_docx()` runs on the entire `document.xml` file in a single try-except block, a single crash in `do_r` silently drops **all** equations in the document, falling back to original unconverted XML.

### Changes
- Guard against `None` return values in `do_r()` before iteration.
- Add a unit test (`test_docx_empty_math_run`) in `test_module_misc.py` using a mock XML structure to verify the fix works and prevents regressions.