### PR TITLE
docs: Use double quotes for pip extras so install commands work in `cmd.exe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ conda activate markitdown
 
 ## Installation
 
-To install MarkItDown, use pip: `pip install 'markitdown[all]'`. Alternatively, you can install it from the source:
+To install MarkItDown, use pip: `pip install "markitdown[all]"`. Alternatively, you can install it from the source:
 
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e 'packages/markitdown[all]'
+pip install -e "packages/markitdown[all]"
 ```
 
 ## Usage
@@ -92,7 +92,7 @@ cat path-to-file.pdf | markitdown
 MarkItDown has optional dependencies for activating various file formats. Earlier in this document, we installed all optional dependencies with the `[all]` option. However, you can also install them individually for more control. For example:
 
 ```bash
-pip install 'markitdown[pdf, docx, pptx]'
+pip install "markitdown[pdf, docx, pptx]"
 ```
 
 will install only the dependencies for PDF, DOCX, and PPTX files.
@@ -163,7 +163,7 @@ See [`packages/markitdown-ocr/README.md`](packages/markitdown-ocr/README.md) for
 
 [Azure Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/) provides higher-quality conversion with structured field extraction (YAML front matter), multi-modal support (documents, images, audio, video), and configurable analyzers.
 
-Install: `pip install 'markitdown[az-content-understanding]'`
+Install: `pip install "markitdown[az-content-understanding]"`
 
 #### When to use Content Understanding
 

--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -13,7 +13,7 @@
 From PyPI:
 
 ```bash
-pip install 'markitdown[all]'
+pip install "markitdown[all]"
 ```
 
 From source:
@@ -21,7 +21,7 @@ From source:
 ```bash
 git clone git@github.com:microsoft/markitdown.git
 cd markitdown
-pip install -e 'packages/markitdown[all]'
+pip install -e "packages/markitdown[all]"
 ```
 
 ## Usage


### PR DESCRIPTION
Closes #2232

## Problem

The install commands in the READMEs single-quote the extras, e.g.
`pip install -e 'packages/markitdown[all]'`. `cmd.exe` does not strip single quotes, so pip receives
them as part of the path and rejects it:

```
ERROR: 'packages/markitdown[all]' is not a valid editable requirement. It should either be
a path to a local project or a VCS URL (beginning with bzr+http, ...).
```

## Change

Switched the six `pip install` snippets in `README.md` and `packages/markitdown/README.md`
from single to double quotes.

Double quotes rather than dropping the quotes entirely, because the quoting is still needed on
POSIX shells - `[all]` is a character-class glob pattern in bash/zsh, so an unquoted
`markitdown[all]` can be word-expanded if a matching path happens to exist. Double quotes are
the one form that works in `cmd.exe`, PowerShell, bash and zsh alike.

## Verification

Windows 11, Python 3.12, pip 26.1.2. Using `--dry-run --no-deps` so nothing is actually
installed:

| command | cmd.exe | PowerShell |
| --- | --- | --- |
| `pip install -e 'packages/markitdown[all]'` (before) | **ERROR: not a valid editable requirement** | ok |
| `pip install -e "packages/markitdown[all]"` (after) | ok | ok |

Note that this only reproduces under `cmd.exe`. PowerShell strips single quotes itself, which
is probably why it has gone unnoticed.

After the change:

- No single-quoted extras remain in any markdown file in the repo.
- All six updated snippets resolve correctly; `invalid editable requirement` errors: 0.
- No CI workflow or shell script referenced the quoted form, so nothing else needed updating.

The reporter suggested removing the quotes; double-quoting keeps the POSIX side safe as well,
but happy to switch to unquoted if you prefer that for consistency with other docs.