### PR TITLE
fix(csv): warn when a data row has more columns than the header

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import re
+import warnings
 from typing import BinaryIO, Any
 from charset_normalizer import from_bytes
 from .._base_converter import DocumentConverter, DocumentConverterResult
@@ -101,14 +102,26 @@ class CsvConverter(DocumentConverter):
         markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
 
         # Add data rows
+        truncated_rows = 0
         for row in rows[1:]:
             # Make sure row has the same number of columns as header
             while len(row) < len(rows[0]):
                 row.append("")
             # Truncate if row has more columns than header
+            if len(row) > len(rows[0]):
+                truncated_rows += 1
             row = row[: len(rows[0])]
             markdown_table.append(
                 "| " + " | ".join(_escape_table_cell(cell) for cell in row) + " |"
+            )
+
+        if truncated_rows:
+            # Silently dropping fields hides real data loss (e.g. a preamble
+            # line mistaken for the header), so surface it instead.
+            warnings.warn(
+                f"{truncated_rows} CSV row(s) have more columns than the header "
+                "row; extra fields were dropped.",
+                stacklevel=2,
             )
 
         result = "\n".join(markdown_table)

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1615,9 +1615,14 @@ def test_csv_row_wider_than_header_warns_before_truncating() -> None:
 
 
 def test_csv_row_matching_header_width_does_not_warn() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         result = _convert_csv(b"name,age\nAlice,30\n")
+
+        mismatch_warnings = [
+            x for x in w if "more columns than the header" in str(x.message)
+        ]
+        assert len(mismatch_warnings) == 0
 
     assert "| Alice | 30 |" in result
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -5,6 +5,7 @@ import ntpath
 import os
 import re
 import shutil
+import warnings
 import zipfile
 import pytest
 from types import SimpleNamespace
@@ -1604,6 +1605,21 @@ def test_csv_backslash_without_a_pipe_is_left_alone() -> None:
     result = _convert_csv(b"name,path\nWidget,C:\\temp\\file.txt\n")
 
     assert r"| Widget | C:\temp\file.txt |" in result
+
+
+def test_csv_row_wider_than_header_warns_before_truncating() -> None:
+    with pytest.warns(UserWarning, match="more columns than the header"):
+        result = _convert_csv(b"name,age\nAlice,30,extra\n")
+
+    assert "| Alice | 30 |" in result
+
+
+def test_csv_row_matching_header_width_does_not_warn() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = _convert_csv(b"name,age\nAlice,30\n")
+
+    assert "| Alice | 30 |" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CsvConverter treats `rows[0]` as the header with no validation, so a data row with extra columns just gets truncated with `row[: len(rows[0])]`, dropping fields silently. WizTree exports hit this in practice: their CSV starts with a one-field banner line before the real header, so every real column after the first gets dropped without any indication something went wrong.

This adds a warning when that truncation happens, so the data loss is visible instead of silent. The truncation behavior itself is unchanged.

Fixes #2390
