### PR TITLE
docs: add 'Use with AI Agents' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,17 @@ docker build -t markitdown:latest .
 docker run --rm -i markitdown:latest < ~/your-file.pdf > output.md
 ```
 
+### Use with AI Agents
+
+To use MarkItDown from AI applications and agents:
+
+- **MCP server** — [`packages/markitdown-mcp`](packages/markitdown-mcp) provides an official Model Context Protocol server exposing MarkItDown as a tool (e.g., for Claude Desktop).
+- **Agent Skills (community)** — for CLI-based coding agents (Claude Code and other agents supporting the [Agent Skills](https://agentskills.io) format), community-maintained skills teach the agent to invoke the `markitdown` CLI when reading documents:
+  - [coroboros/agent-skills](https://github.com/coroboros/agent-skills) (see [#1810](https://github.com/microsoft/markitdown/issues/1810))
+  - [raccioly/markitdown-skill](https://github.com/raccioly/markitdown-skill)
+
+Community tools are not maintained or endorsed by the MarkItDown team.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a


### PR DESCRIPTION
## Summary

Adds a short **Use with AI Agents** section to the README (right after Docker, before Contributing) that:

- Surfaces the official `packages/markitdown-mcp` MCP server, which currently isn't mentioned anywhere in the top-level README.
- Links community-maintained Agent Skills for CLI coding agents (Claude Code and other agents supporting the open Agent Skills format), as discussed in #1810.
- Includes an explicit disclaimer that community tools are not maintained or endorsed by the MarkItDown team.

## Motivation

MarkItDown's README explains it is built "for use with LLMs" — but a reader landing on the repo has no pointer for how to wire it into an AI agent, even though the repo itself ships an MCP server. This closes that gap in 11 lines with zero maintenance burden (community links carry a disclaimer, mirroring the existing `#markitdown-plugin` discovery pattern for plugins).

## Related

- #1810 (community agent skill announcement)

Docs-only change — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)