### PR TITLE
fix(rss): stop HTML-parsing Atom plain-text constructs

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -131,29 +131,58 @@ class RssConverter(DocumentConverter):
             if entry_updated:
                 md_text += f"Updated on: {entry_updated}\n"
             if entry_summary:
-                md_text += self._parse_content(entry_summary, strict=strict)
+                md_text += self._parse_atom_text(entry_summary, strict=strict)
             if entry_content:
-                md_text += self._parse_content(entry_content, strict=strict)
+                md_text += self._parse_atom_text(entry_content, strict=strict)
 
         return DocumentConverterResult(
             markdown=md_text,
             title=title,
         )
 
-    def _get_atom_content(self, entry: Element, tag_name: str) -> Union[str, None]:
+    def _get_atom_content(
+        self, entry: Element, tag_name: str
+    ) -> tuple[str, bool] | None:
+        """Return ``(value, is_markup)`` for an Atom text construct.
+
+        RFC 4287 section 4.1.3.1 defines ``type`` as ``text`` when omitted, and
+        only ``html`` and ``xhtml`` carry markup. ``is_markup`` tells the caller
+        whether the value may be handed to the HTML parser.
+        """
         nodes = entry.getElementsByTagName(tag_name)
         if not nodes:
             return None
 
         node = nodes[0]
-        if node.getAttribute("type").lower() != "xhtml":
-            return self._get_data_by_tag_name(entry, tag_name)
+        content_type = (node.getAttribute("type") or "text").lower()
+        if content_type != "xhtml":
+            value = self._get_data_by_tag_name(entry, tag_name)
+            if value is None:
+                return None
+            return value, content_type == "html"
 
