### PR TITLE
feat(doc-intel): expose model_id and analysis features on DocumentIntelligenceConverter (#2273)

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -222,6 +222,14 @@ class MarkItDown:
                 if docintel_version is not None:
                     docintel_args["api_version"] = docintel_version
 
+                docintel_model_id = kwargs.get("docintel_model_id")
+                if docintel_model_id is not None:
+                    docintel_args["model_id"] = docintel_model_id
+
+                docintel_features = kwargs.get("docintel_features")
+                if docintel_features is not None:
+                    docintel_args["features"] = docintel_features
+
                 self.register_converter(
                     DocumentIntelligenceConverter(**docintel_args),
                 )

--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -146,6 +146,8 @@ class DocumentIntelligenceConverter(DocumentConverter):
             DocumentIntelligenceFileType.BMP,
             DocumentIntelligenceFileType.TIFF,
         ],
+        model_id: str = "prebuilt-layout",
+        features: List[str] | None = None,
     ):
         """
         Initialize the DocumentIntelligenceConverter.
@@ -155,10 +157,18 @@ class DocumentIntelligenceConverter(DocumentConverter):
             api_version (str): The API version to use. Defaults to "2024-07-31-preview".
             credential (AzureKeyCredential | TokenCredential | None): The credential to use for authentication.
             file_types (List[DocumentIntelligenceFileType]): The file types to accept. Defaults to all supported file types.
+            model_id (str): The Document Intelligence model to analyze with. Defaults to "prebuilt-layout".
+                Pass e.g. "prebuilt-read" for cheaper plain-text extraction.
+            features (List[str] | None): The analysis add-on features to request for OCR-eligible
+                file types. Defaults to None, which keeps the built-in set (formulas, high
+                resolution OCR, and font style). Pass an empty list to disable all add-ons.
+                Add-ons are never sent for office file types, which do not support them.
         """
 
         super().__init__()
         self._file_types = file_types
+        self._features = features
+        self.model_id = model_id
 
         # Raise an error if the dependencies are not available.
         # This is different than other converters since this one isn't even instantiated
@@ -228,6 +238,9 @@ class DocumentIntelligenceConverter(DocumentConverter):
             if mimetype.startswith(prefix):
                 return []
 
