### PR TITLE
Add resource-exhaustion guards for untrusted archives and URLs

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -59,6 +59,12 @@ PRIORITY_GENERIC_FILE_FORMAT = (
     10.0  # Near catch-all converters for mimetypes like text/*, etc.
 )
 
+# Defaults for fetching HTTP/HTTPS URIs, guarding against hanging or
+# unbounded responses from untrusted endpoints. Both can be overridden per
+# call via the "timeout" and "max_response_size" keyword arguments.
+DEFAULT_REQUESTS_TIMEOUT = 30  # seconds
+DEFAULT_MAX_RESPONSE_SIZE = 100 * 1024 * 1024  # 100 MB
+
 
 _plugins: Union[None, List[Any]] = None  # If None, plugins have not been loaded yet.
 
@@ -472,7 +478,11 @@ class MarkItDown:
             )
         # HTTP/HTTPS URIs
         elif uri.startswith("http:") or uri.startswith("https:"):
-            response = self._requests_session.get(uri, stream=True)
+            response = self._requests_session.get(
+                uri,
+                stream=True,
+                timeout=kwargs.get("timeout", DEFAULT_REQUESTS_TIMEOUT),
+            )
             response.raise_for_status()
             return self.convert_response(
                 response,
@@ -546,9 +556,27 @@ class MarkItDown:
             # Deprecated -- use stream_info
             base_guess = base_guess.copy_and_update(url=url)
 
-        # Read into BytesIO
+        # Read into BytesIO, refusing responses that exceed the size limit
+        max_response_size = kwargs.get("max_response_size", DEFAULT_MAX_RESPONSE_SIZE)
+
+        content_length = response.headers.get("content-length")
+        if (
+            content_length is not None
+            and content_length.isdigit()
+            and int(content_length) > max_response_size
+        ):
+            raise FileConversionException(
+                f"Response from {response.url} declares {content_length} bytes, which exceeds the maximum supported size ({max_response_size} bytes)."
+            )
+
         buffer = io.BytesIO()
+        total_read = 0
         for chunk in response.iter_content(chunk_size=512):
+            total_read += len(chunk)
+            if total_read > max_response_size:
+                raise FileConversionException(
+                    f"Response from {response.url} exceeded the maximum supported size ({max_response_size} bytes)."
+                )
             buffer.write(chunk)
         buffer.seek(0)
 

--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -2,7 +2,7 @@ import zipfile
 import io
 import os
 
-from typing import BinaryIO, Any, TYPE_CHECKING
+from typing import BinaryIO, Any, List, TYPE_CHECKING
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
@@ -17,6 +17,18 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ]
 
 ACCEPTED_FILE_EXTENSIONS = [".zip"]
+
+# Safety limits applied when extracting untrusted archives, guarding against
+# decompression bombs. Each limit can be overridden per conversion via the
+# corresponding keyword argument (e.g., convert(..., zip_max_members=500)).
+DEFAULT_MAX_MEMBERS = 10000
+DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE = 500 * 1024 * 1024  # 500 MB
+DEFAULT_MAX_COMPRESSION_RATIO = 100.0
+
+# The compression ratio check only applies to members whose declared
+# uncompressed size exceeds this floor. Smaller members are cheap to extract
+# regardless of ratio, and small files can legitimately compress very well.
+COMPRESSION_RATIO_MIN_MEMBER_SIZE = 1024 * 1024  # 1 MB
 
 
 class ZipConverter(DocumentConverter):
@@ -56,6 +68,14 @@ class ZipConverter(DocumentConverter):
     - Uses appropriate converters for each file type
     - Preserves formatting of converted content
     - Cleans up temporary files after processing
