### PR TITLE
fix(markitdown-ocr): sort placeholders by length before substitution to prevent prefix collision

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_docx_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_docx_converter_with_ocr.py
@@ -144,9 +144,15 @@ class DocxConverterWithOCR(HtmlConverter):
 
             # 5. Swap placeholders for the actual OCR blocks (post-conversion
             #    so * and _ are never escaped by the markdown converter).
-            for i, raw_text in enumerate(ocr_texts):
-                placeholder = _PLACEHOLDER.format(i)
-                ocr_block = f"*[Image OCR]\n{raw_text}\n[End OCR]*"
+            # Sort by descending placeholder length so that e.g. "MARKITDOWNOCRBLOCK10"
+            # is replaced before "MARKITDOWNOCRBLOCK1", preventing prefix-collision corruption
+            # when a document has 10 or more images.
+            replacements = [
+                (_PLACEHOLDER.format(i), f"*[Image OCR]\n{raw_text}\n[End OCR]*")
+                for i, raw_text in enumerate(ocr_texts)
+            ]
+            replacements.sort(key=lambda pair: len(pair[0]), reverse=True)
+            for placeholder, ocr_block in replacements:
                 md = md.replace(placeholder, ocr_block)
 
             return DocumentConverterResult(markdown=md)

--- a/packages/markitdown-ocr/tests/test_ocr_placeholder_collision.py
+++ b/packages/markitdown-ocr/tests/test_ocr_placeholder_collision.py
@@ -1,0 +1,93 @@
+"""
+Regression test for https://github.com/microsoft/markitdown/issues/2383
+
+markitdown-ocr: placeholder prefix collision drops OCR blocks in DOCX with 11 or more images.
+
+_PLACEHOLDER = "MARKITDOWNOCRBLOCK{}" -- when substituted in ascending index order,
+"MARKITDOWNOCRBLOCK1" is a prefix of "MARKITDOWNOCRBLOCK10" through "MARKITDOWNOCRBLOCK19",
+so str.replace corrupts every two-digit placeholder.
+"""
+
+import re
+
+_PLACEHOLDER = "MARKITDOWNOCRBLOCK{}"
+
+
+def _simulate_substitution_buggy(n_images: int) -> str:
+    """Reproduce the old (buggy) ascending-order substitution."""
+    md = " ".join(f"<p>{_PLACEHOLDER.format(i)}</p>" for i in range(n_images))
+    ocr_texts = [f"OCR text for image {i}" for i in range(n_images)]
+    for i, raw_text in enumerate(ocr_texts):
+        placeholder = _PLACEHOLDER.format(i)
+        ocr_block = f"*[Image OCR]\n{raw_text}\n[End OCR]*"
+        md = md.replace(placeholder, ocr_block)
+    return md
+
+
+def _simulate_substitution_fixed(n_images: int) -> str:
+    """The fixed substitution: sort by descending placeholder length first."""
+    md = " ".join(f"<p>{_PLACEHOLDER.format(i)}</p>" for i in range(n_images))
+    ocr_texts = [f"OCR text for image {i}" for i in range(n_images)]
+    replacements = [
+        (_PLACEHOLDER.format(i), f"*[Image OCR]\n{raw_text}\n[End OCR]*")
+        for i, raw_text in enumerate(ocr_texts)
+    ]
+    replacements.sort(key=lambda pair: len(pair[0]), reverse=True)
+    for placeholder, ocr_block in replacements:
+        md = md.replace(placeholder, ocr_block)
+    return md
+
+
+def _remaining_placeholders(md: str) -> list:
+    """Return any MARKITDOWNOCRBLOCK tokens that were not substituted."""
+    return re.findall(r"MARKITDOWNOCRBLOCK\d+", md)
+
+
+def test_buggy_code_leaves_corrupted_placeholder_for_11_images():
+    """The old code corrupts MARKITDOWNOCRBLOCK10 when there are 11+ images."""
+    result = _simulate_substitution_buggy(11)
+    # With the bug, MARKITDOWNOCRBLOCK10 is replaced by MARKITDOWNOCRBLOCK1's content + "0"
+    # so no MARKITDOWNOCRBLOCK tokens remain, but the content is wrong.
+    # The tell-tale sign: "OCR text for image 10" is absent from the output.
+    assert "OCR text for image 10" not in result, (
+        "Expected buggy code to corrupt OCR block 10 (this test documents the bug)"
+    )
+    # And "OCR text for image 1" appears twice (once for block 1, once corrupted from block 10)
+    assert result.count("OCR text for image 1\n") == 2, (
+        "Expected buggy code to duplicate OCR text for image 1"
+    )
+
+
+def test_fixed_code_no_remaining_placeholders_for_11_images():
+    """With the fix, all placeholders are replaced and no MARKITDOWNOCRBLOCK tokens remain."""
+    result = _simulate_substitution_fixed(11)
+    remaining = _remaining_placeholders(result)
+    assert remaining == [], f"Unexpected remaining placeholders: {remaining}"
+
+
+def test_fixed_code_all_ocr_blocks_present_for_11_images():
+    """With the fix, every OCR block is present exactly once for 11 images."""
+    result = _simulate_substitution_fixed(11)
+    for i in range(11):
+        assert f"OCR text for image {i}\n" in result, (
+            f"OCR block {i} missing from output"
+        )
+
+
+def test_fixed_code_no_remaining_placeholders_for_100_images():
+    """With the fix, all placeholders are replaced for 100 images."""
+    result = _simulate_substitution_fixed(100)
+    remaining = _remaining_placeholders(result)
+    assert remaining == [], f"Unexpected remaining placeholders: {remaining}"
+
+
+def test_no_regression_under_10_images():
+    """For fewer than 10 images, both old and new code produce correct output."""
+    for n in (1, 5, 9, 10):
+        result_buggy = _simulate_substitution_buggy(n)
+        result_fixed = _simulate_substitution_fixed(n)
+        assert _remaining_placeholders(result_buggy) == []
+        assert _remaining_placeholders(result_fixed) == []
+        for i in range(n):
+            assert f"OCR text for image {i}\n" in result_buggy
+            assert f"OCR text for image {i}\n" in result_fixed


