### PR TITLE
fix(html): preserve non-UTF-8 percent-encoded URL paths in HTML link conversion

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -60,7 +60,11 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
                 parsed_url = urlparse(href)  # type: ignore
                 if parsed_url.scheme and parsed_url.scheme.lower() not in ["http", "https", "file"]:  # type: ignore
                     return "%s%s%s" % (prefix, text, suffix)
-                href = urlunparse(parsed_url._replace(path=quote(unquote(parsed_url.path))))  # type: ignore
+                try:
+                    new_path = quote(unquote(parsed_url.path, errors="strict"))
+                except UnicodeDecodeError:
+                    new_path = parsed_url.path
+                href = urlunparse(parsed_url._replace(path=new_path))  # type: ignore
             except ValueError:  # It's not clear if this ever gets thrown
                 return "%s%s%s" % (prefix, text, suffix)
 


### PR DESCRIPTION
## Description
This PR resolves issue #2171 by catching `UnicodeDecodeError` during `unquote(parsed_url.path, errors="strict")` in `_markdownify.py`.

## Details
- Preserves original percent-encoded octets (e.g. EUC-JP / Shift-JIS URLs) instead of introducing UTF-8 replacement characters (`%EF%BF%BD`).