### PR TITLE
Fix UnicodeDecodeError when non-ASCII text falls past the sniffed charset prefix

### DIFF
--- a/packages/markitdown/src/markitdown/_charset_utils.py
+++ b/packages/markitdown/src/markitdown/_charset_utils.py
@@ -1,0 +1,40 @@
+import codecs
+
+from typing import Optional
+from charset_normalizer import from_bytes
+
+
+def normalize_charset(charset: Optional[str]) -> Optional[str]:
+    """
+    Normalize a charset string to a canonical form.
+    """
+    if charset is None:
+        return None
+    try:
+        return codecs.lookup(charset).name
+    except LookupError:
+        return charset
+
+
+def decode_bytes(data: bytes, charset: Optional[str] = None) -> str:
+    """
+    Decode data to text, tolerating an incorrect charset.
+
+    Charsets reaching the converters are guesses: sniffed from the first few
+    kilobytes of a stream, or read from a Content-Type header that may be wrong.
+    Decoding an entire document with such a guess can fail on bytes the guess
+    never saw -- e.g. an otherwise-ASCII file whose first non-ASCII character
+    appears past the sniffed window. Rather than fail the conversion, re-detect
+    over the full data, and finally fall back to a lossy decode.
+    """
+    if charset:
+        try:
+            return data.decode(charset)
+        except (UnicodeDecodeError, LookupError):
+            pass
+
+    detected = from_bytes(data).best()
+    if detected is not None:
+        return str(detected)
+
+    return data.decode("utf-8", errors="replace")

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -14,7 +14,6 @@ from warnings import warn
 import requests
 import magika
 import charset_normalizer
-import codecs
 
 from ._stream_info import StreamInfo
 from ._uri_utils import parse_data_uri, file_uri_to_path
