### PR TITLE
Fix five small converter correctness bugs (data URIs, RSS, zip, plaintext, CLI)

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -264,12 +264,10 @@ def _handle_output(args, result: DocumentConverterResult):
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(result.markdown)
     else:
-        # Handle stdout encoding errors more gracefully
-        print(
-            result.markdown.encode(sys.stdout.encoding, errors="replace").decode(
-                sys.stdout.encoding
-            )
-        )
+        # Handle stdout encoding errors more gracefully. sys.stdout.encoding can
+        # be None for some redirected/embedded streams, so fall back to UTF-8.
+        encoding = sys.stdout.encoding or "utf-8"
+        print(result.markdown.encode(encoding, errors="replace").decode(encoding))
 
 
 def _exit_with_error(message: str):

--- a/packages/markitdown/src/markitdown/_uri_utils.py
+++ b/packages/markitdown/src/markitdown/_uri_utils.py
@@ -47,6 +47,11 @@ def parse_data_uri(uri: str) -> Tuple[str | None, Dict[str, str], bytes]:
         elif len(part) > 0:
             attributes[part] = ""
 
-    content = base64.b64decode(data) if is_base64 else unquote_to_bytes(data)
+    if is_base64:
+        # Re-pad before decoding: many encoders emit base64 without the trailing
+        # "=" padding, which base64.b64decode rejects with binascii.Error.
+        content = base64.b64decode(data + "=" * (-len(data) % 4))
+    else:
+        content = unquote_to_bytes(data)
 
     return mime_type, attributes, content

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -66,6 +66,9 @@ class PlainTextConverter(DocumentConverter):
         if stream_info.charset:
             text_content = file_stream.read().decode(stream_info.charset)
         else:
-            text_content = str(from_bytes(file_stream.read()).best())
+            # .best() returns None when charset detection finds no match; guard
+            # against it so the document content is never the literal "None".
+            best = from_bytes(file_stream.read()).best()
+            text_content = str(best) if best is not None else ""
 
         return DocumentConverterResult(markdown=text_content)

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -143,8 +143,9 @@ class RssConverter(DocumentConverter):
         channel_title = self._get_data_by_tag_name(channel, "title")
         channel_description = self._get_data_by_tag_name(channel, "description")
         items = channel.getElementsByTagName("item")
+        md_text = ""
         if channel_title:
-            md_text = f"# {channel_title}\n"
+            md_text += f"# {channel_title}\n"
         if channel_description:
             md_text += f"{channel_description}\n"
         for item in items:

--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -90,7 +90,12 @@ class ZipConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
-        file_path = stream_info.url or stream_info.local_path or stream_info.filename
+        file_path = (
+            stream_info.url
+            or stream_info.local_path
+            or stream_info.filename
+            or "unknown.zip"
+        )
         md_content = f"Content from the zip file `{file_path}`:\n\n"
 
         with zipfile.ZipFile(file_stream, "r") as zipObj:

