### PR TITLE
fix(pptx): preserve data points for scatter and bubble charts

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -19,6 +19,7 @@ from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 _dependency_exc_info = None
 try:
     import pptx
+    from pptx.enum.chart import XL_CHART_TYPE
 except ImportError:
     # Preserve the error and stack trace for later
     _dependency_exc_info = sys.exc_info()
@@ -29,6 +30,53 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ]
 
 ACCEPTED_FILE_EXTENSIONS = [".pptx"]
+
+# Chart types drawn on an X/Y (value) axis instead of a category axis. They
+# have no ``chart.plots[0].categories``, so their series data must be read
+# point-by-point rather than row-by-row over categories.
+XY_CHART_TYPES = ()
+BUBBLE_CHART_TYPES = ()
+if _dependency_exc_info is None:
+    XY_CHART_TYPES = (
+        XL_CHART_TYPE.XY_SCATTER,
+        XL_CHART_TYPE.XY_SCATTER_LINES,
+        XL_CHART_TYPE.XY_SCATTER_LINES_NO_MARKERS,
+        XL_CHART_TYPE.XY_SCATTER_SMOOTH,
+        XL_CHART_TYPE.XY_SCATTER_SMOOTH_NO_MARKERS,
+        XL_CHART_TYPE.BUBBLE,
+        XL_CHART_TYPE.BUBBLE_THREE_D_EFFECT,
+    )
+    BUBBLE_CHART_TYPES = (XL_CHART_TYPE.BUBBLE, XL_CHART_TYPE.BUBBLE_THREE_D_EFFECT)
+
+
+def _chart_to_markdown_table(data):
+    """Render a list of rows (first row is the header) as a Markdown table."""
+    if not data:
+        return ""
+    rows = ["| " + " | ".join(map(str, row)) + " |" for row in data]
+    header = rows[0]
+    separator = "|" + "|".join(["---"] * len(data[0])) + "|"
+    return "\n".join([header, separator] + rows[1:])
+
+
+def _xy_point_x(series, idx):
+    """X value of point *idx* in an XY (scatter) series.
+
+    python-pptx only exposes the Y values publicly (``series.values``); the X
+    values live on the internal ``c:xVal`` element, so we read them directly.
+    """
+    x_val = series._element.xVal
+    if x_val is None or idx >= x_val.ptCount_val:
+        return None
+    return x_val.pt_v(idx)
+
+
+def _xy_point_size(series, idx):
+    """Bubble size of point *idx* in a bubble series."""
+    size = series._element.bubbleSize
+    if size is None or idx >= size.ptCount_val:
+        return None
+    return size.pt_v(idx)
 
 
 class PptxConverter(DocumentConverter):
@@ -305,29 +353,46 @@ class PptxConverter(DocumentConverter):
             if chart.has_title:
                 md += f": {chart.chart_title.text_frame.text}"
             md += "\n\n"
-            data = []
-            category_names = [c.label for c in chart.plots[0].categories]
+
             series_list = list(chart.series)
             series_names = [s.name for s in series_list]
-            data.append(["Category"] + series_names)
-
-            # Materialize each series' values once. Accessing series.values[idx]
+            # Materialize each series' Y values once. Accessing series.values[idx]
             # inside the nested loop is O(n^2) in python-pptx (each lookup does an
             # XPath scan of all points), which is extremely slow on large charts.
             series_values = [list(s.values) for s in series_list]
 
+            # Scatter and bubble charts have no category axis: each data point
+            # carries its own X coordinate, so chart.plots[0].categories is empty.
+            # Iterating over categories (as category charts do) would emit zero
+            # data rows and silently drop the entire series.
+            if chart.chart_type in XY_CHART_TYPES:
+                is_bubble = chart.chart_type in BUBBLE_CHART_TYPES
+                header = ["X"]
+                for name in series_names:
+                    header.append(name)
+                    if is_bubble:
+                        header.append(f"{name} (size)")
+                data = [header]
+                num_points = max((len(sv) for sv in series_values), default=0)
+                for idx in range(num_points):
+                    # X is taken from the first series; scatter charts commonly
+                    # share the X axis across series.
+                    row = [_xy_point_x(series_list[0], idx)]
+                    for series, sv in zip(series_list, series_values):
+                        row.append(sv[idx] if idx < len(sv) else None)
+                        if is_bubble:
+                            row.append(_xy_point_size(series, idx))
+                    data.append(row)
+                return md + _chart_to_markdown_table(data)
+
+            category_names = [c.label for c in chart.plots[0].categories]
+            data = [["Category"] + series_names]
             for idx, category in enumerate(category_names):
                 row = [category]
                 for sv in series_values:
                     row.append(sv[idx] if idx < len(sv) else None)
                 data.append(row)
