### PR TITLE
Fix percent-encoded Windows drive paths in file URIs

### DIFF
--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -12,7 +12,10 @@ def file_uri_to_path(file_uri: str) -> Tuple[str | None, str]:
         raise ValueError(f"Not a file URL: {file_uri}")
 
     netloc = parsed.netloc if parsed.netloc else None
-    path = os.path.abspath(url2pathname(parsed.path))
+    path = url2pathname(parsed.path)
+    if os.name == "nt" and path[:1] in "/\\" and path[2:3] == ":":
+        path = path[1:]
+    path = os.path.abspath(path)
     return netloc, path
 
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -261,7 +261,10 @@ def test_file_uris() -> None:
 def test_file_uri_with_percent_encoded_windows_drive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from nturl2path import url2pathname as windows_url2pathname
+
     monkeypatch.setattr(uri_utils, "os", SimpleNamespace(name="nt", path=ntpath))
+    monkeypatch.setattr(uri_utils, "url2pathname", windows_url2pathname)
 
     netloc, path = uri_utils.file_uri_to_path("file:///C%3A/Temp/example.md")
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3 -m pytest
 import io
+import ntpath
 import os
 import re
 import shutil
+from types import SimpleNamespace
 import pytest
 from unittest.mock import MagicMock
 
+import markitdown._uri_utils as uri_utils
 from markitdown._uri_utils import parse_data_uri, file_uri_to_path
 
 from markitdown import (
@@ -250,6 +253,17 @@ def test_file_uris() -> None:
     netloc, path = file_uri_to_path(file_uri)
     assert netloc is None
     assert path == "/path/to/file.txt"
+
+
+def test_file_uri_with_percent_encoded_windows_drive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(uri_utils, "os", SimpleNamespace(name="nt", path=ntpath))
+
+    netloc, path = uri_utils.file_uri_to_path("file:///C%3A/Temp/example.md")
+
+    assert netloc is None
+    assert path == r"C:\Temp\example.md"
 
 
 def test_docx_comments() -> None:


### PR DESCRIPTION
## Summary

Fix percent-encoded Windows drive separators in `file:` URIs so paths such as `file:///C%3A/Temp/example.md` resolve to `C:\Temp\example.md` instead of retaining a leading separator that causes the current drive to be prepended again.

`url2pathname()` checks for a DOS drive before percent-decoding the path. When the colon is encoded, that check misses the drive and leaves a leading separator in the decoded Windows path. The conversion now removes that separator only when the decoded path has Windows drive syntax; POSIX and UNC paths are unchanged.

A platform-independent regression test emulates Windows path handling and verifies the encoded URI result.

Fixes #2208

## Test plan

- `hatch test` — 337 passed, 4 skipped
- `hatch run types:check src/markitdown/_uri_utils.py tests/test_module_misc.py`
- `pre-commit run --all-files`
