### PR TITLE
docs: clarify built-in PDF conversion limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ MarkItDown currently supports the conversion from:
 - EPubs
 - ... and more!
 
+> [!NOTE]
+> The built-in PDF converter extracts text and attempts to preserve tables when they can be detected. Because PDF files encode visual layout rather than semantic structure, it may not infer headings, lists, or other Markdown structure, and the result may be mostly plain text. For layout-aware extraction, use [Azure Content Understanding](#azure-content-understanding) or [Azure Document Intelligence](#azure-document-intelligence).
+
 ## Why Markdown?
 
 Markdown is extremely close to plain text, with minimal markup or formatting, but still


### PR DESCRIPTION
## Summary

- clarify that the built-in PDF converter may produce mostly plain text when semantic structure cannot be inferred
- direct users who need layout-aware extraction to the existing Azure Content Understanding and Azure Document Intelligence options

## Testing

- `git diff --check`
- `pre-commit run --files README.md` (Black skipped because this is a documentation-only change)
- verified both README section links resolve to existing headings

Clarifies #2214.
