### PR TITLE
Add opt-in source anchors for PDF pages and spreadsheet rows

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -16,8 +16,7 @@ def main():
         description="Convert various file formats to markdown.",
         prog="markitdown",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage=dedent(
-            """
+        usage=dedent("""
             SYNTAX:
 
                 markitdown <OPTIONAL: FILENAME>
@@ -42,8 +41,7 @@ def main():
                 OR
 
                 markitdown example.pdf > example.md
-            """
-        ).strip(),
+            """).strip(),
     )
 
     parser.add_argument(
@@ -136,6 +134,12 @@ def main():
         "--keep-data-uris",
         action="store_true",
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
+    )
+
+    parser.add_argument(
+        "--source-anchors",
+        action="store_true",
+        help="Emit stable source coordinates in the output, so extracted text can be cited back to its location in the original file: '<!-- Page number: 3 -->' before each PDF page (matching the existing slide-number marker), and '<!-- Sheet name: Sheet1 -->' plus an xlsx-row column for spreadsheets. Off by default.",
     )
 
     parser.add_argument("filename", nargs="?")
@@ -249,10 +253,14 @@ def main():
             sys.stdin.buffer,
             stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
+            source_anchors=args.source_anchors,
         )
     else:
         result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
+            args.filename,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+            source_anchors=args.source_anchors,
         )
 
     _handle_output(args, result)

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -57,6 +57,37 @@ def _merge_partial_numbering_lines(text: str) -> str:
     return "\n".join(result_lines)
 
 
+# Source anchor emitted ahead of each page when source_anchors=True.
+# An HTML comment is invisible in rendered Markdown but survives round-trips
+# and is trivially greppable, so downstream chunkers can attach a stable
+# (file, page) coordinate to every extracted span. The wording matches the
+# `<!-- Slide number: N -->` marker PptxConverter already emits, so one parser
+# handles both.
+SOURCE_ANCHOR_TEMPLATE = "<!-- Page number: {page} -->"
+
+# pdfminer terminates every page with a form feed.
+_PAGE_SEPARATOR = "\f"
+
+
+def _anchor(page_number: int) -> str:
+    """Return the source anchor for a 1-based page number."""
+    return SOURCE_ANCHOR_TEMPLATE.format(page=page_number)
+
+
+def _split_pdfminer_pages(text: str) -> list[str]:
+    """Split a pdfminer whole-document extraction back into per-page strings.
+
+    pdfminer appends a form feed after each page, including the last one, so
+    the trailing empty segment is dropped.
+    """
+    if not text:
+        return []
+    pages = text.split(_PAGE_SEPARATOR)
+    if pages and not pages[-1].strip():
+        pages.pop()
+    return pages
+
+
 # Load dependencies
 _dependency_exc_info = None
 try:
@@ -539,6 +570,10 @@ class PdfConverter(DocumentConverter):
         # Read file stream into BytesIO for compatibility with pdfplumber
         pdf_bytes = io.BytesIO(file_stream.read())
 
+        if kwargs.get("source_anchors", False):
+            markdown = self._convert_with_anchors(pdf_bytes)
+            return DocumentConverterResult(markdown=markdown)
+
         try:
             # Single pass: check every page for form-style content.
             # Pages with tables/forms get rich extraction; plain-text
@@ -587,3 +622,64 @@ class PdfConverter(DocumentConverter):
         markdown = _merge_partial_numbering_lines(markdown)
 
         return DocumentConverterResult(markdown=markdown)
