### PR TITLE
Support selecting worksheets during XLSX conversion

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -74,13 +74,14 @@ class XlsxConverter(DocumentConverter):
                     extension=".xlsx",
                     feature="xlsx",
                 )
-            ) from _xlsx_dependency_exc_info[
-                1
-            ].with_traceback(  # type: ignore[union-attr]
+            ) from _xlsx_dependency_exc_info[1].with_traceback(  # type: ignore[union-attr]
                 _xlsx_dependency_exc_info[2]
             )
 
-        sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
+        sheet_name = kwargs.pop("sheet_name", None)
+        sheets = pd.read_excel(file_stream, sheet_name=sheet_name, engine="openpyxl")
+        if isinstance(sheets, pd.DataFrame):
+            sheets = {sheet_name or "Sheet1": sheets}
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
@@ -136,13 +137,14 @@ class XlsConverter(DocumentConverter):
                     extension=".xls",
                     feature="xls",
                 )
-            ) from _xls_dependency_exc_info[
-                1
-            ].with_traceback(  # type: ignore[union-attr]
+            ) from _xls_dependency_exc_info[1].with_traceback(  # type: ignore[union-attr]
                 _xls_dependency_exc_info[2]
             )
 
-        sheets = pd.read_excel(file_stream, sheet_name=None, engine="xlrd")
+        sheet_name = kwargs.pop("sheet_name", None)
+        sheets = pd.read_excel(file_stream, sheet_name=sheet_name, engine="xlrd")
+        if isinstance(sheets, pd.DataFrame):
+            sheets = {sheet_name or "Sheet1": sheets}
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"

--- a/packages/markitdown/tests/test_xlsx_converter.py
+++ b/packages/markitdown/tests/test_xlsx_converter.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pandas as pd
+
+from markitdown import MarkItDown
+
+
+def test_convert_xlsx_selected_sheet(tmp_path: Path) -> None:
+    workbook = tmp_path / "workbook.xlsx"
+    with pd.ExcelWriter(workbook, engine="openpyxl") as writer:
+        pd.DataFrame({"value": ["first"]}).to_excel(
+            writer, sheet_name="First", index=False
+        )
+        pd.DataFrame({"value": ["second"]}).to_excel(
+            writer, sheet_name="Second", index=False
+        )
+
+    result = MarkItDown().convert(workbook, sheet_name="Second")
+
+    assert "## Second" in result.markdown
+    assert "second" in result.markdown
+    assert "## First" not in result.markdown
+    assert "first" not in result.markdown
+
+
+def test_convert_xlsx_defaults_to_all_sheets(tmp_path: Path) -> None:
+    workbook = tmp_path / "workbook.xlsx"
+    with pd.ExcelWriter(workbook, engine="openpyxl") as writer:
+        pd.DataFrame({"value": ["first"]}).to_excel(
+            writer, sheet_name="First", index=False
+        )
+        pd.DataFrame({"value": ["second"]}).to_excel(
+            writer, sheet_name="Second", index=False
+        )
+
+    result = MarkItDown().convert(workbook)
+
+    assert "## First" in result.markdown
+    assert "## Second" in result.markdown


### PR DESCRIPTION
Fixes #2290

MarkItDown now accepts `sheet_name` through `convert()` and forwards it to the XLSX/XLS converters. A string or list selects only the requested worksheet(s); omitting it preserves the existing behavior of converting every worksheet.

Tests:
- `PYTHONPATH=packages/markitdown/src .venv/bin/python -m pytest packages/markitdown/tests/test_xlsx_converter.py -q` (2 passed)
- Ruff format and lint checks passed for the changed files.
- `git diff --check` passed.
