### PR TITLE
fix: stop emitting the literal string "None" for undecodable text

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -76,7 +76,16 @@ class CsvConverter(DocumentConverter):
         if stream_info.charset:
             content = file_stream.read().decode(stream_info.charset)
         else:
-            content = str(from_bytes(file_stream.read()).best())
+            data = file_stream.read()
+            detected = from_bytes(data).best()
+            if detected is None:
+                # Detection can fail outright, in which case best() is None and
+                # str() would render it as the literal text "None" - a one-cell
+                # table of content that was never in the file. Decode lossily
+                # instead, matching OutlookMsgConverter.
+                content = data.decode("utf-8", errors="ignore")
+            else:
+                content = str(detected)
 
         # Excel and other tools prepend a UTF-8 BOM to CSV exports; strip it so
         # it does not end up inside the first header cell.

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -55,6 +55,14 @@ class PlainTextConverter(DocumentConverter):
         if stream_info.charset:
             text_content = file_stream.read().decode(stream_info.charset)
         else:
-            text_content = str(from_bytes(file_stream.read()).best())
+            data = file_stream.read()
+            detected = from_bytes(data).best()
+            if detected is None:
+                # Detection can fail outright, in which case best() is None and
+                # str() would render it as the literal text "None". Decode
+                # lossily instead, matching OutlookMsgConverter.
+                text_content = data.decode("utf-8", errors="ignore")
+            else:
+                text_content = str(detected)
 
         return DocumentConverterResult(markdown=text_content)

--- a/packages/markitdown/tests/test_undecodable_text.py
+++ b/packages/markitdown/tests/test_undecodable_text.py
@@ -1,0 +1,77 @@
+"""Undecodable input must not turn into the literal text "None".
+
+CsvConverter and PlainTextConverter fall back to charset detection when no
+charset is known. charset_normalizer's ``best()`` returns ``None`` when
+detection fails outright, and ``str(None)`` is the three-character string
+``"None"`` - content that was never in the file.
+"""
+
+import io
+
+from charset_normalizer import from_bytes
+
+from markitdown import MarkItDown, StreamInfo
+from markitdown.converters import CsvConverter, PlainTextConverter
+
+# charset_normalizer cannot settle on an encoding for this byte string, so
+# from_bytes(...).best() is None. Asserted below so the fixture failing to be
+# undecodable can never quietly turn these tests green.
+UNDECODABLE = b"\xff\xfe" + bytes([0xD8, 0x00, 0xDC])
+
+
+def test_fixture_is_actually_undecodable() -> None:
+    assert from_bytes(UNDECODABLE).best() is None
+
+
+def test_csv_converter_undecodable_is_not_the_string_none() -> None:
+    result = CsvConverter().convert(
+        io.BytesIO(UNDECODABLE),
+        StreamInfo(extension=".csv", mimetype="text/csv"),
+    )
+    assert "None" not in result.markdown
+
+
+def test_plain_text_converter_undecodable_is_not_the_string_none() -> None:
+    result = PlainTextConverter().convert(
+        io.BytesIO(UNDECODABLE),
+        StreamInfo(extension=".txt", mimetype="text/plain"),
+    )
+    assert result.markdown != "None"
+    assert "None" not in result.markdown
+
+
+def test_undecodable_csv_through_markitdown() -> None:
+    result = MarkItDown().convert_stream(
+        io.BytesIO(UNDECODABLE),
+        stream_info=StreamInfo(extension=".csv", mimetype="text/csv"),
+    )
+    assert "None" not in result.markdown
+
+
+def test_undecodable_text_through_markitdown() -> None:
+    result = MarkItDown().convert_stream(
+        io.BytesIO(UNDECODABLE),
+        stream_info=StreamInfo(extension=".txt", mimetype="text/plain"),
+    )
+    assert "None" not in result.markdown
+
+
+def test_decodable_input_still_uses_detected_charset() -> None:
+    # Guards the fallback from swallowing the normal path: Shift-JIS text has
+    # no declared charset here and must still round-trip through detection.
+    payload = "名前,年齢\n佐藤太郎,30\n".encode("shift_jis")
+    result = CsvConverter().convert(
+        io.BytesIO(payload),
+        StreamInfo(extension=".csv", mimetype="text/csv"),
+    )
+    assert "名前" in result.markdown
+    assert "佐藤太郎" in result.markdown
+
+
+def test_declared_charset_path_is_unchanged() -> None:
+    payload = "a,b\n1,2\n".encode("utf-8")
+    result = CsvConverter().convert(
+        io.BytesIO(payload),
+        StreamInfo(extension=".csv", mimetype="text/csv", charset="utf-8"),
+    )
+    assert "| a | b |" in result.markdown


