### PR TITLE
Warn when PDF LLM OCR fails

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pdf_converter_with_ocr.py
@@ -5,6 +5,7 @@ Extracts images from PDFs and performs OCR while maintaining document context.
 
 import io
 import sys
+import warnings
 from typing import Any, BinaryIO, Optional
 
 from markitdown import DocumentConverter, DocumentConverterResult, StreamInfo
@@ -239,6 +240,8 @@ class PdfConverterWithOCR(DocumentConverter):
                                 ocr_result = ocr_service.extract_text(
                                     img_info["stream"]
                                 )
+                                if ocr_result.error:
+                                    warnings.warn(f"LLM OCR failed: {ocr_result.error}")
                                 if ocr_result.text.strip():
                                     image_data.append(
                                         {
@@ -369,6 +372,8 @@ class PdfConverterWithOCR(DocumentConverter):
                         # Run OCR
                         ocr_result = ocr_service.extract_text(img_stream)
 
+                        if ocr_result.error:
+                            warnings.warn(f"LLM OCR failed: {ocr_result.error}")
                         if ocr_result.text.strip():
                             text = ocr_result.text.strip()
                             markdown_parts.append(f"*[Image OCR]\n{text}\n[End OCR]*")
@@ -402,6 +407,8 @@ class PdfConverterWithOCR(DocumentConverter):
 
                         ocr_result = ocr_service.extract_text(img_stream)
 
+                        if ocr_result.error:
+                            warnings.warn(f"LLM OCR failed: {ocr_result.error}")
                         if ocr_result.text.strip():
                             text = ocr_result.text.strip()
                             markdown_parts.append(f"*[Image OCR]\n{text}\n[End OCR]*")


### PR DESCRIPTION
## Summary

- Warn when PDF OCR returns an `OCRResult.error`.
- Cover embedded-image OCR and both full-page OCR rendering paths.
- Preserve the existing behavior of continuing conversion after an OCR failure.

## Motivation

`LLMVisionOCRService.extract_text()` catches client and API exceptions and returns them through `OCRResult.error`. `PdfConverterWithOCR` previously checked only `OCRResult.text`, making configuration errors, incompatible clients, unavailable models, and API failures indistinguishable from OCR producing no text.

Fixes #2313