### PR TITLE
fix(docx): guard None returned by findtext in OMML do_r method

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -373,7 +373,7 @@ class oMath2Latex(Tag2Method):
         @todo \text (latex pure text support)
         """
         _str = []
-        for s in elm.findtext("./{0}t".format(OMML_NS)):
+        for s in (elm.findtext("./{0}t".format(OMML_NS)) or ""):
             # s = s if isinstance(s,unicode) else unicode(s,'utf-8')
             _str.append(self._t_dict.get(s, s))
         return escape_latex(BLANK.join(_str))


### PR DESCRIPTION
## Description
This PR resolves issue #2188 by guarding `elm.findtext(./{0}t.format(OMML_NS)) or ""` in `do_r()` (`packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py`).

## Details
- Prevents `TypeError: 'NoneType' object is not iterable` when an `<m:r>` math run has no `<m:t>` text child, preventing the entire document equation conversion pass from failing silently.