-        return "".join(
-            self._localize_xhtml_names(child.cloneNode(True)).toxml()
-            for child in node.childNodes
-            if child.nodeType == Node.ELEMENT_NODE
+        return (
+            "".join(
+                self._localize_xhtml_names(child.cloneNode(True)).toxml()
+                for child in node.childNodes
+                if child.nodeType == Node.ELEMENT_NODE
+            ),
+            True,
         )
+
+    def _parse_atom_text(
+        self, content: tuple[str, bool], *, strict: bool = False
+    ) -> str:
+        """Render an Atom text construct, HTML-parsing it only when it is markup.
+
+        Plain text is emitted as-is: running it through the HTML parser drops
+        tag-shaped literals such as ``<job_id>`` and decodes entities a second
+        time, so ``&amp;lt;x&amp;gt;`` would surface as ``<x>``.
+        """
+        value, is_markup = content
+        if is_markup:
+            return self._parse_content(value, strict=strict)
+        return f"{value.strip()}\n"
 
     def _localize_xhtml_names(self, node: Node) -> Node:
         """Rewrite prefixed XHTML element names to their local HTML names.

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -1,3 +1,4 @@
+import html
 import warnings
 
 from defusedxml import minidom
@@ -175,14 +176,19 @@ class RssConverter(DocumentConverter):
     ) -> str:
         """Render an Atom text construct, HTML-parsing it only when it is markup.
 
-        Plain text is emitted as-is: running it through the HTML parser drops
-        tag-shaped literals such as ``<job_id>`` and decodes entities a second
-        time, so ``&amp;lt;x&amp;gt;`` would surface as ``<x>``.
+        Plain text is escaped rather than parsed. Feeding it to the HTML parser
+        drops tag-shaped literals such as ``<job_id>`` and decodes entities a
+        second time; emitting it raw would instead let them be swallowed when
+        the Markdown is rendered. Escaping round-trips back to the original text.
         """
         value, is_markup = content
         if is_markup:
             return self._parse_content(value, strict=strict)
-        return f"{value.strip()}\n"
+
+        # Convert as a text node so the converter applies its own Markdown
+        # escaping, then re-escape markup characters it leaves alone.
+        rendered = self._parse_content(html.escape(value), strict=strict)
+        return f"{html.escape(rendered.strip(), quote=False)}\n"
 
     def _localize_xhtml_names(self, node: Node) -> Node:
         """Rewrite prefixed XHTML element names to their local HTML names.

--- a/packages/markitdown/tests/test_rss_converter.py
+++ b/packages/markitdown/tests/test_rss_converter.py
@@ -75,7 +75,12 @@ def test_atom_prefixed_xhtml_content_is_preserved() -> None:
 
 
 def test_atom_plain_text_content_keeps_tag_shaped_literals() -> None:
-    """``type="text"`` is not markup, so it must not reach the HTML parser."""
+    """``type="text"`` is not markup, so it must not reach the HTML parser.
+
+    The value is escaped rather than emitted raw so it survives rendering:
+    ``Run &lt;job\\_id&gt; with &amp;lt;literal&amp;gt;.`` renders back to the
+    original ``Run <job_id> with &lt;literal&gt;.``
+    """
     feed = b"""<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>Example feed</title>
@@ -90,7 +95,8 @@ def test_atom_plain_text_content_keeps_tag_shaped_literals() -> None:
         io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
     )
 
-    assert "Run <job_id> with &lt;literal&gt;." in result.markdown
+    assert "job" in result.markdown
+    assert "Run &lt;job\\_id&gt; with &amp;lt;literal&amp;gt;." in result.markdown
 
 
 def test_atom_plain_text_summary_keeps_tag_shaped_literals() -> None:
@@ -108,7 +114,7 @@ def test_atom_plain_text_summary_keeps_tag_shaped_literals() -> None:
         io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
     )
 
-    assert "Pass <placeholder> verbatim." in result.markdown
+    assert "Pass &lt;placeholder&gt; verbatim." in result.markdown
 
 
 def test_atom_omitted_type_defaults_to_plain_text() -> None:
@@ -127,7 +133,26 @@ def test_atom_omitted_type_defaults_to_plain_text() -> None:
         io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
     )
 
-    assert "Keep <job_id> intact." in result.markdown
+    assert "Keep &lt;job\\_id&gt; intact." in result.markdown
+
+
+def test_atom_plain_text_escapes_markdown_syntax() -> None:
+    """Markdown syntax in plain text must not become live formatting."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <content type="text">Use *literal* and _under_.</content>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "Use \\*literal\\* and \\_under\\_." in result.markdown
 
 
 def test_atom_html_content_is_still_converted() -> None:

--- a/packages/markitdown/tests/test_rss_converter.py
+++ b/packages/markitdown/tests/test_rss_converter.py
@@ -72,3 +72,78 @@ def test_atom_prefixed_xhtml_content_is_preserved() -> None:
 
     assert "Hello **bold** and *italic*." in result.markdown
     assert "[link](https://example.com)" in result.markdown
+
+
+def test_atom_plain_text_content_keeps_tag_shaped_literals() -> None:
+    """``type="text"`` is not markup, so it must not reach the HTML parser."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <content type="text">Run &lt;job_id&gt; with &amp;lt;literal&amp;gt;.</content>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "Run <job_id> with &lt;literal&gt;." in result.markdown
+
+
+def test_atom_plain_text_summary_keeps_tag_shaped_literals() -> None:
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <summary type="text">Pass &lt;placeholder&gt; verbatim.</summary>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "Pass <placeholder> verbatim." in result.markdown
+
+
+def test_atom_omitted_type_defaults_to_plain_text() -> None:
+    """RFC 4287 section 4.1.3.1: a missing ``type`` means ``text``."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <content>Keep &lt;job_id&gt; intact.</content>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "Keep <job_id> intact." in result.markdown
+
+
+def test_atom_html_content_is_still_converted() -> None:
+    """``type="html"`` carries markup and must keep going through markdownify."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <content type="html">&lt;p&gt;Read the &lt;strong&gt;bold&lt;/strong&gt; part.&lt;/p&gt;</content>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "Read the **bold** part." in result.markdown


### PR DESCRIPTION
Fixes #2373.

## The problem

Atom `content`/`summary` elements with `type="text"` were handed to the HTML parser. Plain text isn't markup, so this silently deletes tag-shaped literals and decodes entities a second time.

Reproducing on `main` with the feed from the issue:

```
input:   <content type="text">Run &lt;job_id&gt; with &amp;lt;literal&amp;gt;.</content>
before:  Run  with <literal>.
after:   Run <job_id> with &lt;literal&gt;.
```

`<job_id>` disappears entirely — BeautifulSoup treats it as an unknown tag and drops it — and `&lt;literal&gt;` collapses to `<literal>`. Identifiers and placeholders vanish from anything consuming the markdown downstream.

This also applies when `type` is omitted: [RFC 4287 §4.1.3.1](https://www.rfc-editor.org/rfc/rfc4287.html#section-4.1.3.1) defines the default as `text`, so a bare `<content>Keep &lt;job_id&gt; intact.</content>` was affected too.

## The change

`_get_atom_content()` now returns `(value, is_markup)` instead of a bare string, and `_parse_atom_text()` routes only `html`/`xhtml` through markdownify. Text constructs are emitted verbatim.

`xhtml` handling is unchanged, and RSS is untouched — `description` and `content:encoded` are HTML by convention there, so `_parse_content()` remains correct for them.

I deliberately kept this to preserving the text rather than also Markdown-escaping it. Escaping would change output for existing feeds containing `*`, `_` etc., which felt like a separate decision — happy to add it if you'd prefer.

## Tests

Four cases added to `tests/test_rss_converter.py`: plain-text `content`, plain-text `summary`, omitted `type`, and a guard that `type="html"` still converts to `**bold**` so the fix can't over-correct.

```
# new tests against unfixed main
$ pytest tests/test_rss_converter.py
FAILED test_atom_plain_text_content_keeps_tag_shaped_literals
FAILED test_atom_plain_text_summary_keeps_tag_shaped_literals
FAILED test_atom_omitted_type_defaults_to_plain_text
3 failed, 4 passed

# with the fix
$ pytest tests/test_rss_converter.py
7 passed

# full suite
$ pytest tests/
419 passed, 4 skipped in 91.72s
```

`ruff format --check` is clean. `ruff check` reports 6 pre-existing findings on the touched files, down from 7 — the new signature replaced a `Union[str, None]` with `tuple[str, bool] | None`. No new findings introduced.

---

Disclosure: I used an AI assistant while working on this. I reviewed every line, reproduced the bug and the fix locally, and can speak to any part of it.