### PR TITLE
fix(docx): handle non-OMML XML namespaces in process_children_list

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -88,9 +88,10 @@ class Tag2Method(object):
         process children of the elm,return iterable
         """
         for _e in list(elm):
-            if OMML_NS not in _e.tag:
-                continue
-            stag = _e.tag.replace(OMML_NS, "")
+            if OMML_NS in _e.tag:
+                stag = _e.tag.replace(OMML_NS, "")
+            else:
+                stag = _e.tag.split("}")[-1] if "}" in _e.tag else _e.tag
             if include and (stag not in include):
                 continue
             t = self.call_method(_e, stag=stag)


### PR DESCRIPTION
## Description
This PR resolves issue #2166 by stripping arbitrary XML namespaces in `process_children_list()` (`packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py`).

## Details
- Prevents `KeyError: 'w:type'` when elements carry WordprocessingML or custom XML namespaces during OMML conversion.