### PR TITLE
fix(epub): safely extract metadata text without crashing on None nodeValue or nested elements

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_epub_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_epub_converter.py
@@ -151,7 +151,8 @@ class EpubConverter(HtmlConverter):
     def _collect_node_text(self, node: Any, text_parts: List[str]) -> None:
         """Recursively collect text node values from a DOM node."""
         for child in node.childNodes:
-            if child.nodeValue:
-                text_parts.append(child.nodeValue)
+            if child.nodeType in (child.TEXT_NODE, child.CDATA_SECTION_NODE):
+                if child.nodeValue:
+                    text_parts.append(child.nodeValue)
             elif child.hasChildNodes():
                 self._collect_node_text(child, text_parts)

--- a/packages/markitdown/src/markitdown/converters/_epub_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_epub_converter.py
@@ -141,6 +141,17 @@ class EpubConverter(HtmlConverter):
         """Helper function to extract all occurrences of a tag (e.g., multiple authors)."""
         texts: List[str] = []
         for node in dom.getElementsByTagName(tag_name):
-            if node.firstChild and hasattr(node.firstChild, "nodeValue"):
-                texts.append(node.firstChild.nodeValue.strip())
+            text_parts: List[str] = []
+            self._collect_node_text(node, text_parts)
+            text_val = "".join(text_parts).strip()
+            if text_val:
+                texts.append(text_val)
         return texts
+
+    def _collect_node_text(self, node: Any, text_parts: List[str]) -> None:
+        """Recursively collect text node values from a DOM node."""
+        for child in node.childNodes:
+            if child.nodeValue:
+                text_parts.append(child.nodeValue)
+            elif child.hasChildNodes():
+                self._collect_node_text(child, text_parts)

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -587,6 +587,36 @@ def test_markitdown_llm() -> None:
     validate_strings(result, PPTX_TEST_STRINGS)
 
 
+def test_epub_metadata_nodevalue():
+    from defusedxml.minidom import parseString
+    from markitdown.converters._epub_converter import EpubConverter
+
+    xml_data = (
+        '<package xmlns:dc="http://purl.org/dc/elements/1.1/">'
+        "<dc:title><span>Structured</span> Title</dc:title>"
+        "<dc:creator><name>Author 1</name></dc:creator>"
+        "<dc:creator>Author 2</dc:creator>"
+        "<dc:publisher></dc:publisher>"
+        "<dc:description/>"
+        "</package>"
+    )
+    dom = parseString(xml_data)
+    converter = EpubConverter()
+
+    title = converter._get_text_from_node(dom, "dc:title")
+    assert title == "Structured Title"
+
+    creators = converter._get_all_texts_from_nodes(dom, "dc:creator")
+    assert creators == ["Author 1", "Author 2"]
+
+    publisher = converter._get_text_from_node(dom, "dc:publisher")
+    assert publisher is None
+
+    missing = converter._get_text_from_node(dom, "dc:date")
+    assert missing is None
+
+
+
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
     for test in [
@@ -602,6 +632,7 @@ if __name__ == "__main__":
         test_markitdown_exiftool,
         test_markitdown_llm_parameters,
         test_markitdown_llm,
+        test_epub_metadata_nodevalue,
     ]:
         print(f"Running {test.__name__}...", end="")
         test()


### PR DESCRIPTION
## Summary

- Fixes `EpubConverter` metadata extraction crash (`AttributeError: 'NoneType' object has no attribute 'strip'`) when Dublin Core metadata elements in EPUB `content.opf` contain nested XML/HTML tags or produce a `None` `nodeValue`.
- Recursively collects text node values across child nodes instead of assuming `node.firstChild.nodeValue` is a non-None string.

## Problem

In `xml.dom.minidom`, all `Node` objects (including `Element` nodes) define a `nodeValue` property whose value is `None` for element nodes. `EpubConverter._get_all_texts_from_nodes` checked `hasattr(node.firstChild, "nodeValue")`, which always evaluates to `True` for element children (e.g. `<dc:title><span>Structured</span> Title</dc:title>`). Attempting to call `.strip()` on `None` raised `AttributeError` and caused the entire `EpubConverter.convert()` process to fail.

## Root cause

Line 144 of `_epub_converter.py` assumed `node.firstChild.nodeValue` was a string if `hasattr(node.firstChild, "nodeValue")` returned true. When `node.firstChild` is an `Element`, `nodeValue` is `None`, raising `AttributeError: 'NoneType' object has no attribute 'strip'`.

## Fix

Added `_collect_node_text` to recursively collect text content across text and CDATA child nodes under any metadata element, stripping whitespace and filtering out empty metadata entries.

## Testing

- `pytest -k test_epub_metadata_nodevalue` — PASS (1 passed)
- `ruff check src/markitdown/converters/_epub_converter.py tests/test_module_misc.py` — PASS (0 errors)
- `mypy src/markitdown/converters/_epub_converter.py --ignore-missing-imports` — PASS (Success)
- `git diff --check` — PASS

## Compatibility

100% backward compatible. Preserves valid text extraction for simple string metadata while preventing crashes on formatted or nested metadata elements in EPUB documents.