### PR TITLE
fix(ipynb): handle string and null cell sources in IpynbConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -54,6 +54,16 @@ class IpynbConverter(DocumentConverter):
         notebook_content = file_stream.read().decode(encoding=encoding)
         return self._convert(json.loads(notebook_content))
 
+    def _get_source_lines(self, source: Any) -> list[str]:
+        """Normalize cell source representations (str, list, None) into a list of line strings."""
+        if source is None:
+            return []
+        if isinstance(source, str):
+            return source.splitlines(keepends=True)
+        if isinstance(source, list):
+            return [str(line) for line in source]
+        return []
+
     def _convert(self, notebook_content: dict) -> DocumentConverterResult:
         """Helper function that converts notebook JSON content to Markdown."""
         try:
@@ -62,7 +72,7 @@ class IpynbConverter(DocumentConverter):
 
             for cell in notebook_content.get("cells", []):
                 cell_type = cell.get("cell_type", "")
-                source_lines = cell.get("source", [])
+                source_lines = self._get_source_lines(cell.get("source"))
 
                 if cell_type == "markdown":
                     md_output.append("".join(source_lines))
@@ -83,7 +93,8 @@ class IpynbConverter(DocumentConverter):
             md_text = "\n\n".join(md_output)
 
             # Check for title in notebook metadata
-            title = notebook_content.get("metadata", {}).get("title", title)
+            metadata = notebook_content.get("metadata") or {}
+            title = metadata.get("title", title)
 
             return DocumentConverterResult(
                 markdown=md_text,

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -587,6 +587,47 @@ def test_markitdown_llm() -> None:
     validate_strings(result, PPTX_TEST_STRINGS)
 
 
+def test_ipynb_converter_string_and_none_source() -> None:
+    """Test IpynbConverter when cell source is represented as string, list, or None."""
+    import json
+
+    markitdown = MarkItDown()
+    nb_content = json.dumps(
+        {
+            "nbformat": 4,
+            "nbformat_minor": 2,
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "source": "# String Title Heading\nThis cell source is a single string.",
+                },
+                {
+                    "cell_type": "code",
+                    "source": "x = 42\nprint(x)",
+                },
+                {
+                    "cell_type": "markdown",
+                    "source": None,
+                },
+                {
+                    "cell_type": "raw",
+                    "source": ["raw line 1\n", "raw line 2"],
+                },
+            ],
+            "metadata": None,
+        }
+    ).encode("utf-8")
+
+    result = markitdown.convert_stream(
+        io.BytesIO(nb_content), stream_info=StreamInfo(extension=".ipynb")
+    )
+    assert result.title == "String Title Heading"
+    assert "# String Title Heading" in result.markdown
+    assert "This cell source is a single string." in result.markdown
+    assert "```python\nx = 42\nprint(x)\n```" in result.markdown
+    assert "```\nraw line 1\nraw line 2\n```" in result.markdown
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     for test in [
@@ -602,6 +643,7 @@ if __name__ == "__main__":
         test_markitdown_exiftool,
         test_markitdown_llm_parameters,
         test_markitdown_llm,
+        test_ipynb_converter_string_and_none_source,
     ]:
         print(f"Running {test.__name__}...", end="")
         test()


### PR DESCRIPTION
## Summary

- Normalizes Jupyter notebook cell `source` field representations (`str`, `list[str]`, `None`, or missing) in `IpynbConverter`.
- Enables correct line-by-line title extraction when a notebook cell source is a single string.
- Prevents `TypeError` and conversion failure when cell sources are `None` or missing.

## Problem

According to the Jupyter notebook specification (nbformat v4), cell `source` fields may be represented either as a list of strings or as a single string (or `None`).
When `source` is a string (e.g., `"# Title\nSome markdown"`), `IpynbConverter._convert()` previously iterated over `source_lines` character-by-character (`'#'`, `' '`, ...). As a result, heading detection (`line.startswith("# ")`) never matched, failing to extract the document title.
Additionally, if a cell `source` is `None` or missing, `"".join(None)` raised a `TypeError` wrapped in a `FileConversionException`, causing `MarkItDown` to crash or fall back to raw plain text output.
Furthermore, if `metadata` in the notebook JSON is `null`, `notebook_content.get("metadata", {}).get("title", title)` raised an `AttributeError`.

## Root cause

`IpynbConverter._convert()` assumed `cell.get("source", [])` is always a list of line strings, without normalizing string or `None` values.

## Fix

- Added `_get_source_lines(source: Any) -> list[str]` helper method to normalize cell sources (`str`, `list`, `None`) into a list of line strings with preserved line endings.
- Used `_get_source_lines()` across all cell types (`markdown`, `code`, `raw`).
- Updated metadata dict access to safely handle `metadata: null`.
- Added unit test `test_ipynb_converter_string_and_none_source` covering string, list, and `None` cell sources.

## Testing

- `pytest packages/markitdown/tests/test_module_misc.py -k test_ipynb_converter_string_and_none_source` — PASS
- `pytest packages/markitdown/tests/test_module_vectors.py` — PASS (109 passed)
- `git diff --check` — PASS (clean, no trailing whitespace)

## Compatibility

100% backward compatible. All existing tests pass.