+
+    Resource limits for untrusted archives (configurable via keyword arguments):
+    - zip_max_members: maximum number of archive members (default 10000)
+    - zip_max_total_uncompressed_size: maximum cumulative uncompressed bytes
+      (default 500 MB)
+    - zip_max_compression_ratio: maximum per-member compression ratio for
+      members larger than 1 MB (default 100)
+    Archives exceeding these limits fail with a FileConversionException.
     """
 
     def __init__(
@@ -90,13 +110,64 @@ class ZipConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
+        max_members = kwargs.get("zip_max_members", DEFAULT_MAX_MEMBERS)
+        max_total_uncompressed_size = kwargs.get(
+            "zip_max_total_uncompressed_size", DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE
+        )
+        max_compression_ratio = kwargs.get(
+            "zip_max_compression_ratio", DEFAULT_MAX_COMPRESSION_RATIO
+        )
+
         file_path = stream_info.url or stream_info.local_path or stream_info.filename
         md_content = f"Content from the zip file `{file_path}`:\n\n"
 
         with zipfile.ZipFile(file_stream, "r") as zipObj:
-            for name in zipObj.namelist():
+            infos = zipObj.infolist()
+            if len(infos) > max_members:
+                raise FileConversionException(
+                    f"ZIP archive contains {len(infos)} members, which exceeds the maximum supported ({max_members})."
+                )
+
+            total_uncompressed_size = 0
+            for info in infos:
+                name = info.filename
+
+                # Fast-fail on members with an extreme compression ratio
+                if (
+                    info.file_size > COMPRESSION_RATIO_MIN_MEMBER_SIZE
+                    and info.file_size / max(info.compress_size, 1)
+                    > max_compression_ratio
+                ):
+                    raise FileConversionException(
+                        f"ZIP member '{name}' has a compression ratio of {info.file_size / max(info.compress_size, 1):.0f}:1, which exceeds the maximum supported ({max_compression_ratio}:1)."
+                    )
+
+                # Fast-fail if the declared sizes alone exceed the budget
+                if (
+                    total_uncompressed_size + info.file_size
+                    > max_total_uncompressed_size
+                ):
+                    raise FileConversionException(
+                        f"Extracting ZIP member '{name}' would exceed the maximum supported total uncompressed size ({max_total_uncompressed_size} bytes)."
+                    )
+
+                # Read the member in chunks, tracking the actual decompressed
+                # size, since header sizes in crafted archives cannot be trusted
+                chunks: List[bytes] = []
+                with zipObj.open(info) as z_file:
+                    while True:
+                        chunk = z_file.read(65536)
+                        if not chunk:
+                            break
+                        total_uncompressed_size += len(chunk)
+                        if total_uncompressed_size > max_total_uncompressed_size:
+                            raise FileConversionException(
+                                f"ZIP archive exceeded the maximum supported total uncompressed size ({max_total_uncompressed_size} bytes) while extracting '{name}'."
+                            )
+                        chunks.append(chunk)
+
                 try:
-                    z_file_stream = io.BytesIO(zipObj.read(name))
+                    z_file_stream = io.BytesIO(b"".join(chunks))
                     z_file_stream_info = StreamInfo(
                         extension=os.path.splitext(name)[1],
                         filename=os.path.basename(name),

--- a/packages/markitdown/tests/test_resource_guards.py
+++ b/packages/markitdown/tests/test_resource_guards.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3 -m pytest
 """Tests for resource-exhaustion guards when converting untrusted input.
 
