### PR TITLE
fix(html): preserve whitespace around anchor text

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -61,12 +61,13 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         **kwargs,
     ):
         """Same as usual converter, but removes JavaScript links and escapes URIs."""
+        original_text = text
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
         if not text:
-            return ""
+            return original_text
 
         if el.find_parent("pre") is not None:
-            return text
+            return original_text
 
         href = el.get("href")
         title = el.get("title")
@@ -95,14 +96,14 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             and not self.options["default_title"]
         ):
             # Shortcut syntax
-            return "<%s>" % href
+            return "%s<%s>%s" % (prefix, href, suffix)
         if self.options["default_title"] and not title:
             title = href
         title_part = ' "%s"' % title.replace('"', r"\"") if title else ""
         return (
             "%s[%s](%s%s)%s" % (prefix, text, href, title_part, suffix)
             if href
-            else text
+            else original_text
         )
 
     def convert_img(

--- a/packages/markitdown/tests/test_html_converter.py
+++ b/packages/markitdown/tests/test_html_converter.py
@@ -1,5 +1,7 @@
 import io
 
+import pytest
+
 from markitdown import MarkItDown
 
 
@@ -63,3 +65,47 @@ def test_html_href_does_not_quote_query_or_fragment() -> None:
     markdown = _convert_html(f'<a href="{href}">example</a>')
 
     assert f"[example]({expected_href})" in markdown
+
+
+@pytest.mark.parametrize("attributes", ["", 'name="bookmark"', 'href=""'])
+@pytest.mark.parametrize("text", [" middle ", " "])
+def test_html_anchor_without_destination_preserves_word_boundaries(
+    attributes: str, text: str
+) -> None:
+    markdown = _convert_html(f"<p>before<a {attributes}>{text}</a>after</p>")
+
+    assert markdown == f"before{text}after"
+
+
+@pytest.mark.parametrize("href", ["", 'href="https://example.com"'])
+def test_html_anchor_in_pre_preserves_whitespace(href: str) -> None:
+    markdown = _convert_html(f"<pre>before<a {href}>  middle\n </a>after</pre>")
+
+    assert markdown == "```\nbefore  middle\n after\n```"
+
+
+def test_html_autolink_preserves_surrounding_spaces() -> None:
+    markdown = _convert_html(
+        '<p>before<a href="https://example.com"> https://example.com </a>after</p>'
+    )
+
+    assert markdown == "before <https://example.com> after"
+
+
+def test_html_link_with_whitespace_only_text_preserves_word_boundary() -> None:
+    markdown = _convert_html('<p>before<a href="https://example.com"> </a>after</p>')
+
+    assert markdown == "before after"
+
+
+@pytest.mark.parametrize(
+    "href, expected",
+    [
+        ("https://example.com", "before [middle](https://example.com) after"),
+        ("javascript:void(0)", "before middle after"),
+    ],
+)
+def test_html_link_preserves_surrounding_spaces(href: str, expected: str) -> None:
+    markdown = _convert_html(f'<p>before<a href="{href}"> middle </a>after</p>')
+
+    assert markdown == expected


### PR DESCRIPTION
HTML anchor conversion trims text with `chomp()`, but several return paths discard the removed whitespace. For example, `<p>before<a> middle </a>after</p>` currently becomes `beforemiddleafter`, losing word boundaries.

Preserve the original text when an anchor has no destination, contains only whitespace, or appears inside `<pre>`. Include the extracted prefix and suffix when emitting an autolink. Normal links and rejected JavaScript links retain their existing behavior.

Adds regression coverage through `MarkItDown.convert_stream()` for missing/empty hrefs, named anchors, whitespace-only anchors, preformatted text, and autolinks, plus controls for normal and rejected links.

Validation on Windows, Python 3.12.14, markdownify 1.2.3:
- Before the fix: 10 new regression cases failed; 8 cases passed.
- After the fix: all 18 HTML tests pass.
- Full core suite: 424 passed, 33 skipped, 3 failed. All three failures also reproduce with the original converter: `test_file_uris` and `test_convert_case_insensitive_uri_schemes` expect POSIX paths; `test_doc_rlink` attempts to write to `C:\tmp\test_rlink.txt`. Remote tests were skipped using the suite's `GITHUB_ACTIONS` setting; no live LLM calls were made.
- `pre-commit run --all-files`: passed.
- Wheel build: passed.
- Focused mypy check reports the same five existing `options` attribute errors on both original and changed converter; no new errors.

Prepared and tested with Codex assistance.