### PR DESCRIPTION
## Summary

`CsvConverter` and `PlainTextConverter` can emit the literal three-character
string `None` as document content when charset detection fails, with no error
raised.

Both fall back to detection when no charset is declared:

```python
content = str(from_bytes(file_stream.read()).best())
```

`charset_normalizer.from_bytes(...).best()` returns `None` when it cannot settle
on an encoding, and `str(None) == "None"`.

## Details

Reproduced on `main` (`a035350`) with bytes that defeat detection —
`b"\xff\xfe" + bytes([0xD8, 0x00, 0xDC])`:

| input | before | after |
| --- | --- | --- |
| `.csv` | `\| None \|`<br>`\| --- \|` | `\| \x00 \|`<br>`\| --- \|` |
| `.txt` | `None` | `\x00` |
| `.md` | `None` | `\x00` |
| `.json` | `None` | `\x00` |

The failure mode is what makes this worth fixing: the output is not empty and
not an error, it is a well-formed one-cell Markdown table containing a word
that never appeared in the source. Anything consuming the result downstream
(an index, an LLM prompt) sees `None` as real document text.

This is already handled correctly elsewhere in the repo, so the fix follows
existing precedent rather than inventing a policy:

- `_markitdown.py:751` — `if charset_result is not None:`
- `_outlook_msg_converter.py:290` — `if detected is not None:` … else
  `data.decode("utf-8", errors="ignore")`

Both converters now use that same lossy-decode fallback. Undecodable bytes
degrade instead of fabricating content, and the declared-charset and
successful-detection paths are untouched.

Scope note: `grep -rn 'str(from_bytes(.*).best())'` finds exactly these two
call sites, so this covers all of them.

## Related Issues

None found — searched open issues for `None` / charset / undecodable and found
no existing report. Discovered while probing the text converters directly.

## How to Validate

```bash
cd packages/markitdown
pip install -e ".[all]" pytest
python -m pytest tests/test_undecodable_text.py -q
```

Expected: `7 passed`.

To confirm the tests are load-bearing, stash the two converter changes and
re-run with the new test file in place:

```
4 failed, 3 passed
```

The 4 failures are the undecodable assertions. The 3 that still pass are
deliberate guards: one asserts the fixture really is undecodable (so a future
`charset_normalizer` that starts decoding these bytes cannot quietly turn the
suite green), and two cover the Shift-JIS detection and declared-charset paths
to show the fallback does not swallow the normal cases.

Full suite, before and after this change:

```
before: 438 passed, 5 failed, 4 skipped
after:  445 passed, 5 failed, 4 skipped
```

The 5 failures are identical in both runs and unrelated to this change — they
are missing optional dependencies in my local env (`azure-ai-contentunderstanding`,
`azure-ai-documentintelligence`, `speech_recognition`, `pydub`), which I could
not install because this machine runs Python 3.14 and `youtube-transcript-api~=1.0.0`
in the `all` extra requires `<3.14`. CI runs 3.10–3.13, where `[all]` installs
cleanly, so those 5 should not appear there.

`black` reports all three files unchanged.
