### PR TITLE
feat: add sub-sheet selection for Excel files

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -138,6 +138,24 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "--list-sheets",
+        action="store_true",
+        help="List all available sub-sheets in the Excel file and exit.",
+    )
+
+    parser.add_argument(
+        "--sheet",
+        action="append",
+        help="Specify a sub-sheet to convert. Can be used multiple times.",
+    )
+
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Interactively select sub-sheets to convert.",
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
@@ -249,10 +267,18 @@ def main():
             sys.stdin.buffer,
             stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
+            list_sheets=args.list_sheets,
+            sheet_selection=args.sheet,
+            interactive=args.interactive,
         )
     else:
         result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
+            args.filename, 
+            stream_info=stream_info, 
+            keep_data_uris=args.keep_data_uris,
+            list_sheets=args.list_sheets,
+            sheet_selection=args.sheet,
+            interactive=args.interactive,
         )
 
     _handle_output(args, result)

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -80,7 +80,51 @@ class XlsxConverter(DocumentConverter):
                 _xlsx_dependency_exc_info[2]
             )
 
-        sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
+        excel_file = pd.ExcelFile(file_stream, engine="openpyxl")
+        sheet_names = excel_file.sheet_names
+
+        # Handle --list-sheets
+        if kwargs.get("list_sheets"):
+            print("Available sheets:")
+            for i, sheet in enumerate(sheet_names):
+                print(f"  {i+1}. {sheet}")
+            return DocumentConverterResult(markdown="")
+            
+        # Handle --interactive
+        sheet_selection = kwargs.get("sheet_selection") or []
+        if kwargs.get("interactive"):
+            print("Available sheets:")
+            for i, sheet in enumerate(sheet_names):
+                print(f"  {i+1}. {sheet}")
+            
+            selection = input("Enter the numbers or names of the sheets to convert (comma-separated), or press Enter for all: ")
+            if selection.strip():
+                sheet_selection = []
+                for s in selection.split(","):
+                    s = s.strip()
+                    if s.isdigit():
+                        idx = int(s) - 1
+                        if 0 <= idx < len(sheet_names):
+                            sheet_selection.append(sheet_names[idx])
+                        else:
+                            raise ValueError(f"Invalid sheet number: {s}")
+                    else:
+                        if s in sheet_names:
+                            sheet_selection.append(s)
+                        else:
+                            raise ValueError(f"Invalid sheet name: {s}")
+
+        # Ensure sheet_selection contains valid sheets
+        sheets_to_read = sheet_selection if sheet_selection else sheet_names
+        for s in sheets_to_read:
+            if s not in sheet_names:
+                raise ValueError(f"Sheet not found: {s}")
+
+        sheets = pd.read_excel(excel_file, sheet_name=sheets_to_read)
+        if not isinstance(sheets, dict):
+            # Fallback if pandas returns a single DataFrame
+            sheets = {sheets_to_read[0]: sheets}
+
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
@@ -142,7 +186,51 @@ class XlsConverter(DocumentConverter):
                 _xls_dependency_exc_info[2]
             )
 
-        sheets = pd.read_excel(file_stream, sheet_name=None, engine="xlrd")
+        excel_file = pd.ExcelFile(file_stream, engine="xlrd")
+        sheet_names = excel_file.sheet_names
+
+        # Handle --list-sheets
+        if kwargs.get("list_sheets"):
+            print("Available sheets:")
+            for i, sheet in enumerate(sheet_names):
+                print(f"  {i+1}. {sheet}")
+            return DocumentConverterResult(markdown="")
+            
+        # Handle --interactive
+        sheet_selection = kwargs.get("sheet_selection") or []
+        if kwargs.get("interactive"):
+            print("Available sheets:")
+            for i, sheet in enumerate(sheet_names):
+                print(f"  {i+1}. {sheet}")
+            
+            selection = input("Enter the numbers or names of the sheets to convert (comma-separated), or press Enter for all: ")
+            if selection.strip():
+                sheet_selection = []
+                for s in selection.split(","):
+                    s = s.strip()
+                    if s.isdigit():
+                        idx = int(s) - 1
+                        if 0 <= idx < len(sheet_names):
+                            sheet_selection.append(sheet_names[idx])
+                        else:
+                            raise ValueError(f"Invalid sheet number: {s}")
+                    else:
+                        if s in sheet_names:
+                            sheet_selection.append(s)
+                        else:
+                            raise ValueError(f"Invalid sheet name: {s}")
+
+        # Ensure sheet_selection contains valid sheets
+        sheets_to_read = sheet_selection if sheet_selection else sheet_names
+        for s in sheets_to_read:
+            if s not in sheet_names:
+                raise ValueError(f"Sheet not found: {s}")
+
+        sheets = pd.read_excel(excel_file, sheet_name=sheets_to_read)
+        if not isinstance(sheets, dict):
+            # Fallback if pandas returns a single DataFrame
+            sheets = {sheets_to_read[0]: sheets}
+
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"

--- a/packages/markitdown/tests/test_cu_converter.py
+++ b/packages/markitdown/tests/test_cu_converter.py
@@ -18,7 +18,6 @@ from markitdown.converters._cu_converter import (
     _detect_file_type,
     _canonical_mime_type,
     _content_type_for,
-    _EXTENSION_MAP,
 )
 from markitdown._stream_info import StreamInfo
 
@@ -898,7 +897,12 @@ class TestCLIArgs:
             ],
         )
         markitdown_instance.convert.assert_called_once_with(
-            "fake.pdf", stream_info=None, keep_data_uris=False
+            "fake.pdf",
+            stream_info=None,
+            keep_data_uris=False,
+            list_sheets=False,
+            sheet_selection=None,
+            interactive=False,
         )
         assert capsys.readouterr().out == "converted\n"
 


### PR DESCRIPTION
This pull request enhances the Excel file conversion capabilities in the `markitdown` package by introducing new options for handling Excel sub-sheets. Users can now list available sheets, specify sheets to convert, or interactively select sheets. The changes also ensure that these options are integrated throughout the CLI, conversion logic, and tests.

**Excel sub-sheet selection and listing enhancements:**

* Added new CLI arguments in `__main__.py` to allow users to list available sheets (`--list-sheets`), specify sheets to convert (`--sheet`), or interactively select sheets (`--interactive`).
* Updated the call to `markitdown.convert` to pass the new arguments (`list_sheets`, `sheet_selection`, and `interactive`) from the CLI to the converter logic.

**Conversion logic updates:**

* Refactored both XLSX and XLS converters to:
  * Use `pd.ExcelFile` for improved sheet handling,
  * Print available sheets and exit if `--list-sheets` is used,
  * Prompt the user for sheet selection if `--interactive` is used,
  * Validate selected sheets and only convert those specified,
  * Handle both single and multiple sheet conversions robustly. [[1]](diffhunk://#diff-fdd53518a19ed934c930e2b537bf408e56c312f38c8a58cdc9f7d9f4d42d65daL83-R127) [[2]](diffhunk://#diff-fdd53518a19ed934c930e2b537bf408e56c312f38c8a58cdc9f7d9f4d42d65daL145-R233)

**Testing updates:**

* Updated tests to account for the new arguments passed to `markitdown.convert`, ensuring that the CLI wiring is correct.

**Code cleanup:**

* Removed an unused import from the test file.