### PR TITLE
fix: preserve sparse XLSX rows without placeholder noise

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -80,11 +80,28 @@ class XlsxConverter(DocumentConverter):
                 _xlsx_dependency_exc_info[2]
             )
 
-        sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
+        sheets = pd.read_excel(
+            file_stream, sheet_name=None, engine="openpyxl", header=None
+        )
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            sheet = sheets[s].dropna(axis="index", how="all")
+            sheet = sheet.dropna(axis="columns", how="all")
+
+            # Keep conventional tables unchanged, but treat partial first rows as
+            # data (they are commonly titles above a table rather than headers).
+            has_complete_header = not sheet.empty and sheet.iloc[0].notna().all()
+            if has_complete_header:
+                header = sheet.iloc[0]
+                sheet = sheet.iloc[1:].copy()
+                sheet.columns = header.tolist()
+
+            html_content = sheet.to_html(
+                index=False,
+                header=has_complete_header,
+                na_rep="",
+            )
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs

--- a/packages/markitdown/tests/test_xlsx_converter.py
+++ b/packages/markitdown/tests/test_xlsx_converter.py
@@ -1,0 +1,59 @@
+from io import BytesIO
+
+import openpyxl
+
+from markitdown import MarkItDown, StreamInfo
+
+
+def _convert_workbook(workbook: openpyxl.Workbook) -> str:
+    stream = BytesIO()
+    workbook.save(stream)
+    stream.seek(0)
+    return (
+        MarkItDown().convert(stream, stream_info=StreamInfo(extension=".xlsx")).markdown
+    )
+
+
+def test_xlsx_drops_empty_rows_and_columns_without_losing_title_row() -> None:
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Sheet"
+    sheet["A1"] = "PROGRESS"
+    sheet["A3"] = "Task"
+    sheet["C3"] = "Owner"
+    sheet["D3"] = "Status"
+    sheet["A4"] = "Design"
+    sheet["C4"] = "Ana"
+    sheet["D4"] = "Done"
+
+    markdown = _convert_workbook(workbook)
+
+    assert (
+        markdown
+        == """## Sheet
+|  |  |  |
+| --- | --- | --- |
+| PROGRESS |  |  |
+| Task | Owner | Status |
+| Design | Ana | Done |"""
+    )
+    assert "Unnamed:" not in markdown
+    assert "NaN" not in markdown
+
+
+def test_xlsx_preserves_complete_first_row_as_header() -> None:
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Data"
+    sheet.append(["Alpha", "Beta"])
+    sheet.append([1, 2])
+
+    markdown = _convert_workbook(workbook)
+
+    assert (
+        markdown
+        == """## Data
+| Alpha | Beta |
+| --- | --- |
+| 1 | 2 |"""
+    )


### PR DESCRIPTION
## What changed

- read XLSX sheets without forcing the first row to be a header
- remove fully empty rows and columns before rendering
- preserve a complete first row as the header for conventional tables
- render missing cells as blanks instead of leaking pandas `NaN` and `Unnamed: N` placeholders
- add regression coverage for sparse title rows and conventional complete headers

## Why

Real spreadsheets often begin with a title row, contain spacer rows, or have blank columns. Pandas previously promoted the first row to headers unconditionally, producing noisy and misleading Markdown that is especially harmful for downstream LLM and indexing workflows.

The new behavior keeps ordinary tables unchanged while rendering sparse layouts faithfully and without placeholder noise.

Fixes #2124.

## Validation

- full offline test suite: **309 passed, 33 skipped**
- targeted XLSX regression tests: **2 passed**
- Black 23.7.0: **passed**
- Mypy: **no issues in 2 source files**
- `git diff --check`: **passed**
