### PR TITLE
Preserve strikethrough from <strike> and CSS line-through

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -122,33 +122,9 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             return "[x] " if el.has_attr("checked") else "[ ] "
         return ""
 
-    def convert_strike(
-        self,
-        el: Any,
-        text: str,
-        convert_as_inline: Optional[bool] = False,
-        **kwargs,
-    ) -> str:
+    def convert_strike(self, el: Any, text: str, *args, **kwargs) -> str:
         """Obsolete <strike> is still in the wild; treat it like <s>/<del>."""
-prefix, suffix, text = markdownify.chomp(text)  # type: ignore
-        return f"{prefix}~~{text}~~{suffix}" if text else ""
-
-    def convert_span(
-        self,
-        el: Any,
-        text: str,
-        convert_as_inline: Optional[bool] = False,
-        **kwargs,
-    ) -> str:
-        """Preserve CSS line-through as Markdown strikethrough."""
-        if text and self._has_line_through(el):
-            return f"~~{text}~~"
-        return text
-
-    @staticmethod
-    def _has_line_through(el: Any) -> bool:
-        style = (el.get("style") or "").lower()
-        return "line-through" in style
+        return self.convert_s(el, text, *args, **kwargs)  # type: ignore
 
     def convert_soup(self, soup: Any) -> str:
         return super().convert_soup(soup)  # type: ignore

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -130,7 +130,8 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         **kwargs,
     ) -> str:
         """Obsolete <strike> is still in the wild; treat it like <s>/<del>."""
-        return f"~~{text}~~" if text else ""
+prefix, suffix, text = markdownify.chomp(text)  # type: ignore
+        return f"{prefix}~~{text}~~{suffix}" if text else ""
 
     def convert_span(
         self,

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -122,5 +122,32 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             return "[x] " if el.has_attr("checked") else "[ ] "
         return ""
 
+    def convert_strike(
+        self,
+        el: Any,
+        text: str,
+        convert_as_inline: Optional[bool] = False,
+        **kwargs,
+    ) -> str:
+        """Obsolete <strike> is still in the wild; treat it like <s>/<del>."""
+        return f"~~{text}~~" if text else ""
+
+    def convert_span(
+        self,
+        el: Any,
+        text: str,
+        convert_as_inline: Optional[bool] = False,
+        **kwargs,
+    ) -> str:
+        """Preserve CSS line-through as Markdown strikethrough."""
+        if text and self._has_line_through(el):
+            return f"~~{text}~~"
+        return text
+
+    @staticmethod
+    def _has_line_through(el: Any) -> bool:
+        style = (el.get("style") or "").lower()
+        return "line-through" in style
+
     def convert_soup(self, soup: Any) -> str:
         return super().convert_soup(soup)  # type: ignore

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -261,6 +261,26 @@ def test_docx_comments() -> None:
     validate_strings(result, DOCX_COMMENT_TEST_STRINGS)
 
 
+def test_html_strikethrough_variants(tmp_path) -> None:
+    html = """<!doctype html>
+<html><body>
+<p>Plain <s>s element</s> after.</p>
+<p>Plain <del>del element</del> after.</p>
+<p>Plain <strike>strike element</strike> after.</p>
+<p>Plain <span style="text-decoration: line-through;">inline CSS line-through</span> after.</p>
+<p>Plain <span style="text-decoration-line: line-through;">CSS text-decoration-line</span> after.</p>
+</body></html>
+"""
+    path = tmp_path / "strike.html"
+    path.write_text(html, encoding="utf-8")
+    markdown = MarkItDown().convert(str(path)).markdown
+    assert "~~s element~~" in markdown
+    assert "~~del element~~" in markdown
+    assert "~~strike element~~" in markdown
+    assert "~~inline CSS line-through~~" in markdown
+    assert "~~CSS text-decoration-line~~" in markdown
+
+
 def test_docx_equations() -> None:
     markitdown = MarkItDown()
     docx_file = os.path.join(TEST_FILES_DIR, "equations.docx")

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -270,18 +270,36 @@ def test_html_strikethrough_variants(tmp_path) -> None:
 <p>Plain <s>s element</s> after.</p>
 <p>Plain <del>del element</del> after.</p>
 <p>Plain <strike>strike element</strike> after.</p>
-<p>Plain <span style="text-decoration: line-through;">inline CSS line-through</span> after.</p>
-<p>Plain <span style="text-decoration-line: line-through;">CSS text-decoration-line</span> after.</p>
+<p>Spaces A<strike> B </strike>C.</p>
+<p>Runs D<strike>  E  </strike>F.</p>
+<p>Empty G<strike></strike>H.</p>
+<p>Newline I<strike>J
+K</strike>L.</p>
+<p>Break M<strike>N<br>O</strike>P.</p>
 </body></html>
 """
     path = tmp_path / "strike.html"
     path.write_text(html, encoding="utf-8")
     markdown = MarkItDown().convert(str(path)).markdown
-    assert "~~s element~~" in markdown
-    assert "~~del element~~" in markdown
-    assert "~~strike element~~" in markdown
-    assert "~~inline CSS line-through~~" in markdown
-    assert "~~CSS text-decoration-line~~" in markdown
+
+    assert markdown == "\n\n".join(
+        [
+            # <s>, <del> and the obsolete <strike> all mean strikethrough
+            "Plain ~~s element~~ after.",
+            "Plain ~~del element~~ after.",
+            "Plain ~~strike element~~ after.",
+            # Surrounding whitespace stays outside of the markup ...
+            "Spaces A ~~B~~ C.",
+            # ... and runs of it collapse to a single space
+            "Runs D ~~E~~ F.",
+            # An empty element contributes nothing
+            "Empty GH.",
+            # A line break inside the element is kept, and the markup
+            # survives it because strikethrough may span a single newline
+            "Newline I~~J\nK~~L.",
+            "Break M~~N\nO~~P.",
+        ]
+    )
 
 
 def test_docx_equations() -> None:


### PR DESCRIPTION
`<s>` and `<del>` already convert to `~~text~~`. `<strike>` and `style="text-decoration: line-through"` were flattened, so struck text looked like current text.

I hooked those two cases in the markdownify subclass. DOCX double-strike still depends on how mammoth emits HTML; I left that alone here.

Fixes #2340