### PR TITLE
fix(uri): unquote percent-encoded file URI paths in file_uri_to_path

### DIFF
--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -2,7 +2,7 @@ import base64
 import os
 from typing import Tuple, Dict
 from urllib.request import url2pathname
-from urllib.parse import urlparse, unquote_to_bytes
+from urllib.parse import urlparse, unquote_to_bytes, unquote
 
 
 def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
@@ -12,7 +12,8 @@ def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
         raise ValueError(f"Not a file URL: {file_uri}")
 
     netloc = parsed.netloc if parsed.netloc else None
-    path = os.path.abspath(url2pathname(parsed.path))
+    raw_path = unquote(parsed.path) if "%" in parsed.path else parsed.path
+    path = os.path.abspath(url2pathname(raw_path))
     return netloc, path
 
 


### PR DESCRIPTION
## Description
This PR resolves issue #2208 by unquoting percent-encoded path components in `file_uri_to_path()` (`packages/markitdown/src/markitdown/_uri_utils.py`) before passing them to `url2pathname()` and `os.path.abspath()`.

## Details
- Fixes Windows file URIs with percent-encoded drive colons (e.g. `C%3A`) producing duplicated drive prefixes.