### PR TITLE
Fix --list-plugins help text to reference correct --use-plugins flag

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -133,7 +133,7 @@ def main():
     parser.add_argument(
         "--list-plugins",
         action="store_true",
-        help="List installed 3rd-party plugins. Plugins are loaded when using the -p or --use-plugin option.",
+        help="List installed 3rd-party plugins. Plugins are loaded when using the -p or --use-plugins option.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary
- The `--list-plugins` argument's help text referenced `--use-plugin` (singular), but the actual flag defined a few lines above it is `--use-plugins` (plural).
- Anyone copying the flag name straight from `markitdown --help` output would get an invalid argument.

## Change
One-line fix in `packages/markitdown/src/markitdown/__main__.py` to match the help text to the real flag name.

## Test plan
- [x] Confirmed via source inspection that the argparse flag defined at line 128 (`--use-plugins`) now matches the corrected help text at line 136.
- [x] Confirmed the file still parses as valid Python after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)