### PR TITLE
fix: avoid UnicodeDecodeError when non-ASCII bytes follow the first 4k

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -734,6 +734,15 @@ class MarkItDown:
                     if charset_result is not None:
                         charset = self._normalize_charset(charset_result.encoding)
 
+                        # Detection only saw this first page. If the stream continues
+                        # past it, non-ASCII bytes may appear later and decoding the
+                        # whole stream as ASCII would fail. ASCII is a strict subset of
+                        # UTF-8, so widening the guess still decodes every byte ASCII
+                        # would, plus any multi-byte runs further in. A stream that ends
+                        # within the page was fully inspected, so ASCII stands.
+                        if charset == "ascii" and len(stream_page) == 4096:
+                            charset = "utf-8"
+
                 # Normalize the first extension listed
                 guessed_extension = None
                 if len(result.prediction.output.extensions) > 0:

--- a/packages/markitdown/src/markitdown/converter_utils/charset.py
+++ b/packages/markitdown/src/markitdown/converter_utils/charset.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from charset_normalizer import from_bytes
+
+
+def decode_text(data: bytes, charset: Optional[str]) -> str:
+    """
+    Decode bytes to text, re-detecting the charset when the supplied one does not fit.
+
+    Charset detection inspects only the first 4k of a stream, so a file whose non-ASCII
+    bytes appear later can be labeled with a charset that fails on the full content.
+    Re-running detection over every byte recovers those files instead of raising
+    UnicodeDecodeError.
+    """
+    if charset:
+        try:
+            return data.decode(charset)
+        except UnicodeDecodeError:
+            pass
+
+    best_match = from_bytes(data).best()
+    if best_match is None:
+        # Detection found no viable encoding; keep the readable parts rather than failing.
+        return data.decode("utf-8", errors="replace")
+    return str(best_match)

--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -1,9 +1,9 @@
 import csv
 import io
 from typing import BinaryIO, Any
