### PR TITLE
fix(pptx): chart_title.text_frame is never None — use has_text_frame instead

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
@@ -222,7 +222,11 @@ class PptxConverterWithOCR(DocumentConverter):
     def _convert_chart_to_markdown(self, chart):
         try:
             md = "\\n\\n### Chart"
-            if chart.has_title and chart.chart_title.text_frame is not None:
+            # ChartTitle.text_frame is documented as destructive -- it creates
+            # a text frame if one isn't already present, so it never returns
+            # None. has_text_frame is the property that actually reflects
+            # whether a text frame exists.
+            if chart.has_title and chart.chart_title.has_text_frame:
                 md += f": {chart.chart_title.text_frame.text}"
             md += "\\n\\n"
             data = []

--- a/packages/markitdown-ocr/tests/test_pptx_converter.py
+++ b/packages/markitdown-ocr/tests/test_pptx_converter.py
@@ -152,9 +152,12 @@ def test_pptx_ocr_chart_no_title_text_frame() -> None:
     from unittest.mock import MagicMock
     from markitdown_ocr._pptx_converter_with_ocr import PptxConverterWithOCR
 
+    # python-pptx's ChartTitle.text_frame is destructive -- it creates a text
+    # frame if one isn't already present, so it never returns None.
+    # has_text_frame is the property that actually reflects presence/absence.
     mock_chart = MagicMock()
     mock_chart.has_title = True
-    mock_chart.chart_title.text_frame = None
+    mock_chart.chart_title.has_text_frame = False
 
     mock_category = MagicMock()
     mock_category.label = "Cat 1"
@@ -172,3 +175,27 @@ def test_pptx_ocr_chart_no_title_text_frame() -> None:
     assert "Cat 1" in result
     assert "Series 1" in result
     assert ":" not in result
+
+
+def test_pptx_ocr_chart_with_title_text_frame() -> None:
+    from unittest.mock import MagicMock
+    from markitdown_ocr._pptx_converter_with_ocr import PptxConverterWithOCR
+
+    mock_chart = MagicMock()
+    mock_chart.has_title = True
+    mock_chart.chart_title.has_text_frame = True
+    mock_chart.chart_title.text_frame.text = "Revenue"
+
+    mock_category = MagicMock()
+    mock_category.label = "Cat 1"
+    mock_chart.plots = [MagicMock(categories=[mock_category])]
+
+    mock_series = MagicMock()
+    mock_series.name = "Series 1"
+    mock_series.values = [10.0]
+    mock_chart.series = [mock_series]
+
+    converter = PptxConverterWithOCR()
+    result = converter._convert_chart_to_markdown(mock_chart)
+
+    assert "### Chart: Revenue" in result

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -310,7 +310,11 @@ class PptxConverter(DocumentConverter):
     def _convert_chart_to_markdown(self, chart):
         try:
             md = "\n\n### Chart"
-            if chart.has_title and chart.chart_title.text_frame is not None:
+            # ChartTitle.text_frame is documented as destructive -- it creates
+            # a text frame if one isn't already present, so it never returns
+            # None. has_text_frame is the property that actually reflects
+            # whether a text frame exists.
+            if chart.has_title and chart.chart_title.has_text_frame:
                 md += f": {chart.chart_title.text_frame.text}"
             md += "\n\n"
             data = []

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1281,9 +1281,14 @@ def test_markitdown_llm() -> None:
 def test_pptx_chart_no_title_text_frame() -> None:
     from markitdown.converters._pptx_converter import PptxConverter
 
+    # python-pptx's ChartTitle.text_frame is destructive -- it creates a text
+    # frame if one isn't already present, so it never returns None.
+    # has_text_frame is the property that actually reflects presence/absence,
+    # which is what the has_title=True-but-no-text-frame case looks like
+    # against the real library.
     mock_chart = MagicMock()
     mock_chart.has_title = True
-    mock_chart.chart_title.text_frame = None
+    mock_chart.chart_title.has_text_frame = False
 
     mock_category = MagicMock()
     mock_category.label = "Cat 1"
@@ -1301,6 +1306,29 @@ def test_pptx_chart_no_title_text_frame() -> None:
     assert "Cat 1" in result
     assert "Series 1" in result
     assert ":" not in result