--- a/packages/markitdown/tests/test_converter_bugfixes.py
+++ b/packages/markitdown/tests/test_converter_bugfixes.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3 -m pytest
+"""Regression tests for a set of small converter correctness fixes."""
+import io
+import sys
+import types
+import zipfile
+
+from markitdown import MarkItDown, StreamInfo
+from markitdown._base_converter import DocumentConverterResult
+from markitdown._uri_utils import parse_data_uri
+from markitdown.__main__ import _handle_output
+from markitdown.converters import RssConverter
+import markitdown.converters._plain_text_converter as plain_text_converter
+
+
+def test_parse_data_uri_accepts_unpadded_base64() -> None:
+    # "SGVsbG8" is base64 for b"Hello" with the trailing "=" padding omitted,
+    # which base64.b64decode would otherwise reject with binascii.Error.
+    mimetype, _attributes, data = parse_data_uri("data:text/plain;base64,SGVsbG8")
+    assert data == b"Hello"
+    assert mimetype == "text/plain"
+
+
+def test_rss_without_channel_title_or_description() -> None:
+    # A <channel> lacking both <title> and <description> previously raised
+    # UnboundLocalError because md_text was only bound inside `if channel_title`.
+    rss = (
+        b'<?xml version="1.0"?><rss version="2.0"><channel>'
+        b"<item><title>Item Title</title><description>Body</description></item>"
+        b"</channel></rss>"
+    )
+    result = RssConverter().convert(
+        io.BytesIO(rss), StreamInfo(mimetype="application/rss+xml", extension=".rss")
+    )
+    assert "## Item Title" in result.markdown
+
+
+def test_zip_without_name_does_not_leak_none() -> None:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("a.txt", "hello")
+    buf.seek(0)
+    markdown = MarkItDown().convert_stream(buf, file_extension=".zip").markdown
+    assert "`None`" not in markdown.splitlines()[0]
+
+
+def test_plaintext_none_detection_yields_empty_string(monkeypatch) -> None:
+    # charset_normalizer's .best() returns None when nothing matches; the
+    # converter must not stringify that into the literal "None".
+    monkeypatch.setattr(
+        plain_text_converter,
+        "from_bytes",
+        lambda _data: types.SimpleNamespace(best=lambda: None),
+    )
+    result = plain_text_converter.PlainTextConverter().convert(
+        io.BytesIO(b"\x00\x01\x02"),
+        StreamInfo(extension=".txt", mimetype="text/plain"),
+    )
+    assert result.markdown == ""
+
+
+def test_handle_output_tolerates_none_stdout_encoding(monkeypatch) -> None:
+    class _FakeStdout:
+        encoding = None
+
+        def __init__(self) -> None:
+            self.buffer = ""
+
+        def write(self, text: str) -> int:
+            self.buffer += text
+            return len(text)
+
+        def flush(self) -> None:
+            pass
+
+    fake = _FakeStdout()
+    monkeypatch.setattr(sys, "stdout", fake)
+    _handle_output(
+        types.SimpleNamespace(output=None),
+        DocumentConverterResult(markdown="café"),
+    )
+    assert "caf" in fake.buffer
+
+
+if __name__ == "__main__":
+    import subprocess
+
+    subprocess.run(["python", "-m", "pytest", __file__, "-v"])


### PR DESCRIPTION
## Summary

Five small, independent correctness fixes in the core converters, each with a regression test:

1. **`_uri_utils.parse_data_uri` — accept unpadded base64.** `base64.b64decode` raises `binascii.Error: Incorrect padding` when a `data:` URI's base64 payload length isn't a multiple of 4. Many encoders omit the `=` padding, so e.g. `convert_uri("data:text/plain;base64,SGVsbG8")` crashed. Re-pad before decoding.
2. **`RssConverter` — `UnboundLocalError` on a channel with no title/description.** `md_text` was only bound inside `if channel_title:`, so an RSS `<channel>` lacking both `<title>` and `<description>` raised `UnboundLocalError` in the item loop. Initialize `md_text = ""` first.
3. **`ZipConverter` — don't print `` `None` `` as the archive name.** When converting raw zip bytes via `convert_stream` (no url/local_path/filename), the header read ``Content from the zip file `None`:``. Fall back to `"unknown.zip"`.
4. **`PlainTextConverter` — don't emit the literal `"None"`.** `charset_normalizer`'s `.best()` returns `None` when nothing matches; `str(None)` made the document content `"None"`. Guard against it.
5. **CLI `_handle_output` — tolerate `sys.stdout.encoding is None`.** `sys.stdout.encoding` can be `None` for some redirected/embedded streams, which turned the output step into `AttributeError`. Fall back to UTF-8.

## How these were found

I did a whole-repository read of `markitdown` with an LLM to surface candidate issues, then verified each one by hand — reading the surrounding code and running a minimal repro. Only fixes I could confirm are included, and each is deliberately minimal and idiomatic to the surrounding code. Happy to split this into separate PRs if you'd prefer one change per PR.

## Test plan

- New tests in `packages/markitdown/tests/test_converter_bugfixes.py`; each fails before its fix and passes after.
- Full suite: `340 passed, 4 skipped` locally on Python 3.13 (the one unrelated failure, `test_speech_transcription`, is a network/service-dependent test that also fails on a clean checkout in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
