### PR TITLE
feat: extract outputs from Jupyter Notebook cells

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -77,6 +77,34 @@ class IpynbConverter(DocumentConverter):
                 elif cell_type == "code":
                     # Code cells are wrapped in Markdown code blocks
                     md_output.append(f"```python\n{''.join(source_lines)}\n```")
+
+                    # Extract cell outputs
+                    outputs = cell.get("outputs", [])
+                    if outputs:
+                        output_text = []
+                        for out in outputs:
+                            out_type = out.get("output_type", "")
+                            if out_type == "stream":
+                                output_text.extend(out.get("text", []))
+                            elif out_type in ("execute_result", "display_data"):
+                                data = out.get("data", {})
+                                if "text/plain" in data:
+                                    val = data["text/plain"]
+                                    if isinstance(val, list):
+                                        output_text.extend(val)
+                                    else:
+                                        output_text.append(str(val))
+                            elif out_type == "error":
+                                ename = out.get("ename", "Error")
+                                evalue = out.get("evalue", "")
+                                output_text.append(f"{ename}: {evalue}\n")
+
+                        if output_text:
+                            output_str = "".join(output_text).strip()
+                            if output_str:
+                                md_output.append(
+                                    f"**Output:**\n```text\n{output_str}\n```"
+                                )
                 elif cell_type == "raw":
                     md_output.append(f"```\n{''.join(source_lines)}\n```")
 

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -185,7 +185,11 @@ GENERAL_TEST_VECTORS = [
             "```python",
             'print("markitdown")',
             "```",
+            "**Output:**",
+            "```text\nmarkitdown\n```",
             "## Code Cell Below",
+            "**Output:**",
+            "```text\n42\n```",
         ],
         must_not_include=[
             "nbformat",


### PR DESCRIPTION
## Motivation and Context
Currently, the `IpynbConverter` only extracts source code from Jupyter Notebook cells and drops all cell execution outputs. Because `markitdown` is primarily designed as a utility tool to convert files into Markdown for Large Language Model (LLM) consumption, dropping these outputs results in a significant loss of context. 
For Data Science and RAG pipelines, the execution results of a notebook cell (such as printed metrics, `pandas` DataFrame plain-text representations, or error tracebacks) are often just as critical as the code itself for the LLM to understand the document's state.
This PR introduces robust output extraction for Jupyter Notebook code cells, drastically improving the utility of `.ipynb` conversion for AI and indexing workloads.
## Description of Changes
- **Targeted Output Parsing:** Updated `_ipynb_converter.py` to inspect the `outputs` array of any `cell_type == "code"`.
- **Supported Output Types:**
  - `stream`: Captures standard `stdout` and `stderr` outputs.
  - `execute_result` & `display_data`: Safely extracts the `text/plain` keys (falling back gracefully if they do not exist), which properly captures printed tables, integers, and standard objects.
  - `error`: Captures execution failures by extracting the `ename` (Error Name) and `evalue` (Error Value).
- **Safe Dictionary Access:** All JSON dictionary accesses use `.get()` with safe defaults to prevent `KeyError` exceptions on corrupted, malformed, or manually edited notebooks.
- **Clean Markdown Formatting:** Appends the parsed outputs cleanly below the source code inside a `**Output:**` heading and a ```text``` code block. This distinct formatting allows LLMs to easily differentiate between executable source code and console output. If a cell has no output (e.g. variable assignment), the block is gracefully omitted.
## Testing
- **Updated Test Vectors:** Modified the expected Markdown assertions for `test_notebook.ipynb` within `tests/_test_vectors.py` to ensure that both standard text streams (`"markitdown"`) and integer outputs (`"42"`) are successfully captured by the new logic.
- **Validation:** 
  - Ran `hatch test -v` locally; all 340 test cases passed.
  - Ran `pre-commit run --all-files`; code has been formatted using `black` to match Microsoft's repository standards.