### PR TITLE
fix(docx): one integral silently drops every equation in the document

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/latex_dict.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/latex_dict.py
@@ -225,6 +225,8 @@ BRK = "\\\\"
 CHR_DEFAULT = {
     "ACC_VAL": "\\hat{{{0}}}",
     "GROUP_CHR_VAL": "\\underbrace{{{0}}}",
+    # Omitting m:chr under m:naryPr means U+222B INTEGRAL (ISO/IEC 29500-1).
+    "NARY_VAL": "\\int",
 }
 
 POS = {

--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -366,7 +366,7 @@ class oMath2Latex(Tag2Method):
         bo = ""
         for stag, t, e in self.process_children_list(elm):
             if stag == "naryPr":
-                bo = get_char(t.chr, store=CHR_BO)
+                bo = get_char(t.chr, default=CHR_DEFAULT.get("NARY_VAL"), store=CHR_BO)
             else:
                 res.append(t)
         return bo + BLANK.join(res)

--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -363,7 +363,9 @@ class oMath2Latex(Tag2Method):
         the n-ary object
         """
         res = []
-        bo = ""
+        # m:naryPr is itself optional, so an absent element means every property
+        # takes its default, the operator included.
+        bo = CHR_DEFAULT.get("NARY_VAL", "")
         for stag, t, e in self.process_children_list(elm):
             if stag == "naryPr":
                 bo = get_char(t.chr, default=CHR_DEFAULT.get("NARY_VAL"), store=CHR_BO)

--- a/packages/markitdown/tests/test_docx_math_nary.py
+++ b/packages/markitdown/tests/test_docx_math_nary.py
@@ -46,5 +46,7 @@ def test_nary_with_explicit_chr_is_unchanged():
     assert latex == "\\sum_{0}^{1}x"
 
 
-def test_nary_without_nary_pr_does_not_crash():
-    assert _nary("") == "_{0}^{1}x"
+def test_nary_without_nary_pr_defaults_to_integral():
+    # m:naryPr is optional. Absent, every property takes its default, so the
+    # operator is still U+222B rather than nothing.
+    assert _nary("") == "\\int_{0}^{1}x"

--- a/packages/markitdown/tests/test_docx_math_nary.py
+++ b/packages/markitdown/tests/test_docx_math_nary.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3 -m pytest
+"""Tests for the default n-ary operator in DOCX math conversion.
+
+``m:chr`` under ``m:naryPr`` names the n-ary operator. ISO/IEC 29500-1 states
+that when the element is omitted the operator is U+222B INTEGRAL, so producers
+write ``m:chr`` only for the non-default operators such as the summation sign.
+``do_nary`` passed no default to ``get_char``, so an integral yielded ``None``
+and ``None + ""`` raised ``TypeError``.
+
+That failure is not local to the equation. ``pre_process_docx`` runs
+``_pre_process_math`` over the whole of ``word/document.xml`` inside a blanket
+``except Exception`` and, on error, writes the *original* unprocessed XML back.
+Mammoth does not render OMML, so one integral silently removes every equation
+in the document.
+"""
+
+from xml.etree import ElementTree as ET
+
+from markitdown.converter_utils.docx.math.omml import OMML_NS, oMath2Latex
+
+MATH_NS_DECL = f'xmlns:m="{OMML_NS[1:-1]}"'
+
+SUMMATION = "∑"  # N-ARY SUMMATION, written out by Word as it is not the default
+
+
+def _nary(nary_pr: str):
+    xml = (
+        f"<m:oMath {MATH_NS_DECL}><m:nary>"
+        f"{nary_pr}"
+        "<m:sub><m:r><m:t>0</m:t></m:r></m:sub>"
+        "<m:sup><m:r><m:t>1</m:t></m:r></m:sup>"
+        "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+        "</m:nary></m:oMath>"
+    )
+    return oMath2Latex(ET.fromstring(xml)).latex
+
+
+def test_nary_without_chr_defaults_to_integral():
+    # No m:chr, so the operator is U+222B. Previously raised TypeError.
+    latex = _nary('<m:naryPr><m:limLoc m:val="subSup"/><m:ctrlPr/></m:naryPr>')
+    assert latex == "\\int_{0}^{1}x"
+
+
+def test_nary_with_explicit_chr_is_unchanged():
+    latex = _nary(f'<m:naryPr><m:chr m:val="{SUMMATION}"/></m:naryPr>')
+    assert latex == "\\sum_{0}^{1}x"
+
+
+def test_nary_without_nary_pr_does_not_crash():
+    assert _nary("") == "_{0}^{1}x"


### PR DESCRIPTION
`m:chr` under `m:naryPr` names the n-ary operator. Per ISO/IEC 29500-1 it defaults to U+222B INTEGRAL when omitted, so producers write it only for non-default operators like the summation sign. `do_nary` passed no default to `get_char`, so an integral gave `bo = None` and `None + ""` raised `TypeError`.

The damage is not local. `_pre_process_math` runs over all of `word/document.xml` inside a blanket `except Exception`, so the crash discards the OMML rewrite for the whole part, and Mammoth cannot render raw OMML.

Appending one integral to `tests/test_files/equations.docx` and converting, before the fix:

```
no_integral.docx:   4 lines containing LaTeX
with_integral.docx: 0 lines containing LaTeX
```

After: 4 and 5. `do_acc` and `do_groupchr` already apply their spec defaults this way.

No `m:nary` fixture existed, so the new tests cover the default, an explicit `m:chr`, and a missing `m:naryPr`.

Suite: 404 passed / 4 skipped on `main`, 407 / 4 here, no failures either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