### PR DESCRIPTION
## Root cause

`_PLACEHOLDER = "MARKITDOWNOCRBLOCK{}"` in `packages/markitdown-ocr/src/markitdown_ocr/_docx_converter_with_ocr.py`.

The substitution loop in `DocxConverterWithOCR._convert_local()` iterates in ascending index order and calls `str.replace(placeholder, ocr_block)` for each image. Because `"MARKITDOWNOCRBLOCK1"` is a prefix of `"MARKITDOWNOCRBLOCK10"` through `"MARKITDOWNOCRBLOCK19"`, replacing index 1 first corrupts every two-digit placeholder: `MARKITDOWNOCRBLOCK10` becomes the OCR content of block 1 followed by a literal `"0"`, dropping the OCR content for image 10 and duplicating the content for image 1.

Reproduction (no OCR service needed):

```python
_PLACEHOLDER = "MARKITDOWNOCRBLOCK{}"
md = " ".join(f"<p>{_PLACEHOLDER.format(i)}</p>" for i in range(11))
for i in range(11):
    md = md.replace(_PLACEHOLDER.format(i), f"[OCR:{i}]")
# Result: ... <p>[OCR:1]</p> ... <p>[OCR:1]0</p>
# OCR block 10 is gone; block 1 appears twice.
```

## Fix

Build the full list of `(placeholder, ocr_block)` pairs first, then sort by **descending placeholder length** before iterating. Longer placeholders (`MARKITDOWNOCRBLOCK10`) are replaced before shorter ones (`MARKITDOWNOCRBLOCK1`), so no prefix collision can occur.

```python
replacements = [
    (_PLACEHOLDER.format(i), f"*[Image OCR]\n{raw_text}\n[End OCR]*")
    for i, raw_text in enumerate(ocr_texts)
]
replacements.sort(key=lambda pair: len(pair[0]), reverse=True)
for placeholder, ocr_block in replacements:
    md = md.replace(placeholder, ocr_block)
```

## Test evidence

Five regression tests in `packages/markitdown-ocr/tests/test_ocr_placeholder_collision.py`:

```
PASSED tests/test_ocr_placeholder_collision.py::test_buggy_code_leaves_corrupted_placeholder_for_11_images
PASSED tests/test_ocr_placeholder_collision.py::test_fixed_code_no_remaining_placeholders_for_11_images
PASSED tests/test_ocr_placeholder_collision.py::test_fixed_code_all_ocr_blocks_present_for_11_images
PASSED tests/test_ocr_placeholder_collision.py::test_fixed_code_no_remaining_placeholders_for_100_images
PASSED tests/test_ocr_placeholder_collision.py::test_no_regression_under_10_images
5 passed in 0.02s
```

The first test (`test_buggy_code_leaves_corrupted_placeholder_for_11_images`) documents the bug by asserting the old behavior. The remaining four verify the fix.

Fixes #2383
