### PR TITLE
fix: omit description heading for custom image prompts

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_image_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_image_converter.py
@@ -68,17 +68,21 @@ class ImageConverter(DocumentConverter):
         # Try describing the image with GPT
         llm_client = kwargs.get("llm_client")
         llm_model = kwargs.get("llm_model")
+        llm_prompt = kwargs.get("llm_prompt")
         if llm_client is not None and llm_model is not None:
             llm_description = self._get_llm_description(
                 file_stream,
                 stream_info,
                 client=llm_client,
                 model=llm_model,
-                prompt=kwargs.get("llm_prompt"),
+                prompt=llm_prompt,
             )
 
             if llm_description is not None:
-                md_content += "\n# Description:\n" + llm_description.strip() + "\n"
+                md_content += "\n"
+                if llm_prompt is None or llm_prompt.strip() == "":
+                    md_content += "# Description:\n"
+                md_content += llm_description.strip() + "\n"
 
         return DocumentConverterResult(
             markdown=md_content,

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -561,6 +561,42 @@ def test_markitdown_llm_parameters() -> None:
     assert messages[0]["content"][0]["text"] == test_prompt
 
 
+@pytest.mark.parametrize(
+    ("llm_prompt", "has_default_heading"),
+    [
+        (None, True),
+        ("", True),
+        ("   ", True),
+        ("Beschreibe das Bild auf Deutsch ohne Titel.", False),
+    ],
+)
+def test_markitdown_llm_prompt_controls_default_heading(
+    llm_prompt: str | None, has_default_heading: bool
+) -> None:
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    custom_caption = "Ein roter Kreis und ein blaues Quadrat."
+    mock_response.choices = [MagicMock(message=MagicMock(content=custom_caption))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    result = MarkItDown(
+        llm_client=mock_client,
+        llm_model="gpt-4o",
+        llm_prompt=llm_prompt,
+    ).convert(os.path.join(TEST_FILES_DIR, "test_llm.jpg"))
+
+    assert custom_caption in result.markdown
+    assert ("# Description:" in result.markdown) is has_default_heading
+
+    sent_prompt = mock_client.chat.completions.create.call_args.kwargs["messages"][0][
+        "content"
+    ][0]["text"]
+    if llm_prompt is None or llm_prompt.strip() == "":
+        assert sent_prompt == "Write a detailed caption for this image."
+    else:
+        assert sent_prompt == llm_prompt
+
+
 @pytest.mark.skipif(
     skip_llm,
     reason="do not run llm tests without a key",


### PR DESCRIPTION
## Summary

- Respect non-empty custom image prompts by omitting MarkItDown's hardcoded English `# Description:` heading.
- Preserve the existing heading and default caption prompt when `llm_prompt` is `None`, empty, or whitespace-only.

## Reproduction / root cause

`ImageConverter` correctly passed `llm_prompt` to the LLM client, but then unconditionally prepended `# Description:` to the returned caption. As a result, callers requesting localized or heading-free output still received an English heading.

The regression test uses the repository's existing `test_llm.jpg` and a `MagicMock` client, so it exercises the public `MarkItDown.convert()` path without credentials or network access.

## Changes

- Reuse the resolved `llm_prompt` when generating the image description.
- Add the default heading only when the converter is also using its default prompt semantics.
- Cover `None`, empty, whitespace-only, and non-empty custom prompts with a parameterized regression test.

## Tests

- `hatch test tests/test_module_misc.py -k 'test_markitdown_llm_prompt_controls_default_heading or test_markitdown_llm_parameters' -vv`: **passed** (`5 passed, 14 deselected`).
- Offline `MarkItDown.convert()` probe with `test_llm.jpg` and a mocked client: **passed**; custom output was `\nBeschreibung auf Deutsch.\n`, while default output remained `\n# Description:\nDefault caption.\n`.
- `$testEnv = hatch env find hatch-test.py3.13; $env:PYTHONPATH = (Resolve-Path 'src').Path + ';' + (Join-Path $testEnv 'Lib\site-packages'); $env:GITHUB_ACTIONS = 'true'; $env:PYTHONUTF8 = '1'; hatch test`: `309 passed, 34 skipped, 1 failed`. The remaining failure is the existing Windows-only `test_file_uris` POSIX-path assertion (`/path/to/file.txt` vs `D:\path\to\file.txt`); this PR does not modify URI handling.
- `pre-commit run --all-files`: **passed**.

## Security / compatibility considerations

- No file, URI, network-target, archive, or resource-limit validation is changed.
- No dependencies are added.
- Existing output is preserved for default, empty, and whitespace-only prompts; only non-empty custom prompts stop receiving the library-injected English heading.
- No real LLM request or external credential is used by the regression test.

Fixes #315
