### PR TITLE
Render fragment-only hyperlinks as plain text instead of dead links

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -60,6 +60,11 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
                 parsed_url = urlparse(href)  # type: ignore
                 if parsed_url.scheme and parsed_url.scheme.lower() not in ["http", "https", "file"]:  # type: ignore
                     return "%s%s%s" % (prefix, text, suffix)
+                # Fragment-only hrefs (e.g. Word bookmark links like "#_Toc12345")
+                # never resolve to anything in the Markdown output, since heading
+                # ids are not preserved. Emit the link text instead of a dead link.
+                if parsed_url.fragment and not (parsed_url.scheme or parsed_url.netloc or parsed_url.path):  # type: ignore
+                    return "%s%s%s" % (prefix, text, suffix)
                 href = urlunparse(parsed_url._replace(path=quote(unquote(parsed_url.path))))  # type: ignore
             except ValueError:  # It's not clear if this ever gets thrown
                 return "%s%s%s" % (prefix, text, suffix)

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -393,6 +393,31 @@ def test_deeply_nested_html_fallback() -> None:
     assert "<p>" not in result.markdown
 
 
+def test_fragment_only_links_render_as_plain_text() -> None:
+    """Fragment-only hrefs (e.g. Word TOC/cross-reference bookmarks such as
+    "#_Toc12345") never resolve in the Markdown output, since heading ids are
+    not preserved. They should render as plain text, not dead links (issue #2125).
+    """
+    markitdown = MarkItDown()
+
+    html = (
+        "<html><body>"
+        '<a href="#_Toc12345">Executive Summary</a>'
+        '<a href="https://example.com">External Link</a>'
+        '<a href="page.html#section">Same-Page Fragment</a>'
+        "</body></html>"
+    )
+
+    result = markitdown.convert_stream(
+        io.BytesIO(html.encode("utf-8")), file_extension=".html"
+    )
+
+    assert "[Executive Summary](#_Toc12345)" not in result.markdown
+    assert "Executive Summary" in result.markdown
+    assert "[External Link](https://example.com)" in result.markdown
+    assert "[Same-Page Fragment](page.html#section)" in result.markdown
+
+
 def test_doc_rlink() -> None:
     # Test for: CVE-2025-11849
     markitdown = MarkItDown()


### PR DESCRIPTION
Internal DOCX hyperlinks such as TOC entries and cross-references are converted to Word bookmark anchors like `[Executive Summary](#_Toc12345)`. These anchors never resolve in the Markdown output: nothing in the conversion pipeline preserves heading `id`s (see `_CustomMarkdownify.convert_hn`), so a fragment-only href can never point at anything, no matter which converter produced the source HTML (DOCX, PPTX, or raw HTML). The result is a block of dead links.

This changes `_CustomMarkdownify.convert_a` in `_markdownify.py` to detect hrefs that are fragment-only (no scheme, no netloc, no path — just `#...`) and render the link text plain instead of wrapping it in a non-functional Markdown link. Hrefs with a path plus a fragment (e.g. `page.html#section`) are unaffected.

Fixes #2125.

Verified with a regression test (`test_fragment_only_links_render_as_plain_text` in `tests/test_module_misc.py`) that:
- fails against the old code (`[Executive Summary](#_Toc12345)` present in output)
- passes against the fix
- confirms normal external links and path+fragment links are unaffected

Full existing test suite: 335 passed, 4 skipped, 2 failed. Both failures (`test_markitdown_remote`, `test_speech_transcription`) are pre-existing and unrelated — they fail identically with this change reverted, due to network access to arxiv.org and a speech-recognition API being blocked in the sandbox this was verified in.
