### PR TITLE
Mitigate UnicodeDecodeError due to wrong ASCII charset guess for long files

### DIFF
--- a/packages/markitdown/src/markitdown/_exceptions.py
+++ b/packages/markitdown/src/markitdown/_exceptions.py
@@ -76,7 +76,7 @@ class FileConversionException(MarkItDownException):
                         if isinstance(attempt.exc_info[1], UnicodeDecodeError):
                             message += (
                                 "The charset may have been automatically guessed incorrectly. "
-                                "If you didn't specify the charset, please retry with an explicitly defined one.\n" 
+                                "If you didn't specify the charset, please retry with an explicitly defined one.\n"
                             )
 
         super().__init__(message)

--- a/packages/markitdown/src/markitdown/_exceptions.py
+++ b/packages/markitdown/src/markitdown/_exceptions.py
@@ -73,4 +73,10 @@ class FileConversionException(MarkItDownException):
                     else:
                         message += f" - {type(attempt.converter).__name__} threw {attempt.exc_info[0].__name__} with message: {attempt.exc_info[1]}\n"
 
+                        if isinstance(attempt.exc_info[1], UnicodeDecodeError):
+                            message += (
+                                "The charset may have been automatically guessed incorrectly. "
+                                "If you didn't specify the charset, please retry with an explicitly defined one.\n" 
+                            )
+
         super().__init__(message)

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -357,7 +357,6 @@ class MarkItDown:
             guesses = self._get_stream_info_guesses(
                 file_stream=fh, base_guess=base_guess
             )
-            print(f"Guesses for {path}: {guesses}")
             return self._convert(file_stream=fh, stream_info_guesses=guesses, **kwargs)
 
     def convert_stream(

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -357,6 +357,7 @@ class MarkItDown:
             guesses = self._get_stream_info_guesses(
                 file_stream=fh, base_guess=base_guess
             )
+            print(f"Guesses for {path}: {guesses}")
             return self._convert(file_stream=fh, stream_info_guesses=guesses, **kwargs)
 
     def convert_stream(
@@ -726,9 +727,9 @@ class MarkItDown:
                 # If it's text, also guess the charset
                 charset = None
                 if result.prediction.output.is_text:
-                    # Read the first 4k to guess the charset
+                    # Read the first 64k to guess the charset
                     file_stream.seek(cur_pos)
-                    stream_page = file_stream.read(4096)
+                    stream_page = file_stream.read(65536)
                     charset_result = charset_normalizer.from_bytes(stream_page).best()
 
                     if charset_result is not None:

--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -38,6 +38,8 @@ class IpynbConverter(DocumentConverter):
                         "nbformat" in notebook_content
                         and "nbformat_minor" in notebook_content
                     )
+                except Exception as e:
+                    pass
                 finally:
                     file_stream.seek(cur_pos)
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -597,7 +597,9 @@ def test_json_with_late_non_ascii_character(tmp_path) -> None:
         "notes": "non-ASCII character: è",
     }
     json_path = tmp_path / "input.json"
-    json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    json_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     result = MarkItDown().convert(str(json_path))
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3 -m pytest
 import io
+import json
 import os
 import re
 import shutil
@@ -585,6 +586,22 @@ def test_markitdown_llm() -> None:
         assert test_string in result.text_content
     # Standard alt text is included
     validate_strings(result, PPTX_TEST_STRINGS)
+
+
+def test_json_with_late_non_ascii_character(tmp_path) -> None:
+    payload = {
+        "record": {
+            "title": "Example record",
+            "abstract": "This is sample test. " * 500,
+        },
+        "notes": "non-ASCII character: è",
+    }
+    json_path = tmp_path / "input.json"
+    json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    result = MarkItDown().convert(str(json_path))
+
+    assert "non-ASCII character: è" in result.text_content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR mitigate `UnicodeDecodeError` issues encountered when a non-ASCII character appears late in the file, namely after the window used to guess the charset.

The changes are the following:
- prevent `IpynbConverter.accepts()` from failing when a file cannot be decoded with the guessed charset. I implemented the same solution used in [outlook_msg_converter](https://github.com/microsoft/markitdown/blob/main/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py#L58-L67)
- increase the charset-detection sample from 4 KB to 64 KB, making the issue unlikely to occur 
- add guidance to conversion errors caused by an incorrectly guessed charset

Another possibility is to force a retry if a `UnicodeDecodeError` is encountered in the converter using the same approach used when the detected charset is `None`. But I preferred to not change the current behavior of the converters. https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown/src/markitdown/converters/_plain_text_converter.py#L66-L69


The PR fixes #2359. It could also address #1505, #1894 and #1949 (for which there are no working reproducers).

@afourney I hope you could have a look at this human-generated contribution  ;-)
