### PR TITLE
fix(doc-intel): include HTML in the default DocumentIntelligenceConverter file types

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -140,6 +140,7 @@ class DocumentIntelligenceConverter(DocumentConverter):
             DocumentIntelligenceFileType.DOCX,
             DocumentIntelligenceFileType.PPTX,
             DocumentIntelligenceFileType.XLSX,
+            DocumentIntelligenceFileType.HTML,
             DocumentIntelligenceFileType.PDF,
             DocumentIntelligenceFileType.JPEG,
             DocumentIntelligenceFileType.PNG,

--- a/packages/markitdown/tests/test_docintel_html.py
+++ b/packages/markitdown/tests/test_docintel_html.py
@@ -1,9 +1,15 @@
+import inspect
 import io
 from markitdown.converters._doc_intel_converter import (
     DocumentIntelligenceConverter,
     DocumentIntelligenceFileType,
 )
 from markitdown._stream_info import StreamInfo
+
+
+def _default_file_types():
+    params = inspect.signature(DocumentIntelligenceConverter.__init__).parameters
+    return params["file_types"].default
 
 
 def _make_converter(file_types):
@@ -24,3 +30,19 @@ def test_docintel_accepts_html_mimetype():
     assert conv.accepts(io.BytesIO(b""), stream_info)
     stream_info = StreamInfo(mimetype="application/xhtml+xml", extension=None)
     assert conv.accepts(io.BytesIO(b""), stream_info)
+
+
+def test_docintel_default_file_types_cover_every_supported_type():
+    # The file_types docstring promises "Defaults to all supported file types",
+    # so the default must stay in sync with the enum.
+    assert set(_default_file_types()) == set(DocumentIntelligenceFileType)
+
+
+def test_docintel_default_accepts_html():
+    conv = _make_converter(_default_file_types())
+    for stream_info in (
+        StreamInfo(mimetype=None, extension=".html"),
+        StreamInfo(mimetype="text/html", extension=None),
+        StreamInfo(mimetype="application/xhtml+xml", extension=None),
+    ):
+        assert conv.accepts(io.BytesIO(b""), stream_info)


### PR DESCRIPTION
### What

Adds `DocumentIntelligenceFileType.HTML` to the default `file_types` of `DocumentIntelligenceConverter`.

### Why

`DocumentIntelligenceConverter.__init__` documents the parameter as:

> `file_types (List[DocumentIntelligenceFileType])`: The file types to accept. **Defaults to all supported file types.**

but the default list has never contained `HTML`, even though every other part of the converter treats HTML as supported:

* `DocumentIntelligenceFileType` lists `HTML = "html"` under the `# No OCR` group, next to `DOCX` / `PPTX` / `XLSX` — all three of which *are* in the default.
* `_get_mime_type_prefixes()` maps it to `text/html` and `application/xhtml+xml`.
* `_get_file_extensions()` maps it to `.html`.
* `_analysis_features()` puts `HTML` in `no_ocr_types`, and its docstring names `.html` explicitly.

`accepts()` is gated purely on `self._file_types`, so with the default the converter rejects HTML:

```python
>>> conv = DocumentIntelligenceConverter.__new__(DocumentIntelligenceConverter)
>>> conv._file_types = inspect.signature(
...     DocumentIntelligenceConverter.__init__).parameters["file_types"].default
>>> conv.accepts(io.BytesIO(b""), StreamInfo(mimetype=None, extension=".docx"))
True
>>> conv.accepts(io.BytesIO(b""), StreamInfo(mimetype=None, extension=".html"))
False
>>> conv.accepts(io.BytesIO(b""), StreamInfo(mimetype="text/html", extension=None))
False
```

This looks like an oversight in #1352 ("Add HTML support to DocumentIntelligenceConverter"): that PR added the mimetype/extension mappings and tests, but the tests construct the converter with `file_types=[DocumentIntelligenceFileType.HTML]` explicitly, so the default path was never exercised. `MarkItDown.enable_builtins()` never passes `file_types`, so a user who configures `docintel_endpoint` gets HTML support only if they build the converter by hand.

### Tests

Extends `tests/test_docintel_html.py` with two cases that read the actual default off the signature:

* `test_docintel_default_file_types_cover_every_supported_type` — pins the documented "all supported file types" contract to the enum, so the default cannot drift again when a type is added.
* `test_docintel_default_accepts_html` — the default converter accepts `.html`, `text/html` and `application/xhtml+xml`.

Both fail on `main` and pass with the change; the two pre-existing tests in the file are untouched and still pass. Formatted with `black==23.7.0` (the pinned `.pre-commit-config.yaml` revision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
