### PR TITLE
docs: add Sealos deployment option for MCP server

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -54,6 +54,12 @@ docker run -it --rm -v /home/user/data:/workdir markitdown-mcp:latest
 
 Once mounted, all files under data will be accessible under `/workdir` in the container. For example, if you have a file `example.txt` in `/home/user/data`, it will be accessible in the container at `/workdir/example.txt`.
 
+## Deploy on Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/markitdown)
+
+The Sealos template runs the MCP server as a private trusted service, keeps `/workdir` persistent, and exposes the Streamable HTTP and SSE transports over HTTPS for clients you control.
+
 ## Accessing from Claude Desktop
 
 It is recommended to use the Docker image when running the MCP server for Claude Desktop.


### PR DESCRIPTION
## Summary

This PR adds a Sealos deployment option for the MarkItDown MCP server.

It adds:
- a Deploy on Sealos button in `packages/markitdown-mcp/README.md`
- a short note that the template keeps `/workdir` persistent and exposes Streamable HTTP and SSE over HTTPS for trusted clients

## Why

This gives MarkItDown MCP users a private one-click deployment path without changing the default local-use guidance.

## Validation

- Sealos template: https://sealos.io/products/app-store/markitdown
- Template repo: https://github.com/labring-actions/templates
- Validation record: PR #737, validated on 2026-08-10
- Persistence covered: yes
- Required env vars documented: yes

## Maintenance

I can help maintain the Sealos deployment path and follow up if the template or docs need updates.
Prepared with AI assistance and reviewed end to end.