### PR TITLE
fix(doc-intel): default api_version to None in DocumentIntelligenceConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -134,7 +134,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
         self,
         *,
         endpoint: str,
-        api_version: str = "2024-07-31-preview",
+        api_version: str | None = None,
         credential: AzureKeyCredential | TokenCredential | None = None,
         file_types: List[DocumentIntelligenceFileType] = [
             DocumentIntelligenceFileType.DOCX,
@@ -152,7 +152,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         Args:
             endpoint (str): The endpoint for the Document Intelligence service.
-            api_version (str): The API version to use. Defaults to "2024-07-31-preview".
+            api_version (str | None): The API version to use. Defaults to None.
             credential (AzureKeyCredential | TokenCredential | None): The credential to use for authentication.
             file_types (List[DocumentIntelligenceFileType]): The file types to accept. Defaults to all supported file types.
         """
@@ -180,11 +180,15 @@ class DocumentIntelligenceConverter(DocumentConverter):
 
         self.endpoint = endpoint
         self.api_version = api_version
-        self.doc_intel_client = DocumentIntelligenceClient(
-            endpoint=self.endpoint,
-            api_version=self.api_version,
-            credential=credential,
-        )
+
+        client_kwargs: dict[str, Any] = {
+            "endpoint": self.endpoint,
+            "credential": credential,
+        }
+        if self.api_version is not None:
+            client_kwargs["api_version"] = self.api_version
+
+        self.doc_intel_client = DocumentIntelligenceClient(**client_kwargs)
 
     def accepts(
         self,

--- a/packages/markitdown/tests/test_docintel_html.py
+++ b/packages/markitdown/tests/test_docintel_html.py
@@ -55,4 +55,3 @@ def test_docintel_api_version_custom():
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
         assert kwargs.get("api_version") == "2024-07-31-preview"
-

--- a/packages/markitdown/tests/test_docintel_html.py
+++ b/packages/markitdown/tests/test_docintel_html.py
@@ -24,3 +24,35 @@ def test_docintel_accepts_html_mimetype():
     assert conv.accepts(io.BytesIO(b""), stream_info)
     stream_info = StreamInfo(mimetype="application/xhtml+xml", extension=None)
     assert conv.accepts(io.BytesIO(b""), stream_info)
+
+
+def test_docintel_api_version_default_none():
+    from unittest.mock import patch
+
+    with patch(
+        "markitdown.converters._doc_intel_converter.DocumentIntelligenceClient"
+    ) as mock_client:
+        conv = DocumentIntelligenceConverter(
+            endpoint="https://example.cognitiveservices.azure.com/",
+        )
+        assert conv.api_version is None
+        mock_client.assert_called_once()
+        _, kwargs = mock_client.call_args
+        assert "api_version" not in kwargs
+
+
+def test_docintel_api_version_custom():
+    from unittest.mock import patch
+
+    with patch(
+        "markitdown.converters._doc_intel_converter.DocumentIntelligenceClient"
+    ) as mock_client:
+        conv = DocumentIntelligenceConverter(
+            endpoint="https://example.cognitiveservices.azure.com/",
+            api_version="2024-07-31-preview",
+        )
+        assert conv.api_version == "2024-07-31-preview"
+        mock_client.assert_called_once()
+        _, kwargs = mock_client.call_args
+        assert kwargs.get("api_version") == "2024-07-31-preview"
+


### PR DESCRIPTION
### Description
`DocumentIntelligenceConverter` previously set a default `api_version="2024-07-31-preview"`. This prevented users from using Azure Document Intelligence SDK's native default API version (e.g. `2024-11-30`).

This PR changes the default `api_version` parameter in `DocumentIntelligenceConverter.__init__` to `None` and passes `api_version` to `DocumentIntelligenceClient` only when explicitly specified.

Fixes #1904