-Verifies that ZipConverter refuses archives with too many members,
-excessive total uncompressed size, or extreme per-member compression ratios.
+Verifies that:
+- ZipConverter refuses archives with too many members, excessive total
+  uncompressed size, or extreme per-member compression ratios.
+- URL fetches apply an explicit timeout and refuse oversized responses.
 """
 
 import io
 import zipfile
 
 import pytest
+import requests
+
+from unittest.mock import MagicMock
 
 from markitdown import (
     MarkItDown,
@@ -82,3 +87,84 @@ class TestZipConverterGuards:
         result = _convert_zip(markitdown, archive)
 
         assert "Sample text for resource guard tests." in result.markdown
+
+
+def _mock_response(chunks, headers=None, url="https://example.com/file.txt"):
+    """Build a mock requests.Response streaming the given chunks."""
+    response = MagicMock(spec=requests.Response)
+    response.headers = headers or {}
+    response.url = url
+    response.raise_for_status = MagicMock()
+    response.iter_content = MagicMock(return_value=iter(chunks))
+    return response
+
+
+class TestUrlFetchGuards:
+    """URL fetches apply an explicit timeout and a response size limit."""
+
+    def test_default_timeout_applied(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_response([b"Hello from the mock server."])
+        markitdown = MarkItDown(requests_session=session)
+
+        result = markitdown.convert("https://example.com/file.txt")
+
+        session.get.assert_called_once_with(
+            "https://example.com/file.txt", stream=True, timeout=30
+        )
+        assert "Hello from the mock server." in result.markdown
+
+    def test_custom_timeout_applied(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_response([b"Hello from the mock server."])
+        markitdown = MarkItDown(requests_session=session)
+
+        markitdown.convert("https://example.com/file.txt", timeout=5)
+
+        session.get.assert_called_once_with(
+            "https://example.com/file.txt", stream=True, timeout=5
+        )
+
+    def test_timeout_error_surfaces(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.Timeout("Connection timed out")
+        markitdown = MarkItDown(requests_session=session)
+
+        with pytest.raises(requests.Timeout):
+            markitdown.convert("https://example.com/file.txt")
+
+    def test_content_length_over_limit_rejected(self):
+        session = MagicMock(spec=requests.Session)
+        response = _mock_response(
+            [b"x" * 512],
+            headers={"content-length": str(200 * 1024 * 1024)},
+        )
+        session.get.return_value = response
+        markitdown = MarkItDown(requests_session=session)
+
+        with pytest.raises(FileConversionException, match="maximum supported size"):
+            markitdown.convert("https://example.com/file.txt")
+
+        # The body is never streamed when the declared length is over the limit
+        response.iter_content.assert_not_called()
+
+    def test_streaming_over_limit_aborted(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_response([b"x" * 512] * 4)
+        markitdown = MarkItDown(requests_session=session)
+
+        with pytest.raises(FileConversionException, match="maximum supported size"):
+            markitdown.convert("https://example.com/file.txt", max_response_size=1024)
+
+    def test_response_at_limit_converts(self):
+        text_chunk = (b"Hello world. " * 44)[:512]
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_response([text_chunk, text_chunk])
+        markitdown = MarkItDown(requests_session=session)
+
+        # Exactly 1024 bytes is allowed when the limit is 1024
+        result = markitdown.convert(
+            "https://example.com/file.txt", max_response_size=1024
+        )
+
+        assert "Hello world." in result.markdown

--- a/packages/markitdown/tests/test_resource_guards.py
+++ b/packages/markitdown/tests/test_resource_guards.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for resource-exhaustion guards when converting untrusted input.
+
+Verifies that ZipConverter refuses archives with too many members,
+excessive total uncompressed size, or extreme per-member compression ratios.
+"""
+
+import io
+import zipfile
+
+import pytest
+
+from markitdown import (
+    MarkItDown,
+    StreamInfo,
+    FileConversionException,
+)
+
+
+def _make_zip(members, compression=zipfile.ZIP_DEFLATED):
+    """Build an in-memory ZIP archive from a {name: bytes} mapping."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=compression) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    buffer.seek(0)
+    return buffer
+
+
+def _convert_zip(markitdown, zip_stream, **kwargs):
+    return markitdown.convert_stream(
+        zip_stream,
+        stream_info=StreamInfo(extension=".zip", mimetype="application/zip"),
+        **kwargs,
+    )
+
+
+class TestZipConverterGuards:
+    """ZipConverter refuses archives that exceed resource limits."""
+
+    def test_member_count_limit(self):
+        markitdown = MarkItDown()
+        archive = _make_zip({f"file_{i}.txt": b"hello" for i in range(3)})
+
+        with pytest.raises(FileConversionException, match="members"):
+            _convert_zip(markitdown, archive, zip_max_members=2)
+
+    def test_compression_ratio_limit(self):
+        markitdown = MarkItDown()
+        # 2 MB of zeros compresses to ~2 KB (a ratio of roughly 1000:1)
+        archive = _make_zip({"zeros.bin": b"\x00" * (2 * 1024 * 1024)})
+        assert archive.getbuffer().nbytes < 100 * 1024
+
+        with pytest.raises(FileConversionException, match="compression ratio"):
+            _convert_zip(markitdown, archive)
+
+    def test_small_compressible_members_allowed(self):
+        # Members below the ratio-check floor compress well legitimately
+        markitdown = MarkItDown()
+        archive = _make_zip({"small.txt": b"a" * 4096})
+
+        result = _convert_zip(markitdown, archive)
+
+        assert "a" * 100 in result.markdown
+
+    def test_total_uncompressed_size_limit(self):
+        markitdown = MarkItDown()
+        archive = _make_zip(
+            {
+                "a.txt": b"a" * 600,
+                "b.txt": b"b" * 600,
+            }
+        )
+
+        with pytest.raises(FileConversionException, match="total uncompressed size"):
+            _convert_zip(markitdown, archive, zip_max_total_uncompressed_size=1024)
+
+    def test_normal_archive_converts(self):
+        markitdown = MarkItDown()
+        archive = _make_zip({"notes.txt": b"Sample text for resource guard tests."})
+
+        result = _convert_zip(markitdown, archive)
+
+        assert "Sample text for resource guard tests." in result.markdown


### PR DESCRIPTION
## Problem

When converting untrusted input, two code paths allow unbounded resource consumption:

1. `ZipConverter` extracts every archive member into memory with no limits on member count, total uncompressed size, or compression ratio. A small crafted archive (a zip bomb, including nested archives processed recursively) can expand into gigabytes of memory and CPU work.
2. `convert_uri()` fetches remote content with no explicit timeout, and `convert_response()` buffers the entire response body with no size cap. A slow or endless endpoint can hang a conversion indefinitely or stream unbounded data into memory.

## Changes

**ZipConverter guards** (`_zip_converter.py`), each overridable per conversion via keyword arguments:

- `zip_max_members` (default 10000): maximum number of archive members
- `zip_max_total_uncompressed_size` (default 500 MB): enforced against declared sizes up front, and against actual bytes read during chunked extraction, since header sizes in crafted archives cannot be trusted
- `zip_max_compression_ratio` (default 100): per-member ratio check, applied only to members larger than 1 MB so small legitimately compressible files are not affected

Archives exceeding a limit fail with a `FileConversionException` describing the violated limit.

**URL fetch guards** (`_markitdown.py`):

- Explicit timeout passed to `requests` (default 30 seconds, overridable via the `timeout` keyword argument); `requests.Timeout` surfaces on slow endpoints
- `max_response_size` (default 100 MB, overridable via keyword argument): fast-fail on oversized `Content-Length` headers, and streaming reads abort past the limit with a `FileConversionException`

Defaults are conservative but chosen so normal documents are unaffected; the existing `test_files.zip` vector and the existing module tests pass unchanged.

## Tests

New `tests/test_resource_guards.py` (11 tests, no live network; HTTP is mocked):

- Zip: member count, compression ratio, and total size limits each reject crafted archives; small compressible members and normal archives still convert
- URL: default and custom timeout plumbed through to `session.get`; timeout errors surface; oversized `Content-Length` rejected before streaming; streaming past the limit aborts; a response exactly at the limit still converts

The guard tests were verified to fail without the source changes (revert-test), and `test_module_vectors.py` plus `test_module_misc.py` pass.

Refs #1514 and #1167.

Made with [Cursor](https://cursor.com)