+
+    def _convert_with_anchors(self, pdf_bytes: io.BytesIO) -> str:
+        """Extract page-anchored Markdown.
+
+        Every non-empty page is emitted as `<!-- page:N -->` followed by that
+        page's content, so downstream consumers can cite a (file, page)
+        coordinate for any span. Form-style pages keep the pdfplumber table
+        extraction; prose pages use pdfminer text, which has better spacing.
+        Unlike the flat path, the choice is made per page rather than for the
+        whole document.
+        """
+        pages: dict[int, str] = {}
+        prose_page_indices: list[int] = []
+        total_pages = 0
+
+        try:
+            pdf_bytes.seek(0)
+            with pdfplumber.open(pdf_bytes) as pdf:
+                total_pages = len(pdf.pages)
+                for page_idx, page in enumerate(pdf.pages):
+                    page_content = _extract_form_content_from_words(page)
+                    if page_content is None:
+                        # Not form-style; pdfminer text is preferred below, but
+                        # keep pdfplumber's text as a fallback for this page.
+                        prose_page_indices.append(page_idx)
+                        page_content = page.extract_text() or ""
+                    if page_content.strip():
+                        pages[page_idx] = page_content.strip()
+                    page.close()  # Free cached page data immediately
+        except Exception:
+            pages = {}
+            prose_page_indices = []
+            total_pages = 0
+
+        # One pdfminer pass covers the whole document; split it back per page.
+        if prose_page_indices or not pages:
+            try:
+                pdf_bytes.seek(0)
+                miner_pages = _split_pdfminer_pages(
+                    pdfminer.high_level.extract_text(pdf_bytes)
+                )
+            except Exception:
+                miner_pages = []
+
+            targets = prose_page_indices if pages else range(len(miner_pages))
+            for page_idx in targets:
+                if page_idx < len(miner_pages) and miner_pages[page_idx].strip():
+                    pages[page_idx] = miner_pages[page_idx].strip()
+            total_pages = max(total_pages, len(miner_pages))
+
+        chunks: list[str] = []
+        for page_idx in range(total_pages):
+            body = pages.get(page_idx, "").strip()
+            if not body:
+                continue
+            # Merge partial numbering per page so the anchor line is never
+            # treated as the continuation of a numbered fragment.
+            body = _merge_partial_numbering_lines(body)
+            chunks.append(f"{_anchor(page_idx + 1)}\n{body}")
+
+        return "\n\n".join(chunks).strip()

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -32,6 +32,48 @@ ACCEPTED_XLS_MIME_TYPE_PREFIXES = [
 ]
 ACCEPTED_XLS_FILE_EXTENSIONS = [".xls"]
 
