### PR TITLE
fix: use sys.executable in CLI tests, handle optional dependencies in pptx test, and cleanup youtube converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_youtube_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_youtube_converter.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlparse, unquote
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
+from .._exceptions import FileConversionException
 
 # Optional YouTube transcription support
 try:
@@ -113,7 +114,6 @@ class YouTubeConverter(DocumentConverter):
                     break
         except Exception as e:
             print(f"Error extracting description: {e}")
-            pass
 
         # Start preparing the page
         webpage_text = "# YouTube\n"
@@ -218,7 +218,7 @@ class YouTubeConverter(DocumentConverter):
         elif isinstance(json, dict):
             for k, v in json.items():
                 if k == key:
-                    return json[k]
+                    return v
                 if result := self._findKey(v, key):
                     return result
         return None
@@ -235,4 +235,4 @@ class YouTubeConverter(DocumentConverter):
                     time.sleep(delay)  # Wait before retrying
                 attempt += 1
         # If all attempts fail, raise the last exception
-        raise Exception(f"Operation failed after {retries} attempts.")
+        raise FileConversionException(f"Operation failed after {retries} attempts.")

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3 -m pytest
 import subprocess
+import sys
+
 from markitdown import __version__
 
 # This file contains CLI tests that are not directly tested by the FileTestVectors.
@@ -8,7 +10,9 @@ from markitdown import __version__
 
 def test_version() -> None:
     result = subprocess.run(
-        ["python", "-m", "markitdown", "--version"], capture_output=True, text=True
+        [sys.executable, "-m", "markitdown", "--version"],
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 0, f"CLI exited with error: {result.stderr}"
@@ -17,7 +21,9 @@ def test_version() -> None:
 
 def test_invalid_flag() -> None:
     result = subprocess.run(
-        ["python", "-m", "markitdown", "--foobar"], capture_output=True, text=True
+        [sys.executable, "-m", "markitdown", "--foobar"],
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode != 0, f"CLI exited with error: {result.stderr}"

--- a/packages/markitdown/tests/test_pptx_svg.py
+++ b/packages/markitdown/tests/test_pptx_svg.py
@@ -10,12 +10,16 @@ the SVG. When a picture has no raster fallback the ``<a:blip>`` has no
 """
 import os
 
-from lxml import etree
-from pptx import Presentation
-from pptx.enum.shapes import MSO_SHAPE_TYPE
+import pytest
 
+pptx = pytest.importorskip("pptx")
+lxml = pytest.importorskip("lxml")
+
+from lxml import etree
 from markitdown import MarkItDown
 from markitdown.converters._pptx_converter import PptxConverter
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 


### PR DESCRIPTION
### Summary
1. **CLI Tests**: Replace hardcoded `"python"` string in subprocess calls with `sys.executable` to ensure tests run against the active Python environment.
2. **PPTX SVG Test**: Add `pytest.importorskip` for optional dependencies (`pptx`, `lxml`) in `test_pptx_svg.py` to prevent test collection failures when optional extras are not installed.
3. **YouTube Converter**: Replace redundant dictionary lookup `json[k]` with `v` in `_findKey()`, remove unnecessary `pass` statement, and raise specific `FileConversionException` instead of generic `Exception`.

### Validation
- `pytest packages/markitdown/tests/test_cli_misc.py packages/markitdown/tests/test_pptx_svg.py` -> All tests passed!