### PR TITLE
fix: escape square brackets in link text and image alt (#1302)

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -4,6 +4,20 @@ import markdownify
 from typing import Any, Optional
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
+# Matches square brackets that are not already backslash-escaped. CommonMark
+# only permits brackets inside link text / image alt text when they are escaped
+# or appear as a matched pair, so unbalanced brackets otherwise break the link.
+_UNESCAPED_BRACKET_RE = re.compile(r"(?<!\\)([\[\]])")
+
+
+def _escape_brackets(text: str) -> str:
+    """Backslash-escape square brackets so they can't terminate a link label.
+
+    See #1302. Escaped brackets render identically to balanced ones, so this is
+    applied unconditionally rather than only to unbalanced input.
+    """
+    return _UNESCAPED_BRACKET_RE.sub(r"\\\1", text)
+
 
 class _CustomMarkdownify(markdownify.MarkdownConverter):
     """
@@ -77,7 +91,8 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             title = href
         title_part = ' "%s"' % title.replace('"', r"\"") if title else ""
         return (
-            "%s[%s](%s%s)%s" % (prefix, text, href, title_part, suffix)
+            "%s[%s](%s%s)%s"
+            % (prefix, _escape_brackets(text), href, title_part, suffix)
             if href
             else text
         )
@@ -107,7 +122,7 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         if src.startswith("data:") and not self.options["keep_data_uris"]:
             src = src.split(",")[0] + "..."
 
-        return "![%s](%s%s)" % (alt, src, title_part)
+        return "![%s](%s%s)" % (_escape_brackets(alt), src, title_part)
 
     def convert_input(
         self,

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -393,6 +393,46 @@ def test_deeply_nested_html_fallback() -> None:
     assert "<p>" not in result.markdown
 
 
+def test_link_text_bracket_escaping() -> None:
+    """Square brackets in link text and image alt text must be escaped so they
+    can't terminate the label early (issue #1302).
+
+    Unbalanced brackets are the breaking case: '[Unbalanced ] close](url)' is
+    not a link at all per CommonMark, and is emitted verbatim by parsers.
+    Balanced brackets happen to survive unescaped, but escaping them renders
+    identically, so it is applied unconditionally.
+    """
+    markitdown = MarkItDown()
+
+    html = (
+        "<html><body>"
+        '<p><a href="https://example.com/a">Learn [GPT]</a></p>'
+        '<p><a href="https://example.com/b">Unbalanced ] close</a></p>'
+        '<p><a href="https://example.com/c">Unbalanced [ open</a></p>'
+        '<p><img src="pic.png" alt="Figure [1]"></p>'
+        '<p><img src="pic2.png" alt="Bad ] alt"></p>'
+        "<p>Plain [text] outside a link</p>"
+        "</body></html>"
+    )
+    result = markitdown.convert_stream(
+        io.BytesIO(html.encode("utf-8")), file_extension=".html"
+    )
+
+    assert r"[Learn \[GPT\]](https://example.com/a)" in result.markdown
+    assert r"[Unbalanced \] close](https://example.com/b)" in result.markdown
+    assert r"[Unbalanced \[ open](https://example.com/c)" in result.markdown
+    assert r"![Figure \[1\]](pic.png)" in result.markdown
+    assert r"![Bad \] alt](pic2.png)" in result.markdown
+
+    # Brackets in ordinary text are not link syntax and must be left alone.
+    assert "Plain [text] outside a link" in result.markdown
+
+    # Escaping must be idempotent -- never double-escape an already-escaped
+    # bracket (markdownify emits these when escape_misc is enabled).
+    assert "\\\\[" not in result.markdown
+    assert "\\\\]" not in result.markdown
+
+
 def test_doc_rlink() -> None:
     # Test for: CVE-2025-11849
     markitdown = MarkItDown()


### PR DESCRIPTION
Fixes #1302.

## Problem

Link text and image alt text are emitted unescaped inside `[...](...)` / `![...](...)`. When the text contains an **unbalanced** `[` or `]`, the bracket terminates the label early and the link is destroyed.

Repro on `main`:

```python
from io import BytesIO
from markitdown import MarkItDown

html = b'<html><body><a href="https://example.com">Unbalanced ] close</a></body></html>'
print(MarkItDown().convert_stream(BytesIO(html), file_extension=".html").markdown)
# => [Unbalanced ] close](https://example.com)
```

That output is not a link. Per CommonMark, brackets are permitted in a link label only when backslash-escaped or appearing as a matched pair, so parsers emit the whole string as literal text — both the link and its target are lost:

```
[Unbalanced ] close](https://example.com)   ->   <p>[Unbalanced ] close](https://example.com)</p>
```

An unbalanced *opening* bracket fails differently, truncating the label:

```
[Unbalanced [ open](https://example.com)    ->   <p>[Unbalanced <a href="https://example.com">open</a></p>
```

Image alt text breaks the same way (`![Bad ] alt](pic.png)` renders as literal text).

Since this lives in `_CustomMarkdownify`, it affects every HTML-backed converter — HTML, DOCX, EPUB, RSS, Wikipedia, and Bing SERP.

One clarification on the issue as filed: it reports `[Learn [GPT]](url)` as broken, but *balanced* brackets are actually legal CommonMark and already round-trip correctly today. The genuine defect is the unbalanced case.

## Fix

Escape `[` and `]` in the two `_CustomMarkdownify` overrides that build Markdown link syntax (`convert_a` and `convert_img`).

Escaping is applied unconditionally rather than only to unbalanced input: escaped brackets render identically to balanced ones, so this avoids having to detect balance for no behavioural gain. A negative lookbehind keeps the substitution idempotent for callers who enable markdownify's `escape_misc`, which pre-escapes brackets.

Keeping the escape local to these two methods avoids flipping `escape_misc` on globally, which would also escape ``&<>~=+|`` and change output well beyond links.

Brackets in ordinary text are left untouched — they aren't link syntax there.

## Verification

Escaped output was checked against the CommonMark reference implementation (`commonmark`) and `mistletoe`; all cases now render as intended links/images with the brackets preserved in the visible text:

| Markdown | Renders as |
| --- | --- |
| `[Learn \[GPT\]](u)` | `<a href="u">Learn [GPT]</a>` |
| `[Unbalanced \] close](u)` | `<a href="u">Unbalanced ] close</a>` |
| `[Unbalanced \[ open](u)` | `<a href="u">Unbalanced [ open</a>` |
| `![Bad \] alt](p.png)` | `<img src="p.png" alt="Bad ] alt">` |

## Tests

Adds `test_link_text_bracket_escaping`, covering balanced, unbalanced-open, and unbalanced-close brackets in both link text and image alt, plus assertions that plain-text brackets are untouched and that escaping is idempotent.

Full suite run locally: no regressions. The pre-existing failures on my Windows machine (cp1252 stdout encoding, missing `ffmpeg`, missing Azure credentials) are identical with and without this change.

`black` (pre-commit, 23.7.0) is clean.