-
-            markdown_table = []
-            for row in data:
-                markdown_table.append("| " + " | ".join(map(str, row)) + " |")
-            header = markdown_table[0]
-            separator = "|" + "|".join(["---"] * len(data[0])) + "|"
-            return md + "\n".join([header, separator] + markdown_table[1:])
+            return md + _chart_to_markdown_table(data)
         except ValueError as e:
             # Handle the specific error for unsupported chart types
             if "unsupported plot type" in str(e):

--- a/packages/markitdown/tests/test_pptx_chart.py
+++ b/packages/markitdown/tests/test_pptx_chart.py
@@ -1,0 +1,78 @@
+"""Tests for PPTX chart conversion.
+
+Scatter and bubble charts have no category axis, so their data must be read
+point-by-point. Previously ``_convert_chart_to_markdown`` iterated over
+``chart.plots[0].categories`` (empty for these chart types) and silently
+dropped the entire series. These tests assert the data points are preserved.
+"""
+import io
+
+from pptx import Presentation
+from pptx.util import Inches
+from pptx.chart.data import XyChartData, BubbleChartData
+from pptx.enum.chart import XL_CHART_TYPE
+
+from markitdown import MarkItDown
+
+
+def _build_xy_pptx(bubble):
+    """Build an in-memory PPTX containing a single scatter or bubble chart."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    if bubble:
+        chart_data = BubbleChartData()
+        series = chart_data.add_series("Series 1")
+        series.add_data_point(1.0, 2.0, 10)
+        series.add_data_point(2.0, 3.0, 20)
+        series.add_data_point(3.0, 4.0, 30)
+        chart_type = XL_CHART_TYPE.BUBBLE
+    else:
+        chart_data = XyChartData()
+        series = chart_data.add_series("Series 1")
+        series.add_data_point(1.0, 2.0)
+        series.add_data_point(2.0, 3.0)
+        series.add_data_point(3.0, 4.0)
+        series2 = chart_data.add_series("Series 2")
+        series2.add_data_point(1.0, 5.0)
+        series2.add_data_point(2.0, 6.0)
+        series2.add_data_point(3.0, 7.0)
+        chart_type = XL_CHART_TYPE.XY_SCATTER
+    slide.shapes.add_chart(
+        chart_type, Inches(1), Inches(1), Inches(5), Inches(4), chart_data
+    )
+    buf = io.BytesIO()
+    prs.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_scatter_chart_preserves_data_points() -> None:
+    # Regression: scatter series used to be dropped entirely (only the header
+    # was emitted) because the chart has no category axis.
+    md = (
+        MarkItDown()
+        .convert_stream(_build_xy_pptx(bubble=False), file_extension=".pptx")
+        .markdown
+    )
+    assert "| X | Series 1 | Series 2 |" in md
+    assert "| 1.0 | 2.0 | 5.0 |" in md
+    assert "| 3.0 | 4.0 | 7.0 |" in md
+
+
+def test_bubble_chart_preserves_data_points_and_sizes() -> None:
+    # Bubble charts additionally carry a per-point size, which must appear in a
+    # dedicated "(size)" column.
+    md = (
+        MarkItDown()
+        .convert_stream(_build_xy_pptx(bubble=True), file_extension=".pptx")
+        .markdown
+    )
+    assert "| X | Series 1 | Series 1 (size) |" in md
+    assert "| 1.0 | 2.0 | 10.0 |" in md
+    assert "| 3.0 | 4.0 | 30.0 |" in md
+
+
+if __name__ == "__main__":
+    test_scatter_chart_preserves_data_points()
+    test_bubble_chart_preserves_data_points_and_sizes()
+    print("All chart tests passed!")


### PR DESCRIPTION
## Summary

`markitdown` silently dropped **all** data when converting PPTX **scatter** and **bubble** charts to Markdown.

## Root cause

`_convert_chart_to_markdown` builds the Markdown table by iterating over `chart.plots[0].categories`. Scatter/bubble charts have **no category axis**, so `categories` is empty and the row loop ran zero times — only the header was emitted and every data point was lost.

## Fix

Detect XY/bubble chart types via `XL_CHART_TYPE` and render rows point-by-point instead of row-by-category:
- The first column is the point's **X** value, read from the internal `c:xVal` element (python-pptx only exposes the Y values publicly via `series.values`).
- For bubble charts, an additional `"(size)"` column per series shows the bubble size.

Category charts (column, bar, line, pie, doughnut, radar, area, …) keep their original behavior unchanged. The O(n^2)→O(n) materialization of `series.values` is preserved.

## Testing

Added `packages/markitdown/tests/test_pptx_chart.py`, which builds in-memory scatter and bubble charts and asserts the data points (and bubble sizes) appear in the converted Markdown. Both new tests pass and the existing `test_pptx_svg.py` still passes. Verified locally with `pytest` and `black`.

Fixes the data-loss behavior when converting real-world scatter/bubble charts.