### PR TITLE
fix(cli): allow Content Understanding conversion from stdin

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -216,8 +216,6 @@ def main():
             _exit_with_error(
                 "Content Understanding Endpoint (--cu-endpoint) is required when using --use-cu."
             )
-        elif args.filename is None:
-            _exit_with_error("Filename is required when using Content Understanding.")
 
         cu_kwargs: Dict[str, Any] = {
             "cu_endpoint": args.cu_endpoint,

--- a/packages/markitdown/tests/test_cu_converter.py
+++ b/packages/markitdown/tests/test_cu_converter.py
@@ -902,6 +902,41 @@ class TestCLIArgs:
         )
         assert capsys.readouterr().out == "converted\n"
 
+    def test_use_cu_reads_from_stdin(self, capsys):
+        """--use-cu should preserve the CLI's filename-optional stdin mode."""
+        import markitdown.__main__ as markitdown_cli
+
+        input_buffer = io.BytesIO(b"fake pdf")
+        stdin = MagicMock(buffer=input_buffer)
+        markitdown_instance = MagicMock()
+        markitdown_instance.convert_stream.return_value.markdown = "converted"
+        markitdown_cls = MagicMock(return_value=markitdown_instance)
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "markitdown",
+                "--use-cu",
+                "--cu-endpoint",
+                "https://fake-cu",
+            ],
+        ), patch.object(sys, "stdin", stdin), patch.object(
+            markitdown_cli, "MarkItDown", markitdown_cls
+        ):
+            markitdown_cli.main()
+
+        markitdown_cls.assert_called_once_with(
+            enable_plugins=False,
+            cu_endpoint="https://fake-cu",
+        )
+        markitdown_instance.convert_stream.assert_called_once_with(
+            input_buffer,
+            stream_info=None,
+            keep_data_uris=False,
+        )
+        assert capsys.readouterr().out == "converted\n"
+
 
 # ---------------------------------------------------------------------------
 # MissingDependencyException test


### PR DESCRIPTION
## Summary

- preserve the CLI's filename-optional stdin mode when `--use-cu` is enabled
- let piped input use the existing `convert_stream()` dispatch path
- add a regression test for Content Understanding stdin routing

## Problem

The CLI documents piping input without a filename, but the `--use-cu` branch exits before reaching the shared stdin path. Content Understanding analyzes binary input and does not require a local file path, so this guard unnecessarily prevents `cat report.pdf | markitdown --use-cu --cu-endpoint ...`.

The endpoint validation remains unchanged, and filename-based conversion is unaffected.

## Tests

- `hatch test tests/test_cu_converter.py tests/test_cli_misc.py -q` — 127 passed
- `hatch test -q` — 337 passed, 4 skipped
- Black 23.7.0 on both changed files — passed

OpenAI Codex assisted with identifying the inconsistent CLI branch and preparing the focused regression test; the behavior and test results were verified locally.
