### PR TITLE
fix(ipynb): preserve leading # in notebook heading titles

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -73,7 +73,7 @@ class IpynbConverter(DocumentConverter):
                     if title is None:
                         for line in source_lines:
                             if line.startswith("# "):
-                                title = line.lstrip("# ").strip()
+                                title = line.removeprefix("# ").strip()
                                 break
 
                 elif cell_type == "code":

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -956,6 +956,29 @@ def test_zip_stream_no_filename_header() -> None:
     assert "Hello world" in result.markdown
 
 
+def test_ipynb_heading_title_preserves_leading_hash() -> None:
+    """Heading marker strip must not eat '#' or spaces from the title text.
+
+    Regression for https://github.com/microsoft/markitdown/issues/2367
+    """
+    from markitdown.converters._ipynb_converter import IpynbConverter
+
+    notebook = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": ["# #hashtag campaign results\n"],
+                "metadata": {},
+            }
+        ],
+    }
+    result = IpynbConverter()._convert(notebook)
+    assert result.title == "#hashtag campaign results"
+
+
 def test_ipynb_accepts_non_ascii() -> None:
     """IpynbConverter.accepts() must not raise on non-ASCII binary content."""
     from markitdown.converters._ipynb_converter import IpynbConverter

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -957,7 +957,7 @@ def test_zip_stream_no_filename_header() -> None:
 
 
 def test_ipynb_heading_title_preserves_leading_hash() -> None:
-    """Heading marker strip must not eat '#' or spaces from the title text.
+    """Heading marker removal must not eat a leading '#' from the title text.
 
     Regression for https://github.com/microsoft/markitdown/issues/2367
     """


### PR DESCRIPTION
## Summary
- Fixes #2367: `IpynbConverter` used `str.lstrip("# ")` to strip the ATX heading marker, which treats the argument as a character set and over-strips titles that themselves start with `#` or spaces (e.g. `# #hashtag campaign results` → `hashtag campaign results`).
- Switch to `str.removeprefix("# ")` after the existing `startswith("# ")` check so only the literal marker is removed.
- Add a regression test covering a heading whose title text begins with `#`.

## Test plan
- [x] Reproduced baseline: title became `hashtag campaign results`
- [x] After fix: title is `#hashtag campaign results`
- [x] Ordinary `# My Report` title still extracts as `My Report`
- [x] `pytest packages/markitdown/tests/test_module_misc.py -k 'ipynb_heading_title or ipynb_accepts'` → 2 passed


Made with [Cursor](https://cursor.com)