### PR TITLE
docs: use canonical markdown result property

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ md = MarkItDown(
     llm_model="gpt-4o",
 )
 result = md.convert("document_with_images.pdf")
-print(result.text_content)
+print(result.markdown)
 ```
 
 If no `llm_client` is provided the plugin still loads, but OCR is silently skipped and the standard built-in converter is used instead.
@@ -255,7 +255,7 @@ from markitdown import MarkItDown
 
 md = MarkItDown(enable_plugins=False) # Set to True to enable plugins
 result = md.convert("test.xlsx")
-print(result.text_content)
+print(result.markdown)
 ```
 
 Document Intelligence conversion in Python:
@@ -265,7 +265,7 @@ from markitdown import MarkItDown
 
 md = MarkItDown(docintel_endpoint="<document_intelligence_endpoint>")
 result = md.convert("test.pdf")
-print(result.text_content)
+print(result.markdown)
 ```
 
 To use Large Language Models for image descriptions (currently only for pptx and image files), provide `llm_client` and `llm_model`:
@@ -277,7 +277,7 @@ from openai import OpenAI
 client = OpenAI()
 md = MarkItDown(llm_client=client, llm_model="gpt-4o", llm_prompt="optional custom prompt")
 result = md.convert("example.jpg")
-print(result.text_content)
+print(result.markdown)
 ```
 
 ### Docker

--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -39,7 +39,7 @@ from markitdown import MarkItDown
 
 md = MarkItDown()
 result = md.convert("test.xlsx")
-print(result.text_content)
+print(result.markdown)
 ```
 
 ### More Information


### PR DESCRIPTION
## Summary
- update README Python snippets to print `result.markdown` instead of the soft-deprecated `result.text_content` alias
- keep the PyPI package README example aligned with the top-level README and current `DocumentConverterResult` API

## Verification
- `rg "result\.text_content|text_content" README.md packages/markitdown/README.md; test 0 -eq 1`
- `rg "result\.markdown" README.md packages/markitdown/README.md -n`

Note: a local import smoke test with `python3` was blocked because this environment does not have the package dependency `magika` installed.