### PR TITLE
fix(pdf): pad table rows to prevent silent cell truncation in PDF tables

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -95,6 +95,10 @@ def _to_markdown_table(table: list[list[str]], include_separator: bool = True) -
     if not table:
         return ""
 
+    # Pad rows to the maximum row length so zip(*table) and fmt_row process all columns
+    max_cols = max(len(row) for row in table)
+    table = [row + [""] * (max_cols - len(row)) for row in table]
+
     # Column widths
     col_widths = [max(len(str(cell)) for cell in col) for col in zip(*table)]
 

--- a/packages/markitdown/tests/test_pdf_tables.py
+++ b/packages/markitdown/tests/test_pdf_tables.py
@@ -1196,3 +1196,20 @@ class TestPdfTableStructureConsistency:
         table_text = str(second_table)
         assert "Electronics" in table_text, "Second table should contain Electronics"
         assert "Hardware" in table_text, "Second table should contain Hardware"
+
+
+def test_pdf_to_markdown_table_unequal_columns() -> None:
+    """Test that _to_markdown_table does not truncate cells when rows have unequal column counts."""
+    from markitdown.converters._pdf_converter import _to_markdown_table
+
+    # Header has 2 columns, second row has 3 columns
+    table_1 = [["Header1", "Header2"], ["Val1", "Val2", "Val3"]]
+    result_1 = _to_markdown_table(table_1)
+    assert "Val3" in result_1, "Cell data 'Val3' from longer data row was truncated"
+
+    # Header has 3 columns, second row has 2 columns
+    table_2 = [["Header1", "Header2", "Header3"], ["Val1", "Val2"]]
+    result_2 = _to_markdown_table(table_2)
+    assert (
+        "Header3" in result_2
+    ), "Header cell 'Header3' from longer header row was truncated"


### PR DESCRIPTION
## Summary

- Pads rows in `_to_markdown_table` to match the maximum row length in PDF table extraction.
- Prevents cell data loss when tables contain rows with unequal column counts.

## Problem

When converting PDF tables to Markdown tables using `_to_markdown_table`, column widths and row formatting were calculated using `zip(*table)`. Because Python's built-in `zip()` truncates iteration at the length of the shortest row in the sequence, any table row containing more columns than the shortest row would have its extra cells silently dropped and discarded from the resulting Markdown table output.

## Root cause

`_to_markdown_table` computed `col_widths = [max(...) for col in zip(*table)]` directly on raw input rows without ensuring all rows had uniform length. When `zip(*table)` ran on a 2D list with unequal row lengths, it stopped at the shortest row, reducing `col_widths` to that shorter column count. Subsequent calls to `zip(row, col_widths)` inside `fmt_row` then truncated all cells beyond that index.

## Fix

Pad every row in `table` with empty strings up to `max_cols = max(len(row) for row in table)` prior to calculating `col_widths` and building table lines. This ensures all columns across all rows are preserved in the Markdown table layout.

## Testing

- `pytest tests/test_pdf_tables.py` — PASSED (23/23 tests pass, including new regression test)
- `black --check src/markitdown/converters/_pdf_converter.py tests/test_pdf_tables.py` — PASSED
- `git diff --check` — PASSED (no whitespace or formatting issues)

## Compatibility

- Fully backward-compatible. No breaking changes or new external dependencies introduced.