-from charset_normalizer import from_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
+from ..converter_utils.charset import decode_text
 
 ACCEPTED_MIME_TYPE_PREFIXES = [
     "text/csv",
@@ -42,10 +42,7 @@ class CsvConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Read the file content
-        if stream_info.charset:
-            content = file_stream.read().decode(stream_info.charset)
-        else:
-            content = str(from_bytes(file_stream.read()).best())
+        content = decode_text(file_stream.read(), stream_info.charset)
 
         # Parse CSV content
         reader = csv.reader(io.StringIO(content))

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -1,9 +1,9 @@
 import sys
 
 from typing import BinaryIO, Any
-from charset_normalizer import from_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
+from ..converter_utils.charset import decode_text
 
 # Try loading optional (but in this case, required) dependencies
 # Save reporting of any exceptions for later
@@ -63,9 +63,6 @@ class PlainTextConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
-        if stream_info.charset:
-            text_content = file_stream.read().decode(stream_info.charset)
-        else:
-            text_content = str(from_bytes(file_stream.read()).best())
+        text_content = decode_text(file_stream.read(), stream_info.charset)
 
         return DocumentConverterResult(markdown=text_content)

--- a/packages/markitdown/tests/test_charset_detection.py
+++ b/packages/markitdown/tests/test_charset_detection.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3 -m pytest
+import io
+
+from markitdown import MarkItDown, StreamInfo
+from markitdown.converter_utils.charset import decode_text
+
+# Charset detection only inspects the first 4k of a stream, so the non-ASCII bytes in
+# these fixtures are placed well past that boundary to exercise the misdetection path.
+PADDING = "a" * 5000
+ACCENTED_TEXT = "Considerações de segurança: acentuação e cedilha."
+
+
+def test_utf8_bytes_after_detection_window() -> None:
+    """A UTF-8 file that looks like ASCII in its first 4k must still convert."""
+    content = (PADDING + "\n" + ACCENTED_TEXT + "\n").encode("utf-8")
+
+    markitdown = MarkItDown()
+    result = markitdown.convert_stream(
+        io.BytesIO(content), stream_info=StreamInfo(extension=".md")
+    )
+
+    assert ACCENTED_TEXT in result.markdown
+
+
+def test_csv_utf8_bytes_after_detection_window() -> None:
+    """The same misdetection must not break the CSV converter."""
+    content = ("header\n" + PADDING + "\n" + ACCENTED_TEXT + "\n").encode("utf-8")
+
+    markitdown = MarkItDown()
+    result = markitdown.convert_stream(
+        io.BytesIO(content), stream_info=StreamInfo(extension=".csv")
+    )
+
+    assert ACCENTED_TEXT in result.markdown
+
+
+def test_decode_text_recovers_from_wrong_charset() -> None:
+    """A charset that fails on the full content must not raise.
+
+    'ascii' fits the first 4k but not the accented tail. Re-detection then picks the
+    encoding it judges best. Which one that is depends on charset_normalizer's
+    heuristics, so the guarantee under test is that decoding yields usable text
+    instead of raising UnicodeDecodeError.
+    """
+    content = (PADDING + "\n" + ACCENTED_TEXT + "\n").encode("cp1252")
+
+    decoded = decode_text(content, "ascii")
+
+    assert isinstance(decoded, str)
+    assert PADDING in decoded
+
+
+def test_decode_text_honors_a_valid_charset() -> None:
+    """An explicit charset that does decode the content is used as given."""
+    content = ACCENTED_TEXT.encode("cp1252")
+
+    assert decode_text(content, "cp1252") == ACCENTED_TEXT
+
+
+def test_decode_text_without_charset() -> None:
+    """With no charset supplied, detection runs over the whole content."""
+    content = (PADDING + "\n" + ACCENTED_TEXT + "\n").encode("utf-8")
+
+    assert ACCENTED_TEXT in decode_text(content, None)
+
+
+if __name__ == "__main__":
+    """Runs this file's tests from the command line."""
+    for test in [
+        test_utf8_bytes_after_detection_window,
+        test_csv_utf8_bytes_after_detection_window,
+        test_decode_text_recovers_from_wrong_charset,
+        test_decode_text_honors_a_valid_charset,
+        test_decode_text_without_charset,
+    ]:
+        print(f"Running {test.__name__}...", end="")
+        test()
+        print("OK")
+    print("All tests passed!")


### PR DESCRIPTION
## Problem

Charset detection in `_markitdown.py` inspects only the first 4096 bytes of a stream. A text file whose non-ASCII bytes appear past that window is labeled `ascii`, and decoding the full content then fails:

```
FileConversionException: File conversion failed after 1 attempts:
 - PlainTextConverter threw UnicodeDecodeError with message:
   'ascii' codec can't decode byte 0xe2 in position 5030: ordinal not in range(128)
```

Minimal reproduction: 5000 ASCII characters followed by `café`. Detection over the first 4k returns `ascii`; detection over the full content returns `utf_8`.

This affects `.md`, `.txt`, `.csv` and other text formats large enough to exceed the detection window. It is easy to hit with real documents: an English-language file whose first accented character, em dash, or curly quote happens to sit past the 4k mark converts fine until the day that character moves earlier or later.

## Fix

**`_markitdown.py`** — when detection returns ASCII **and** the stream continues past the inspected page, the guess is widened to UTF-8. ASCII is a strict subset of UTF-8, so nothing that decoded before stops decoding.

The size condition is the important part. A stream that ends within the 4096-byte page was fully inspected, so ASCII still holds and is kept. Without that condition, `guess_stream_info()` would start reporting `utf-8` for small, purely ASCII files, which breaks the `test.json` and `test_notebook.ipynb` vectors in `test_module_vectors.py`. Those vectors are correct as written, so the fix is scoped to the case where detection was actually partial.

**`converter_utils/charset.py`** (new) — `decode_text()` centralizes decoding: it tries the supplied charset and, on `UnicodeDecodeError`, re-detects over every byte. This covers misdetected non-UTF-8 charsets (cp1252, latin-1), where widening to UTF-8 is not enough. It also handles `from_bytes(...).best()` returning `None`, which previously produced the literal string `"None"` as the document's content.

**`_plain_text_converter.py`** and **`_csv_converter.py`** — use the helper.

## Tests

5 new cases in `tests/test_charset_detection.py`: UTF-8 past the detection window, the same for CSV, recovery from a wrong charset, honoring a valid explicit charset, and decoding with no charset supplied.

Full suite: **341 passed, 4 skipped**. `black` clean.

One test note for macOS: the CLI tests invoke `python` via subprocess, and macOS ships only `python3` on PATH, so they need the venv on PATH (`PATH="$PWD/.venv/bin:$PATH"`) or 50 tests fail for environmental reasons unrelated to any change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)