+        if self._features is not None:
+            return list(self._features)
+
         return [
             DocumentAnalysisFeature.FORMULAS,  # enable formula extraction
             DocumentAnalysisFeature.OCR_HIGH_RESOLUTION,  # enable high resolution OCR
@@ -242,7 +255,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
     ) -> DocumentConverterResult:
         # Extract the text using Azure Document Intelligence
         poller = self.doc_intel_client.begin_analyze_document(
-            model_id="prebuilt-layout",
+            model_id=self.model_id,
             body=AnalyzeDocumentRequest(bytes_source=file_stream.read()),
             features=self._analysis_features(stream_info),
             output_content_format=CONTENT_FORMAT,  # TODO: replace with "ContentFormat.MARKDOWN" when the bug is fixed

--- a/packages/markitdown/tests/test_docintel_options.py
+++ b/packages/markitdown/tests/test_docintel_options.py
@@ -1,0 +1,74 @@
+import io
+
+from markitdown._stream_info import StreamInfo
+from markitdown.converters._doc_intel_converter import (
+    DocumentIntelligenceConverter,
+    DocumentIntelligenceFileType,
+)
+
+ALL_TYPES = list(DocumentIntelligenceFileType)
+
+
+def _make_converter(features=None, model_id="prebuilt-layout"):
+    """Build a converter without touching Azure (mirrors test_docintel_html.py)."""
+    conv = DocumentIntelligenceConverter.__new__(DocumentIntelligenceConverter)
+    conv._file_types = ALL_TYPES
+    conv._features = features
+    conv.model_id = model_id
+    return conv
+
+
+PDF = StreamInfo(mimetype="application/pdf", extension=".pdf")
+DOCX = StreamInfo(mimetype=None, extension=".docx")
+
+
+def _values(features):
+    """Azure's feature enum is a str-enum; compare on the wire values."""
+    return [getattr(f, "value", f) for f in features]
+
+
+def test_default_features_unchanged():
+    conv = _make_converter()
+    assert _values(conv._analysis_features(PDF)) == [
+        "formulas",
+        "ocrHighResolution",
+        "styleFont",
+    ]
+
+
+def test_default_model_id_unchanged():
+    assert _make_converter().model_id == "prebuilt-layout"
+
+
+def test_empty_features_disables_addons():
+    conv = _make_converter(features=[])
+    assert conv._analysis_features(PDF) == []
+
+
+def test_explicit_features_are_used():
+    conv = _make_converter(features=["ocrHighResolution"])
+    assert _values(conv._analysis_features(PDF)) == ["ocrHighResolution"]
+
+
+def test_explicit_features_not_sent_for_office_types():
+    """Office file types do not support add-ons, so they stay empty."""
+    conv = _make_converter(features=["ocrHighResolution"])
+    assert conv._analysis_features(DOCX) == []
+
+
+def test_explicit_features_list_is_copied():
+    """The caller's list must not be aliased into the request."""
+    requested = ["ocrHighResolution"]
+    conv = _make_converter(features=requested)
+    returned = conv._analysis_features(PDF)
+    returned.append("styleFont")
+    assert requested == ["ocrHighResolution"]
+
+
+def test_custom_model_id_is_stored():
+    assert _make_converter(model_id="prebuilt-read").model_id == "prebuilt-read"
+
+
+def test_accepts_still_works():
+    """Sanity: the new attributes do not disturb accepts()."""
+    assert _make_converter().accepts(io.BytesIO(b""), PDF)


### PR DESCRIPTION
Closes #2273.

## Problem

`DocumentIntelligenceConverter` hardcodes both the analysis model and the add-on
feature set:

```python
poller = self.doc_intel_client.begin_analyze_document(
    model_id="prebuilt-layout",
    ...
    features=self._analysis_features(stream_info),   # always FORMULAS + OCR_HIGH_RESOLUTION + STYLE_FONT
)
```

There is no constructor parameter for either, so a caller who only needs plain
text OCR has no way to ask for `prebuilt-read` or to drop the add-ons short of
bypassing MarkItDown and calling `azure-ai-documentintelligence` directly. As
#2273 notes, on Azure pay-as-you-go that is roughly a 10–19× cost difference
(~$1.50 vs ~$16–28 per 1,000 pages).

## Change

Two new keyword-only parameters on `DocumentIntelligenceConverter`, plumbed
through `MarkItDown(...)` following the existing `docintel_*` kwargs pattern:

| parameter | `MarkItDown` kwarg | default | meaning |
|---|---|---|---|
| `model_id: str` | `docintel_model_id` | `"prebuilt-layout"` | model passed to `begin_analyze_document` |
| `features: List[str] \| None` | `docintel_features` | `None` | `None` keeps today's add-on set; `[]` disables all add-ons |

```python
md = MarkItDown(
    docintel_endpoint=...,
    docintel_model_id="prebuilt-read",
    docintel_features=[],
)
```

The defaults are the current values, so existing callers send byte-identical
requests. This exposes the choice rather than changing it, as the issue asks.

Two behaviours are deliberately preserved:

- **Office types still get no add-ons.** The `.docx/.pptx/.xlsx/.html` early
  return runs before the new branch, because the service does not accept add-ons
  for those types — an explicit `features=[...]` cannot re-introduce a request
  the API would reject.
- **The caller's list is copied**, not aliased into the request.

## Tests

New `packages/markitdown/tests/test_docintel_options.py` (8 tests), built with
the same `__new__` no-Azure-client pattern as the existing
`test_docintel_html.py`.

Run against the released package with the patch applied and removed:

```
# unpatched: the two tests that assert the new behaviour fail, the
# "defaults unchanged" guards pass
2 failed, 6 passed

# patched
8 passed
```

`test_docintel_html.py` still passes (2 passed), and `black==23.7.0` (the pinned
pre-commit version) reports all three touched files unchanged.

Plumbing verified end to end:

```
custom  model_id = prebuilt-read   | features = []
default model_id = prebuilt-layout | features = ['formulas', 'ocrHighResolution', 'styleFont']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
