### PR TITLE
fix(rss): preserve Atom XHTML content

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -28,6 +28,8 @@ CANDIDATE_FILE_EXTENSIONS = [
     ".xml",
 ]
 
+XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml"
+
 
 class RssConverter(DocumentConverter):
     """Convert RSS / Atom type to markdown"""
@@ -148,10 +150,26 @@ class RssConverter(DocumentConverter):
             return self._get_data_by_tag_name(entry, tag_name)
 
         return "".join(
-            child.toxml()
+            self._localize_xhtml_names(child.cloneNode(True)).toxml()
             for child in node.childNodes
             if child.nodeType == Node.ELEMENT_NODE
         )
+
+    def _localize_xhtml_names(self, node: Node) -> Node:
+        """Rewrite prefixed XHTML element names to their local HTML names.
+
+        Atom permits XHTML content to be namespace-prefixed (e.g. ``x:strong``).
+        The downstream HTML converter dispatches on HTML tag names, so the
+        prefix has to be dropped or the element is treated as an unknown tag
+        and its formatting is lost.
+        """
+        if node.nodeType == Node.ELEMENT_NODE:
+            if node.prefix and node.namespaceURI == XHTML_NAMESPACE:
+                node.tagName = node.nodeName = node.localName
+                node.prefix = None
+            for child in node.childNodes:
+                self._localize_xhtml_names(child)
+        return node
 
     def _parse_rss_type(
         self, doc: Document, *, strict: bool = False

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -1,4 +1,5 @@
 from defusedxml import minidom
+from xml.dom import Node
 from xml.dom.minidom import Document, Element
 from typing import BinaryIO, Any, Union
 from bs4 import BeautifulSoup
@@ -112,9 +113,9 @@ class RssConverter(DocumentConverter):
             md_text += f"{subtitle}\n"
         for entry in entries:
             entry_title = self._get_data_by_tag_name(entry, "title")
-            entry_summary = self._get_data_by_tag_name(entry, "summary")
+            entry_summary = self._get_atom_content(entry, "summary")
             entry_updated = self._get_data_by_tag_name(entry, "updated")
-            entry_content = self._get_data_by_tag_name(entry, "content")
+            entry_content = self._get_atom_content(entry, "content")
 
             if entry_title:
                 md_text += f"\n## {entry_title}\n"
@@ -128,6 +129,21 @@ class RssConverter(DocumentConverter):
         return DocumentConverterResult(
             markdown=md_text,
             title=title,
+        )
+
+    def _get_atom_content(self, entry: Element, tag_name: str) -> Union[str, None]:
+        nodes = entry.getElementsByTagName(tag_name)
+        if not nodes:
+            return None
+
+        node = nodes[0]
+        if node.getAttribute("type").lower() != "xhtml":
+            return self._get_data_by_tag_name(entry, tag_name)
+
+        return "".join(
+            child.toxml()
+            for child in node.childNodes
+            if child.nodeType == Node.ELEMENT_NODE
         )
 
     def _parse_rss_type(self, doc: Document) -> DocumentConverterResult:

--- a/packages/markitdown/tests/test_rss_converter.py
+++ b/packages/markitdown/tests/test_rss_converter.py
@@ -48,3 +48,27 @@ def test_atom_xhtml_summary_is_preserved() -> None:
 
     assert "A *structured* summary." in result.markdown
     assert "Plain text content." in result.markdown
+
+
+def test_atom_prefixed_xhtml_content_is_preserved() -> None:
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:x="http://www.w3.org/1999/xhtml">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <content type="xhtml">
+      <x:div>
+        <x:p>Hello <x:strong>bold</x:strong> and <x:em>italic</x:em>.</x:p>
+        <x:a href="https://example.com">link</x:a>
+      </x:div>
+    </content>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "Hello **bold** and *italic*." in result.markdown
+    assert "[link](https://example.com)" in result.markdown

--- a/packages/markitdown/tests/test_rss_converter.py
+++ b/packages/markitdown/tests/test_rss_converter.py
@@ -1,0 +1,50 @@
+import io
+
+from markitdown import StreamInfo
+from markitdown.converters import RssConverter
+
+
+def test_atom_xhtml_content_is_preserved() -> None:
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <content type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>Read the <strong>important details</strong>.</p>
+      </div>
+    </content>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "Read the **important details**." in result.markdown
+
+
+def test_atom_xhtml_summary_is_preserved() -> None:
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <summary type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>A <em>structured</em> summary.</p>
+      </div>
+    </summary>
+    <content type="text">Plain text content.</content>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "A *structured* summary." in result.markdown
+    assert "Plain text content." in result.markdown


### PR DESCRIPTION
## What

Preserve structured Atom `summary` and `content` elements whose `type` is `xhtml`. Their child XHTML is now serialized and passed through the existing HTML-to-Markdown conversion path, while plain text and escaped HTML entries keep their current behavior.

## Why

Atom allows XHTML content as child elements rather than character data. The existing helper only returned the first text/CDATA child, so valid `type="xhtml"` summaries and content were silently dropped from converted feeds. This loses the most important part of many entries for downstream LLM and indexing workflows.

## Validation

- New regression tests reproduce the loss on `main` and cover XHTML `summary`, XHTML `content`, and unchanged plain-text content behavior (2 passed)
- Existing RSS/Atom vector coverage: 7 passed
- Black check: passed
- mypy for the changed source and tests: passed
- `git diff --check`: passed

I also ran the wider vector file in the minimal environment: 63 cases passed; 48 optional-format cases could not run because DOCX/XLSX/PDF/PPTX and related extras were not installed.