@@ -44,6 +43,7 @@ from .converters import (
 
 from ._base_converter import DocumentConverter, DocumentConverterResult
 
+from ._charset_utils import normalize_charset
 from ._exceptions import (
     FileConversionException,
     UnsupportedFormatException,
@@ -734,6 +734,14 @@ class MarkItDown:
                     if charset_result is not None:
                         charset = self._normalize_charset(charset_result.encoding)
 
+                        # The charset was sniffed from a prefix of the stream, but
+                        # is used to decode all of it. ASCII is a strict subset of
+                        # UTF-8, so widening the guess decodes genuine ASCII
+                        # identically, while also handling a stream whose first
+                        # non-ASCII character falls beyond the sniffed prefix.
+                        if charset == self._normalize_charset("ascii"):
+                            charset = self._normalize_charset("utf-8")
+
                 # Normalize the first extension listed
                 guessed_extension = None
                 if len(result.prediction.output.extensions) > 0:
@@ -798,9 +806,4 @@ class MarkItDown:
         """
         Normalize a charset string to a canonical form.
         """
-        if charset is None:
-            return None
-        try:
-            return codecs.lookup(charset).name
-        except LookupError:
-            return charset
+        return normalize_charset(charset)

--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -1,7 +1,7 @@
 import csv
 import io
 from typing import BinaryIO, Any
-from charset_normalizer import from_bytes
+from .._charset_utils import decode_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
 
@@ -42,10 +42,7 @@ class CsvConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Read the file content
-        if stream_info.charset:
-            content = file_stream.read().decode(stream_info.charset)
-        else:
-            content = str(from_bytes(file_stream.read()).best())
+        content = decode_bytes(file_stream.read(), stream_info.charset)
 
         # Parse CSV content
         reader = csv.reader(io.StringIO(content))

--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -1,6 +1,7 @@
 from typing import BinaryIO, Any
 import json
 
+from .._charset_utils import decode_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._exceptions import FileConversionException
 from .._stream_info import StreamInfo
@@ -32,8 +33,9 @@ class IpynbConverter(DocumentConverter):
                 # Read further to see if it's a notebook
                 cur_pos = file_stream.tell()
                 try:
-                    encoding = stream_info.charset or "utf-8"
-                    notebook_content = file_stream.read().decode(encoding)
+                    notebook_content = decode_bytes(
+                        file_stream.read(), stream_info.charset
+                    )
                     return (
                         "nbformat" in notebook_content
                         and "nbformat_minor" in notebook_content
@@ -50,8 +52,7 @@ class IpynbConverter(DocumentConverter):
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
         # Parse and convert the notebook
-        encoding = stream_info.charset or "utf-8"
-        notebook_content = file_stream.read().decode(encoding=encoding)
+        notebook_content = decode_bytes(file_stream.read(), stream_info.charset)
         return self._convert(json.loads(notebook_content))
 
     def _convert(self, notebook_content: dict) -> DocumentConverterResult:

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -1,7 +1,7 @@
 import sys
 
 from typing import BinaryIO, Any
-from charset_normalizer import from_bytes
+from .._charset_utils import decode_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
 from .._stream_info import StreamInfo
 
@@ -63,9 +63,6 @@ class PlainTextConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
-        if stream_info.charset:
-            text_content = file_stream.read().decode(stream_info.charset)
-        else:
-            text_content = str(from_bytes(file_stream.read()).best())
+        text_content = decode_bytes(file_stream.read(), stream_info.charset)
 
         return DocumentConverterResult(markdown=text_content)

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -155,7 +155,7 @@ GENERAL_TEST_VECTORS = [
     FileTestVector(
         filename="test.json",
         mimetype="application/json",
-        charset="ascii",
+        charset="utf-8",
         url=None,
         must_include=[
             "5b64c88c-b3c3-4510-bcb8-da0b200602d8",
@@ -178,7 +178,7 @@ GENERAL_TEST_VECTORS = [
     FileTestVector(
         filename="test_notebook.ipynb",
         mimetype="application/json",
-        charset="ascii",
+        charset="utf-8",
         url=None,
         must_include=[
             "# Test Notebook",

--- a/packages/markitdown/tests/test_charset.py
+++ b/packages/markitdown/tests/test_charset.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3 -m pytest
+import io
+import json
+
+import pytest
+
+from markitdown import MarkItDown, StreamInfo
+from markitdown._charset_utils import decode_bytes, normalize_charset
+
+# Longer than the 4k prefix that _get_stream_info_guesses sniffs for a charset,
+# so the non-ASCII character below lands outside the sniffed window.
+_PREFIX_PADDING = "word " * 1200
+
+# Sits beyond _PREFIX_PADDING, and is not representable in ASCII or cp1252-as-ASCII.
+_LATE_CHARACTER = "—"  # em dash
+
+
+def _convert_bytes(data: bytes, extension: str) -> str:
+    markitdown = MarkItDown()
+    return markitdown.convert(
+        io.BytesIO(data), stream_info=StreamInfo(extension=extension)
+    ).markdown
+
+
+def _convert_declared(data: bytes, extension: str, charset: str) -> str:
+    """Convert with a charset declared up front, as a Content-Type header would."""
+    markitdown = MarkItDown()
+    return markitdown.convert(
+        io.BytesIO(data), stream_info=StreamInfo(extension=extension, charset=charset)
+    ).markdown
+
+
+def test_decode_bytes_honors_correct_charset():
+    assert decode_bytes("café".encode("utf-8"), "utf-8") == "café"
+    assert decode_bytes("café".encode("cp1252"), "cp1252") == "café"
+
+
+def test_decode_bytes_recovers_from_wrong_charset():
+    """A charset that cannot decode the data must not raise."""
+    assert decode_bytes("café".encode("utf-8"), "ascii") == "café"
+
+
+def test_decode_bytes_recovers_from_unknown_charset():
+    assert decode_bytes(b"plain text", "not-a-real-codec") == "plain text"
+
+
+def test_decode_bytes_without_charset_detects():
+    assert decode_bytes("café".encode("utf-8")) == "café"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"valid ascii tail \xc3\x28",  # truncated utf-8 sequence
+        b"valid ascii tail \xff\xff\xff",
+        b"\xff\xfe\x00 utf-16 byte order mark",
+        b"",
+    ],
+)
+def test_decode_bytes_never_raises(data):
+    """Undecodable bytes degrade to a lossy decode rather than failing the conversion."""
+    assert isinstance(decode_bytes(data, "utf-8"), str)
+    assert isinstance(decode_bytes(data), str)
+
+
+def test_decode_bytes_preserves_decodable_text_around_bad_bytes():
+    assert "valid ascii tail" in decode_bytes(b"valid ascii tail \xc3\x28", "utf-8")
+
+
+def test_normalize_charset():
+    assert normalize_charset(None) is None
+    assert normalize_charset("UTF8") == normalize_charset("utf-8")
+    assert normalize_charset("not-a-real-codec") == "not-a-real-codec"
+
+
+def test_non_ascii_beyond_sniffed_prefix():
+    """
+    Regression: the charset is sniffed from the first 4k of the stream but used
+    to decode all of it, so a mostly-ASCII document whose first non-ASCII
+    character appears past that window used to fail with a UnicodeDecodeError.
+    """
+    content = _PREFIX_PADDING + _LATE_CHARACTER + " tail"
+    result = _convert_bytes(content.encode("utf-8"), ".txt")
+    assert _LATE_CHARACTER in result
+    assert "tail" in result
+
+
+# A charset can also arrive already declared -- from a Content-Type header, or
+# from the caller -- in which case it is trusted without being sniffed at all.
+# These cover each converter that decodes a whole stream with such a charset.
+
+
+def test_declared_charset_too_narrow_plain_text():
+    content = _PREFIX_PADDING + _LATE_CHARACTER
+    result = _convert_declared(content.encode("utf-8"), ".txt", "ascii")
+    assert _LATE_CHARACTER in result
+
+
+def test_declared_charset_too_narrow_csv():
+    content = "header\n" + _PREFIX_PADDING + "\n" + _LATE_CHARACTER + "\n"
+    result = _convert_declared(content.encode("utf-8"), ".csv", "ascii")
+    assert _LATE_CHARACTER in result
+
+
+def test_declared_charset_too_narrow_ipynb():
+    notebook = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            # Padded so the non-ASCII cell below falls outside the sniffed prefix,
+            # leaving the declared charset the only one in play.
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [_PREFIX_PADDING],
+            },
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [f"late {_LATE_CHARACTER} character"],
+            },
+        ],
+    }
+    data = json.dumps(notebook, ensure_ascii=False).encode("utf-8")
+    result = _convert_declared(data, ".ipynb", "ascii")
+    assert _LATE_CHARACTER in result
+
+
+def test_pure_ascii_still_round_trips():
+    content = _PREFIX_PADDING + "plain ascii tail"
+    result = _convert_bytes(content.encode("ascii"), ".txt")
+    assert "plain ascii tail" in result
+
+
+def test_non_utf8_charset_is_not_clobbered():
+    """Widening applies only to an ASCII guess -- other charsets are preserved."""
+    markitdown = MarkItDown()
+    content = "テスト " + _PREFIX_PADDING
+    stream = io.BytesIO(content.encode("cp932"))
+    guesses = markitdown._get_stream_info_guesses(
+        stream, base_guess=StreamInfo(extension=".txt")
+    )
+    assert normalize_charset(guesses[0].charset) == normalize_charset("cp932")
+    assert "テスト" in markitdown.convert(stream, file_extension=".txt").markdown


### PR DESCRIPTION
## Problem

The charset is sniffed from the first 4k of a stream but then used to decode all of it, so a mostly-ASCII document whose first non-ASCII character appears beyond that window fails to convert.

This repo's own README reproduces it — its first em dash sits at byte 5030:

```console
$ markitdown README.md
markitdown._exceptions.FileConversionException: File conversion failed after 1 attempts:
 - PlainTextConverter threw UnicodeDecodeError with message: 'ascii' codec can't decode byte 0xe2 in position 5030: ordinal not in range(128)
```

## Fix

Two layers, because the bug has two halves.

**Detection** — widen an ASCII guess to UTF-8 in `_get_stream_info_guesses`. ASCII is a strict subset of UTF-8, so genuine ASCII decodes identically, while UTF-8 content beyond the sniffed prefix now decodes correctly. This layer matters beyond decoding: the charset is part of the `StreamInfo` identity used to decide which guesses are compatible, so it also affects which converters get tried.

**Decoding** — add `decode_bytes()` in a new `_charset_utils` module: try the declared charset, re-detect over the full data if that fails, and fall back to a lossy decode as a last resort. A charset can also arrive already declared — from a `Content-Type` header, or from the caller — in which case it is trusted without being sniffed and can be wrong in the same way.

Wired into the three converters that decode a whole stream with such a charset: plain text, CSV, and ipynb. The HTML-family converters (`_html_converter`, `_bing_serp_converter`, `_wikipedia_converter`, `_youtube_converter`) pass the charset to BeautifulSoup as `from_encoding`, which recovers on its own, so they are left alone.

`_normalize_charset` now delegates to the shared helper rather than duplicating it.

## Tests

New `tests/test_charset.py` (16 tests) covering the sniffed-prefix regression, a too-narrow declared charset through each of the three converters, and the `decode_bytes` fallback chain. Verified they catch the bug: with the fix reverted, 4 fail; restored, all pass.

Full suite goes from 335 to 351 passing, with no new failures.

## One expectation changed

Two vectors in `_test_vectors.py` asserted `charset="ascii"` for `test.json` and `test_notebook.ipynb`. Both fixtures are pure ASCII, so UTF-8 decodes them byte-identically; the expectations are updated to match the widened guess. Flagging it explicitly since it is an assertion change rather than a code fix — happy to take a different approach if you would rather the widening not be observable in `_get_stream_info_guesses` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)