### PR TITLE
fix: correct \underleftarrow macro and map math italic h in equation conversion

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/latex_dict.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/latex_dict.py
@@ -50,7 +50,7 @@ CHR = {
     "\u20e8": "\\threeunderdot{{{0}}}",
     "\u20ec": "\\underrightharpoondown{{{0}}}",
     "\u20ed": "\\underleftharpoondown{{{0}}}",
-    "\u20ee": "\\underledtarrow{{{0}}}",
+    "\u20ee": "\\underleftarrow{{{0}}}",
     "\u20ef": "\\underrightarrow{{{0}}}",
     # Over | group
     "\u23b4": "\\overbracket{{{0}}}",
@@ -180,6 +180,8 @@ T = {
     "\U0001d452": "e",
     "\U0001d453": "f",
     "\U0001d454": "g",
+    # U+1D455 is reserved: the math italic small h is unified with U+210E
+    "\u210e": "h",
     "\U0001d456": "i",
     "\U0001d457": "j",
     "\U0001d458": "k",

--- a/packages/markitdown/tests/test_docx_math_symbols.py
+++ b/packages/markitdown/tests/test_docx_math_symbols.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for the OMML -> LaTeX symbol tables used by the DOCX converter.
+
+Two independent defects are covered here:
+
+``CHR`` maps a combining accent to a LaTeX template. U+20EE COMBINING LEFT
+ARROW BELOW mapped to ``\\underledtarrow``, which is not a LaTeX macro -- the
+name is a scrambled ``\\underleftarrow``. Its two neighbours in the same table
+(U+20D6 -> ``\\overleftarrow``, U+20EF -> ``\\underrightarrow``) show the
+intent. The template still formats, so nothing raises: the document simply ends
+up with an undefined control sequence that no renderer can typeset.
+
+``T`` normalizes the Mathematical Alphanumeric Symbols back to ASCII, so that
+an equation written with math italic letters yields ``h(x)`` rather than a
+string of astral-plane codepoints. U+1D455 -- the slot where math italic small
+h would sit -- is permanently reserved, because Unicode unifies that letter
+with U+210E PLANCK CONSTANT. The table followed the contiguous block and so
+skipped h, leaving it as the single letter of the alphabet that survived
+untranslated into the LaTeX output.
+"""
+
+from markitdown.converter_utils.docx.math.latex_dict import T
+from markitdown.converter_utils.docx.math.omml import load_string
+
+# Math italic Latin: A-Z is contiguous, a-z has a hole at U+1D455 (small h),
+# which Unicode unifies with U+210E.
+ITALIC_UPPERCASE = {
+    chr(0x1D434 + i): c for i, c in enumerate("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+}
+ITALIC_LOWERCASE = {
+    chr(0x1D44E + i): c for i, c in enumerate("abcdefghijklmnopqrstuvwxyz")
+}
+ITALIC_LOWERCASE.pop(chr(0x1D455))  # reserved codepoint, never assigned
+ITALIC_LOWERCASE["ℎ"] = "h"
+
+_DOC = (
+    "<w:document "
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" '
+    'xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">'
+    "{0}</w:document>"
+)
+
+_ACCENT = (
+    "<m:oMath><m:acc>"
+    '<m:accPr><m:chr m:val="{chr}"/></m:accPr>'
+    "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+    "</m:acc></m:oMath>"
+)
+
+_RUN = "<m:oMath><m:r><m:t>{text}</m:t></m:r></m:oMath>"
+
+
+def _latex(fragment: str) -> str:
+    return next(load_string(_DOC.format(fragment))).latex
+
+
+def _accent_latex(accent_char: str) -> str:
+    return _latex(_ACCENT.format(chr=accent_char))
+
+
+def _run_latex(text: str) -> str:
+    return _latex(_RUN.format(text=text))
+
+
+def test_combining_left_arrow_below() -> None:
+    """U+20EE must produce \\underleftarrow, not the misspelled macro."""
+    assert _accent_latex("⃮") == "\\underleftarrow{x}"
+
+
+def test_arrow_accents_are_consistent() -> None:
+    """The three arrow accents share one naming scheme; none may be misspelled."""
+    assert _accent_latex("⃖") == "\\overleftarrow{x}"  # left arrow above
+    assert _accent_latex("⃯") == "\\underrightarrow{x}"  # right arrow below
+    assert _accent_latex("⃮") == "\\underleftarrow{x}"  # left arrow below
+
+
+def test_math_italic_small_h_is_normalized() -> None:
+    """U+210E is the math italic h; it must not survive into the LaTeX."""
+    assert _run_latex("ℎ") == "h"
+
+
+def test_math_italic_latin_alphabet_is_complete() -> None:
+    """No math italic Latin letter may leak through untranslated."""
+    for char, expected in {**ITALIC_UPPERCASE, **ITALIC_LOWERCASE}.items():
+        assert T.get(char) == expected, f"U+{ord(char):04X} is missing from T"
+        assert _run_latex(char) == expected
+
+
+def test_math_italic_expression_is_fully_normalized() -> None:
+    """A whole expression must come out as plain ASCII LaTeX."""
+    # h(x) = g(x), written entirely with math italic codepoints.
+    expression = "ℎ(\U0001d465)=\U0001d454(\U0001d465)"
+    assert _run_latex(expression) == "h(x)=g(x)"
+
+
+if __name__ == "__main__":
+    test_combining_left_arrow_below()
+    test_arrow_accents_are_consistent()
+    test_math_italic_small_h_is_normalized()
+    test_math_italic_latin_alphabet_is_complete()
+    test_math_italic_expression_is_fully_normalized()
+    print("All tests passed!")


### PR DESCRIPTION
Two small fixes in the OMML → LaTeX tables used to convert equations out of `.docx`. I ran into both while auditing the symbol tables after #2228 and #2257; neither is covered by an open PR as far as I can tell.

### 1. `U+20EE` emits a macro that does not exist

`CHR` maps `U+20EE COMBINING LEFT ARROW BELOW` to `\underledtarrow`. That is not a LaTeX macro — the name is a scrambled `\underleftarrow`. The two neighbouring entries in the same table make the intent clear:

```python
"⃭": "\\underleftharpoondown{{{0}}}",
"⃮": "\\underledtarrow{{{0}}}",       # <-- here
"⃯": "\\underrightarrow{{{0}}}",
```

and `U+20D6`, the "above" counterpart, is already `\overleftarrow`.

The template is still well formed, so nothing raises and the conversion looks like it succeeded — the equation just carries an undefined control sequence that no renderer can typeset. The entry dates back to the original `dwml` table this module was adapted from.

### 2. Math italic `h` is the only Latin letter left untranslated

`T` normalizes the Mathematical Alphanumeric Symbols back to ASCII so equations come out as readable LaTeX. It walks `U+1D434`–`U+1D44D` for `A`–`Z` and `U+1D44E`–`U+1D467` for `a`–`z`, but math italic small h has no codepoint inside that block: `U+1D455` is permanently reserved, because Unicode unifies that letter with `U+210E PLANCK CONSTANT`. Following the contiguous range therefore skipped `h`, and it is the single letter of the alphabet that survives into the output.

An expression written with math italic codepoints:

| | output |
|---|---|
| before | `ℎ(x)=g(x)` |
| after | `h(x)=g(x)` |

### Tests

Added `packages/markitdown/tests/test_docx_math_symbols.py`. All five tests fail on `main` and pass with this change. One of them walks the entire math italic alphabet and asserts every letter round-trips to ASCII, so a future gap in that range cannot slip back in unnoticed.

```
5 passed
```

The rest of the suite is unaffected, and `black` reports no changes.