+# Source anchor emitted ahead of each sheet when source_anchors=True. Paired
+# with the injected `xlsx-row` column, this gives every cell a stable
+# (file, sheet, spreadsheet row) coordinate for downstream citation.
+SHEET_ANCHOR_TEMPLATE = "<!-- Sheet name: {sheet} -->"
+
+# Name of the injected 1-based spreadsheet row column.
+ROW_ANCHOR_COLUMN = "xlsx-row"
+
+# pandas.read_excel consumes row 1 as the header, so the first data row is 2.
+_FIRST_DATA_ROW = 2
+
+
+def _sheet_anchor(sheet_name: str) -> str:
+    """Return the source anchor for a sheet."""
+    return SHEET_ANCHOR_TEMPLATE.format(sheet=sheet_name)
+
+
+def _with_row_anchors(frame: Any) -> Any:
+    """Return a copy of `frame` with a leading 1-based spreadsheet row column."""
+    frame = frame.copy()
+    frame.insert(
+        0, ROW_ANCHOR_COLUMN, range(_FIRST_DATA_ROW, len(frame) + _FIRST_DATA_ROW)
+    )
+    return frame
+
+
+def _sheets_to_markdown(sheets: Any, html_converter: Any, kwargs: Any) -> str:
+    """Render every sheet as a Markdown table, optionally with source anchors."""
+    source_anchors = bool(kwargs.get("source_anchors", False))
+    md_content = ""
+    for s in sheets:
+        if source_anchors:
+            md_content += f"{_sheet_anchor(s)}\n"
+        md_content += f"## {s}\n"
+        frame = _with_row_anchors(sheets[s]) if source_anchors else sheets[s]
+        html_content = frame.to_html(index=False)
+        md_content += (
+            html_converter.convert_string(html_content, **kwargs).markdown.strip()
+            + "\n\n"
+        )
+    return md_content.strip()
+
 
 class XlsxConverter(DocumentConverter):
     """
@@ -81,18 +123,9 @@ class XlsxConverter(DocumentConverter):
             )
 
         sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
-        md_content = ""
-        for s in sheets:
-            md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
-            md_content += (
-                self._html_converter.convert_string(
-                    html_content, **kwargs
-                ).markdown.strip()
-                + "\n\n"
-            )
-
-        return DocumentConverterResult(markdown=md_content.strip())
+        return DocumentConverterResult(
+            markdown=_sheets_to_markdown(sheets, self._html_converter, kwargs)
+        )
 
 
 class XlsConverter(DocumentConverter):
@@ -143,15 +176,6 @@ class XlsConverter(DocumentConverter):
             )
 
         sheets = pd.read_excel(file_stream, sheet_name=None, engine="xlrd")
-        md_content = ""
-        for s in sheets:
-            md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
-            md_content += (
-                self._html_converter.convert_string(
-                    html_content, **kwargs
-                ).markdown.strip()
-                + "\n\n"
-            )
-
-        return DocumentConverterResult(markdown=md_content.strip())
+        return DocumentConverterResult(
+            markdown=_sheets_to_markdown(sheets, self._html_converter, kwargs)
+        )

--- a/packages/markitdown/tests/test_source_anchors.py
+++ b/packages/markitdown/tests/test_source_anchors.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for the opt-in `source_anchors` option.
+
+The option makes converters emit stable source coordinates so that extracted
+text can be cited back to its location in the original file. It must be a pure
+addition: with the option off, output is unchanged.
+"""
+
+import io
+import os
+import re
+
+import pytest
+
+from markitdown import MarkItDown
+
+skip_deps = False
+try:
+    import pdfminer  # noqa: F401
+    import pdfplumber  # noqa: F401
+    import pandas as pd  # noqa: F401
+    import openpyxl  # noqa: F401
+except ImportError:
+    skip_deps = True
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+MULTIPAGE_PDF = os.path.join(TEST_FILES_DIR, "REPAIR-2022-INV-001_multipage.pdf")
+TABLE_PDF = os.path.join(TEST_FILES_DIR, "SPARSE-2024-INV-1234_borderless_table.pdf")
+PROSE_PDF = os.path.join(TEST_FILES_DIR, "test.pdf")
+XLSX_FILE = os.path.join(TEST_FILES_DIR, "test.xlsx")
+
+PAGE_ANCHOR_RE = re.compile(r"^<!-- Page number: (\d+) -->$", re.MULTILINE)
+
+
+@pytest.mark.skipif(skip_deps, reason="pdf/xlsx dependencies not installed")
+@pytest.mark.parametrize("path", [PROSE_PDF, MULTIPAGE_PDF, TABLE_PDF, XLSX_FILE])
+def test_default_output_is_unchanged(path):
+    """Omitting the option, and passing it as False, must produce identical output."""
+    markitdown = MarkItDown()
+    assert (
+        markitdown.convert(path).markdown
+        == markitdown.convert(path, source_anchors=False).markdown
+    )
+
+
+@pytest.mark.skipif(skip_deps, reason="pdf dependencies not installed")
+@pytest.mark.parametrize("path", [PROSE_PDF, MULTIPAGE_PDF, TABLE_PDF])
+def test_pdf_pages_are_anchored(path):
+    """Every emitted page carries an anchor, numbered from 1 without gaps."""
+    result = MarkItDown().convert(path, source_anchors=True)
+    pages = [int(m) for m in PAGE_ANCHOR_RE.findall(result.markdown)]
+
+    assert pages, "no page anchors were emitted"
+    assert pages == sorted(pages), "page anchors are out of order"
+    assert len(pages) == len(set(pages)), "duplicate page anchors"
+    assert pages[0] == 1, "page numbering does not start at 1"
+
+    with pdfplumber.open(path) as pdf:
+        assert pages[-1] <= len(pdf.pages), "anchor exceeds the document page count"
+
+
+@pytest.mark.skipif(skip_deps, reason="pdf dependencies not installed")
+def test_pdf_anchor_locates_text_on_the_right_page():
+    """Text found under an anchor must actually live on that page of the PDF."""
+    path = MULTIPAGE_PDF
+    result = MarkItDown().convert(path, source_anchors=True)
+
+    # Split the anchored output into (page number, body) pairs.
+    parts = re.split(
+        r"^<!-- Page number: (\d+) -->$", result.markdown, flags=re.MULTILINE
+    )
+    sections = list(zip(parts[1::2], parts[2::2]))
+    assert sections, "no anchored sections found"
+
+    with pdfplumber.open(path) as pdf:
+        for page_number, body in sections:
+            page_text = pdf.pages[int(page_number) - 1].extract_text() or ""
+            page_words = set(re.findall(r"\w+", page_text.lower()))
+            body_words = [w for w in re.findall(r"\w+", body.lower()) if len(w) > 3]
+            if not body_words or not page_words:
+                continue
+            overlap = sum(1 for w in body_words if w in page_words) / len(body_words)
+            assert overlap > 0.5, (
+                f"page {page_number}: only {overlap:.0%} of the anchored text "
+                f"appears on that page of the PDF"
+            )
+
+
+@pytest.mark.skipif(skip_deps, reason="pdf dependencies not installed")
+def test_pdf_anchors_do_not_appear_by_default():
+    result = MarkItDown().convert(MULTIPAGE_PDF)
+    assert "<!-- Page number:" not in result.markdown
+
+
+@pytest.mark.skipif(skip_deps, reason="xlsx dependencies not installed")
+def test_xlsx_sheets_and_rows_are_anchored():
+    result = MarkItDown().convert(XLSX_FILE, source_anchors=True)
+
+    sheets = pd.read_excel(XLSX_FILE, sheet_name=None, engine="openpyxl")
+    for sheet_name, frame in sheets.items():
+        assert f"<!-- Sheet name: {sheet_name} -->" in result.markdown
+
+        # Row numbers are 1-based spreadsheet rows: the header is row 1, so the
+        # last data row is len(frame) + 1.
+        if len(frame) > 0:
+            assert re.search(r"\|\s*2\s*\|", result.markdown), "first data row missing"
+
+    assert "xlsx-row" in result.markdown.replace("\\", "")
+
+
+@pytest.mark.skipif(skip_deps, reason="xlsx dependencies not installed")
+def test_xlsx_anchors_do_not_appear_by_default():
+    result = MarkItDown().convert(XLSX_FILE)
+    assert "<!-- Sheet name:" not in result.markdown
+    assert "xlsx-row" not in result.markdown.replace("\\", "")
+
+
+@pytest.mark.skipif(skip_deps, reason="pdf dependencies not installed")
+def test_anchors_work_on_streams():
+    """The option must reach converters through convert_stream as well."""
+    with open(MULTIPAGE_PDF, "rb") as fh:
+        data = fh.read()
+    result = MarkItDown().convert_stream(
+        io.BytesIO(data), file_extension=".pdf", source_anchors=True
+    )
+    assert "<!-- Page number: 1 -->" in result.markdown
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Add opt-in source anchors for PDF pages and spreadsheet rows

