### PR TITLE
Add context-cost badge to markitdown-mcp (64 tokens — leanest of 57 measured servers)

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -1,5 +1,7 @@
 # MarkItDown-MCP
 
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fmarkitdown.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
+
 > [!IMPORTANT]
 > The MarkItDown-MCP package is meant for **local use**, with local trusted agents. In particular, when running the MCP server with Streamable HTTP or SSE, it binds to `localhost` by default, and is not exposed to other machines on the network or Internet. In this configuration, it is meant to be a direct alternative to the STDIO transport, which may be more convenient in some cases. DO NOT bind the server to other interfaces unless you understand the [security implications](#security-considerations) of doing so.
 


### PR DESCRIPTION
One line in the markitdown-mcp README: a shields.io badge showing what the server's tool schemas cost in context tokens — currently **64 tokens for its single `convert_to_markdown` tool** (measured 2026-08-16). That makes it literally the leanest of the 57 popular MCP servers we measured (median: 2,636; heaviest: 54,422) — a number worth wearing.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; it links to a reproducible methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from [results/markitdown/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/markitdown/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).