### PR TITLE
fix(ocr): tolerate None shape and notes text in the PPTX OCR converter

### DIFF
--- a/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py
@@ -147,10 +147,11 @@ class PptxConverterWithOCR(DocumentConverter):
 
                 # Text areas
                 elif shape.has_text_frame:
+                    text = shape.text or ""
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\\n"
+                        md_content += "# " + text.lstrip() + "\\n"
                     else:
-                        md_content += shape.text + "\\n"
+                        md_content += text + "\\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -180,7 +181,7 @@ class PptxConverterWithOCR(DocumentConverter):
                 md_content += "\\n\\n### Notes:\\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
+                    md_content += notes_frame.text or ""
                 md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())

--- a/packages/markitdown-ocr/tests/test_pptx_converter.py
+++ b/packages/markitdown-ocr/tests/test_pptx_converter.py
@@ -62,6 +62,17 @@ def _convert(filename: str, ocr_service: MockOCRService) -> str:
         ).text_content
 
 
+def _build_pptx_with_notes() -> io.BytesIO:
+    # A one-slide deck whose only content is a speaker note.
+    prs = pptx.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.notes_slide.notes_text_frame.text = "some notes"
+    buf = io.BytesIO()
+    prs.save(buf)
+    buf.seek(0)
+    return buf
+
+
 # ---------------------------------------------------------------------------
 # pptx_image_start.pptx
 # ---------------------------------------------------------------------------
@@ -217,16 +228,13 @@ def test_pptx_ocr_none_shape_text(
         raising=True,
     )
 
-    assert _convert("pptx_complex_layout.pptx", svc) is not None
+    assert "<!-- Slide number: 1 -->" in _convert("pptx_complex_layout.pptx", svc)
 
 
 def test_pptx_ocr_none_notes_text(monkeypatch: pytest.MonkeyPatch) -> None:
-    prs = pptx.Presentation()
-    slide = prs.slides.add_slide(prs.slide_layouts[6])
-    slide.notes_slide.notes_text_frame.text = "some notes"
-    buf = io.BytesIO()
-    prs.save(buf)
-    buf.seek(0)
+    # Same for notes_text_frame.text, which the notes branch concatenates
+    # directly.
+    buf = _build_pptx_with_notes()
 
     real_notes = pptx.slide.NotesSlide.notes_text_frame
 
@@ -249,4 +257,4 @@ def test_pptx_ocr_none_notes_text(monkeypatch: pytest.MonkeyPatch) -> None:
     converter = PptxConverterWithOCR()
     result = converter.convert(buf, StreamInfo(extension=".pptx"))
 
-    assert result.text_content is not None
+    assert "### Notes:" in result.text_content

--- a/packages/markitdown-ocr/tests/test_pptx_converter.py
+++ b/packages/markitdown-ocr/tests/test_pptx_converter.py
@@ -13,10 +13,14 @@ Note: PPTX slide text uses literal backslash-n (\\n) sequences from the
 underlying PPTX converter template; OCR blocks use real newlines.
 """
 
+import io
 import sys
 from pathlib import Path
 from typing import Any
 
+import pptx
+import pptx.shapes.autoshape
+import pptx.slide
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -199,3 +203,50 @@ def test_pptx_ocr_chart_with_title_text_frame() -> None:
     result = converter._convert_chart_to_markdown(mock_chart)
 
     assert "### Chart: Revenue" in result
+
+
+def test_pptx_ocr_none_shape_text(
+    svc: MockOCRService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # python-pptx returns None for shape.text when an <a:r> run has no <a:t>
+    # child, which happens in some third-party-generated decks.
+    monkeypatch.setattr(
+        pptx.shapes.autoshape.Shape,
+        "text",
+        property(lambda self: None),
+        raising=True,
+    )
+
+    assert _convert("pptx_complex_layout.pptx", svc) is not None
+
+
+def test_pptx_ocr_none_notes_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    prs = pptx.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.notes_slide.notes_text_frame.text = "some notes"
+    buf = io.BytesIO()
+    prs.save(buf)
+    buf.seek(0)
+
+    real_notes = pptx.slide.NotesSlide.notes_text_frame
+
+    class _NoneText:
+        text = None
+
+    def fake_notes(self: pptx.slide.NotesSlide) -> Any:
+        frame = real_notes.fget(self)
+        if frame is None:
+            return None
+        return _NoneText()
+
+    monkeypatch.setattr(
+        pptx.slide.NotesSlide,
+        "notes_text_frame",
+        property(fake_notes),
+        raising=True,
+    )
+
+    converter = PptxConverterWithOCR()
+    result = converter.convert(buf, StreamInfo(extension=".pptx"))
+
+    assert result.text_content is not None


### PR DESCRIPTION
## Description

#2059 made `PptxConverter` tolerate `None` from `shape.text` and `notes_text_frame.text`, but the sibling `PptxConverterWithOCR` kept the original unguarded concatenation, so the same decks still fail with `AttributeError: 'NoneType' object has no attribute 'lstrip'` or `TypeError: can only concatenate str (not "NoneType") to str` once the OCR plugin is enabled.

This applies the same `or ""` guard at the three sites in `packages/markitdown-ocr/src/markitdown_ocr/_pptx_converter_with_ocr.py`, and adds two regression tests mirroring the ones #2059 added for the core converter. Both new tests fail on the current code and pass with the fix; the full `packages/markitdown-ocr` suite is green (43 passed).

Fixes #2398