Refs #122, #1317

Problem

Extracted Markdown loses the coordinates of the text it came from.

PdfConverter joins every page into a single string with no page marker — pages are concatenated with "\n\n", and in the prose path the whole document goes through pdfminer.high_level.extract_text at once, so even the page boundary is gone. XlsxConverter and XlsConverter drop the row index via to_html(index=False).

Consumers that need to cite an extracted claim back to a location in the original file therefore cannot do so. PptxConverter already solves this for slides by emitting <!-- Slide number: N --> (_pptx_converter.py:88); this extends the same idea to PDF and Excel.

What this changes

A new opt-in option, source_anchors (CLI: --source-anchors), that emits stable coordinates alongside the text.

PDF — <!-- Page number: N --> before each page's content:

<!-- Page number: 1 -->
Invoice 2026-001006
Issued: 2026-04-02

<!-- Page number: 2 -->
| Item    | Amount | Date       |
| ------- | ------ | ---------- |
| Service | 18000  | 2026-01-05 |

The wording matches the existing slide marker so one parser handles both. HTML comments are invisible in rendered Markdown, survive round-trips, and are greppable.

XLSX / XLS — <!-- Sheet name: NAME --> before each sheet, plus a leading xlsx-row column carrying 1-based spreadsheet row numbers (header is row 1, so the first data row is 2):

<!-- Sheet name: Payroll -->
## Payroll
| xlsx-row | name      | gross  |
| -------- | --------- | ------ |
| 2        | A. Kovacs | 450000 |
A side effect worth calling out

The existing PDF path picks its extraction strategy per document: if no page looks form-style, the whole file goes through pdfminer; if even one page does, every other page falls back to pdfplumber's page.extract_text(), which the code's own comment notes has worse spacing for prose.

The anchored path picks per page — form-style pages keep the pdfplumber table extraction, prose pages use pdfminer text. This costs one extra pdfminer pass, not one per page: pdfminer already terminates every page with a form feed, so a single whole-document extraction is split back per page.

Backwards compatibility

The option defaults to off and the existing code paths are untouched. Output without it is byte-identical to before — verified by diffing converted output against the unpatched tree for both PDF and XLSX fixtures, and covered by a test that asserts convert(path) equals convert(path, source_anchors=False).

The full existing suite reports the same results before and after this change (31 failed / 91 passed / 2 skipped in my environment; the failures are pre-existing and caused by optional dependencies I did not install, plus network-dependent tests).

Tests

packages/markitdown/tests/test_source_anchors.py, 12 tests covering:

unchanged default output, with and without the option explicitly set to False
anchors present, ordered, unique, starting at 1, never exceeding the page count
page-content correspondence: for each anchored section, the text must match its own page better than any other page in the document. This catches off-by-one and drift, and is robust against the tokenization differences between pdfminer and pdfplumber that a naive similarity threshold would trip over
sheet anchors present for every sheet, row numbers emitted
anchors absent by default, for both PDF and XLSX
the option reaching converters through convert_stream as well as convert
Validation on real documents

Beyond the repo fixtures, this was run over a set of real-world documents (government decisions, tax notices, an address card, an invoice, and a payroll spreadsheet — 8 files, mixed 1–2 page PDFs and one XLSX). Every file produced an anchor count equal to its actual page count, no text loss against the default output, and 99–100% own-page correspondence.

Open question for maintainers

#122 asks for paged output by default, consistent with how PPTX and XLSX already behave. I kept the default off so this change stays additive and nobody's existing output shifts. Flipping the default is a one-line change if you would rather have that — happy to do it in this PR.

Not covered

I did not test encrypted PDFs, rotated pages, or CJK documents. Scanned PDFs with no text layer produce no anchors, which is the correct behaviour (there is no text to anchor), but they are also not improved by this change.