+
+
+def test_pptx_chart_with_title_text_frame() -> None:
+    from markitdown.converters._pptx_converter import PptxConverter
+
+    mock_chart = MagicMock()
+    mock_chart.has_title = True
+    mock_chart.chart_title.has_text_frame = True
+    mock_chart.chart_title.text_frame.text = "Revenue"
+
+    mock_category = MagicMock()
+    mock_category.label = "Cat 1"
+    mock_chart.plots = [MagicMock(categories=[mock_category])]
+
+    mock_series = MagicMock()
+    mock_series.name = "Series 1"
+    mock_series.values = [10.0]
+    mock_chart.series = [mock_series]
+
+    converter = PptxConverter()
+    result = converter._convert_chart_to_markdown(mock_chart)
+
+    assert "### Chart: Revenue" in result
 
 
 def test_youtube_converter_missing_title_metadata() -> None:
@@ -1650,6 +1678,7 @@ if __name__ == "__main__":
         test_markitdown_llm_parameters,
         test_markitdown_llm,
         test_pptx_chart_no_title_text_frame,
+        test_pptx_chart_with_title_text_frame,
         test_ipynb_accepts_non_ascii,
         test_epub_metadata_nodevalue,
         test_exiftool_metadata_with_nonexistent_binary,


### PR DESCRIPTION
## Description

Follow-up to #2194, which added `chart.chart_title.text_frame is not None` as a guard before reading `chart.chart_title.text_frame.text`.

That guard doesn't actually check what it's meant to. Against the real, installed `python-pptx` (1.0.2, the current PyPI release — `python-pptx` isn't version-pinned in `pyproject.toml` so this is what anyone installing `markitdown` gets), `ChartTitle.text_frame` is documented as destructive: it creates a text frame if one isn't already present, so **it can never return `None`**.

I verified this both by reading `python-pptx`'s source (`chart/chart.py`, `oxml/chart/shared.py`) and empirically, by building a real chart with `python-pptx` and setting `has_title = True` without ever touching `text_frame`:

```pycon
>>> chart.has_title
True
>>> chart.chart_title.has_text_frame
False
>>> chart.chart_title.text_frame is None
False
>>> chart.chart_title.text_frame.text
''
```

So the `#2194` guard is a no-op against the real library — it's always `True`, and the existing unit test for it only passes because it uses `MagicMock()` with `text_frame` force-set to `None`, a state that can't occur with real `python-pptx`. (Worth noting: with the real library, this also means the *original* crash this was meant to fix doesn't reproduce via this exact code path either — `.text_frame.text` just comes back as `''`, not an `AttributeError`. I don't know what the original report's exact repro was, so I can't rule out a different code path or an older `python-pptx` version being the real cause — but whatever it was, this specific guard doesn't touch it.)

`has_text_frame` is the property that actually reflects presence/absence (it checks a different underlying XML property, `tx_rich`, without the auto-creating side effect). Swapping to it is also a small behavior improvement: a chart with `has_title=True` but no real title text currently renders as `"### Chart: "` (empty string after the colon); with `has_text_frame`, it correctly renders as just `"### Chart"`.

## Changes

- `packages/markitdown/src/markitdown/converters/_pptx_converter.py` and `packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py`: swapped `chart.chart_title.text_frame is not None` for `chart.chart_title.has_text_frame`.
- Updated the `#2194` mock-based tests in both packages to set `has_text_frame = False` (matching how the real library actually signals "no text frame") instead of `text_frame = None`.
- Added a positive-path test in both packages (`has_text_frame = True` with real title text) so both branches of the condition are covered.

## Testing

Set up a clean environment rather than relying on mocks alone, since that's exactly the gap this PR is about:

```bash
python3 -m venv venv && source venv/bin/activate
pip install -e "packages/markitdown[pptx]"
pip install -e "packages/markitdown-ocr"
pip install pytest
python3 -c "import pptx; print(pptx.__version__)"   # 1.0.2
```

- Ran the pptx-related suites in both packages: **4/4 passing** in `packages/markitdown` (`pytest packages/markitdown/tests/test_module_misc.py -k pptx`), **8/8 passing** in `packages/markitdown-ocr` (`pytest packages/markitdown-ocr/tests/test_pptx_converter.py`) — 6 pre-existing + 2 new, no regressions.
- Confirmed the updated tests are meaningful, not tautological: temporarily reverted the guard back to `text_frame is not None` and reran — `test_pptx_chart_no_title_text_frame` failed as expected (`AssertionError: assert ':' not in ...`), then restored the fix and confirmed all tests pass again.
- Independently confirmed the `text_frame`-never-`None` behavior empirically against the real, installed `python-pptx` 1.0.2 in that same venv (see the `pycon` repro above) — not just by reading source.

![test run](https://raw.githubusercontent.com/kapil971390/markitdown/assets/pptx-charttitle-tests-passing.png)

