### PR TITLE
fix(ocr): tolerate legacy showZeroes sheet views in XLSX conversion

### DIFF
--- a/packages/markitdown-ocr/pyproject.toml
+++ b/packages/markitdown-ocr/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 
 # Core dependencies — matches the file-format libraries markitdown already uses
 dependencies = [
-  "markitdown>=0.1.0",
+  # 0.1.8b1 is the first version with the showZeroes sheet view repair helpers
+  "markitdown>=0.1.8b1",
   "pdfminer.six>=20251230",
   "pdfplumber>=0.11.9",
   "PyMuPDF>=1.24.0",

--- a/packages/markitdown-ocr/src/markitdown_ocr/_xlsx_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_xlsx_converter_with_ocr.py
@@ -8,6 +8,10 @@ import sys
 from typing import Any, BinaryIO, Optional
 
 from markitdown.converters import HtmlConverter
+from markitdown.converters._xlsx_converter import (
+    _read_xlsx_sheets,
+    _repair_sheetview_show_zeroes,
+)
 from markitdown import DocumentConverter, DocumentConverterResult, StreamInfo
 from markitdown._exceptions import (
     MissingDependencyException,
@@ -90,7 +94,7 @@ class XlsxConverterWithOCR(DocumentConverter):
     ) -> DocumentConverterResult:
         """Standard conversion without OCR."""
         file_stream.seek(0)
-        sheets = pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
+        sheets = _read_xlsx_sheets(file_stream)
         md_content = ""
 
         for sheet_name in sheets:
@@ -110,7 +114,13 @@ class XlsxConverterWithOCR(DocumentConverter):
     ) -> DocumentConverterResult:
         """Convert XLSX with image OCR."""
         file_stream.seek(0)
-        wb = load_workbook(file_stream)
+        try:
+            wb = load_workbook(file_stream)
+        except TypeError as exc:
+            if "showZeroes" not in str(exc):
+                raise
+            file_stream = _repair_sheetview_show_zeroes(file_stream)
+            wb = load_workbook(file_stream)
 
         md_content = ""
 

--- a/packages/markitdown-ocr/src/markitdown_ocr/_xlsx_converter_with_ocr.py
+++ b/packages/markitdown-ocr/src/markitdown_ocr/_xlsx_converter_with_ocr.py
@@ -28,6 +28,26 @@ except ImportError:
     _xlsx_dependency_exc_info = sys.exc_info()
 
 
+def _load_xlsx_workbook(file_stream: BinaryIO) -> tuple[Any, BinaryIO]:
+    """
+    Load a workbook, returning it along with the stream it was read from.
+
+    Some producers write the legacy attribute "showZeroes" on <sheetView>, which
+    openpyxl rejects. The workbook is repaired and read again, the same way the core
+    XLSX converter does. The returned stream is the repaired copy in that case, so
+    callers that read the same workbook again do not hit the rejected attribute.
+    """
+    start_pos = file_stream.tell()
+    try:
+        return load_workbook(file_stream), file_stream
+    except TypeError as exc:
+        if "showZeroes" not in str(exc):
+            raise
+
+        repaired_stream = _repair_sheetview_show_zeroes(file_stream, start_pos)
+        return load_workbook(repaired_stream), repaired_stream
+
+
 class XlsxConverterWithOCR(DocumentConverter):
     """
     Enhanced XLSX Converter with OCR support for embedded images.
@@ -114,13 +134,7 @@ class XlsxConverterWithOCR(DocumentConverter):
     ) -> DocumentConverterResult:
         """Convert XLSX with image OCR."""
         file_stream.seek(0)
-        try:
-            wb = load_workbook(file_stream)
-        except TypeError as exc:
-            if "showZeroes" not in str(exc):
-                raise
-            file_stream = _repair_sheetview_show_zeroes(file_stream)
-            wb = load_workbook(file_stream)
+        wb, file_stream = _load_xlsx_workbook(file_stream)
 
         md_content = ""
 

--- a/packages/markitdown-ocr/tests/test_xlsx_converter.py
+++ b/packages/markitdown-ocr/tests/test_xlsx_converter.py
@@ -255,46 +255,53 @@ def test_xlsx_no_ocr_service_no_tags() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _write_legacy_show_zeroes_xlsx(tmp_path: Path) -> Path:
-    from openpyxl import Workbook
+def _write_legacy_show_zeroes_xlsx(filename: str, tmp_path: Path) -> Path:
+    """Copy a test workbook, writing the legacy showZeroes attribute on its sheet views."""
+    source_path = TEST_DATA_DIR / filename
+    if not source_path.exists():
+        pytest.skip(f"Test file not found: {source_path}")
 
-    base_path = tmp_path / "base.xlsx"
-    xlsx_path = tmp_path / "legacy_show_zeroes.xlsx"
+    target_path = tmp_path / "legacy_show_zeroes.xlsx"
+    patched = False
 
-    workbook = Workbook()
-    sheet = workbook.active
-    sheet.title = "Data"
-    sheet["A1"] = "hello"
-    sheet["B1"] = "world"
-    workbook.save(base_path)
-
-    with zipfile.ZipFile(base_path) as source:
-        with zipfile.ZipFile(xlsx_path, "w", zipfile.ZIP_DEFLATED) as target:
+    with zipfile.ZipFile(source_path) as source:
+        with zipfile.ZipFile(target_path, "w", zipfile.ZIP_DEFLATED) as target:
             for item in source.infolist():
                 data = source.read(item.filename)
-                if item.filename == "xl/worksheets/sheet1.xml":
-                    data = data.replace(
-                        b"<sheetView ", b'<sheetView showZeroes="0" ', 1
+                if item.filename.startswith(
+                    "xl/worksheets/"
+                ) and item.filename.endswith(".xml"):
+                    updated = data.replace(
+                        b"<sheetView ", b'<sheetView showZeroes="0" '
                     )
-                    assert b'showZeroes="0"' in data
+                    patched = patched or updated != data
+                    data = updated
                 target.writestr(item, data)
 
-    return xlsx_path
+    # Guard the fixture: without the legacy attribute these tests stop exercising
+    # the repair and pass against unfixed code.
+    assert patched
+
+    return target_path
 
 
 def test_xlsx_legacy_show_zeroes_sheetview(svc: MockOCRService, tmp_path: Path) -> None:
-    xlsx_path = _write_legacy_show_zeroes_xlsx(tmp_path)
+    xlsx_path = _write_legacy_show_zeroes_xlsx("xlsx_image_start.xlsx", tmp_path)
     converter = XlsxConverterWithOCR()
     with open(xlsx_path, "rb") as f:
         md = converter.convert(
             f, StreamInfo(extension=".xlsx"), ocr_service=svc
         ).text_content
-    assert md == "## Data\n\n| hello | world |\n| --- | --- |"
+    # The repair keeps the sheet tables and the embedded images, so the output
+    # matches the untouched workbook.
+    assert _IMG_SECTION in md
+    assert md == _convert("xlsx_image_start.xlsx", svc)
 
 
 def test_xlsx_legacy_show_zeroes_sheetview_no_ocr_service(tmp_path: Path) -> None:
-    xlsx_path = _write_legacy_show_zeroes_xlsx(tmp_path)
+    xlsx_path = _write_legacy_show_zeroes_xlsx("xlsx_image_start.xlsx", tmp_path)
     converter = XlsxConverterWithOCR()
     with open(xlsx_path, "rb") as f:
         md = converter.convert(f, StreamInfo(extension=".xlsx")).text_content
-    assert md == "## Data\n| hello | world |\n| --- | --- |"
+    assert "| Widget A | 100 |" in md
+    assert "*[Image OCR]" not in md

--- a/packages/markitdown-ocr/tests/test_xlsx_converter.py
+++ b/packages/markitdown-ocr/tests/test_xlsx_converter.py
@@ -14,6 +14,7 @@ Images are grouped at the end of each sheet under:
 """
 
 import sys
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -247,3 +248,53 @@ def test_xlsx_no_ocr_service_no_tags() -> None:
         md = converter.convert(f, StreamInfo(extension=".xlsx")).text_content
     assert "*[Image OCR]" not in md
     assert "[End OCR]*" not in md
+
+
+# ---------------------------------------------------------------------------
+# Legacy showZeroes sheet views
+# ---------------------------------------------------------------------------
+
+
+def _write_legacy_show_zeroes_xlsx(tmp_path: Path) -> Path:
+    from openpyxl import Workbook
+
+    base_path = tmp_path / "base.xlsx"
+    xlsx_path = tmp_path / "legacy_show_zeroes.xlsx"
+
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Data"
+    sheet["A1"] = "hello"
+    sheet["B1"] = "world"
+    workbook.save(base_path)
+
+    with zipfile.ZipFile(base_path) as source:
+        with zipfile.ZipFile(xlsx_path, "w", zipfile.ZIP_DEFLATED) as target:
+            for item in source.infolist():
+                data = source.read(item.filename)
+                if item.filename == "xl/worksheets/sheet1.xml":
+                    data = data.replace(
+                        b"<sheetView ", b'<sheetView showZeroes="0" ', 1
+                    )
+                    assert b'showZeroes="0"' in data
+                target.writestr(item, data)
+
+    return xlsx_path
+
+
+def test_xlsx_legacy_show_zeroes_sheetview(svc: MockOCRService, tmp_path: Path) -> None:
+    xlsx_path = _write_legacy_show_zeroes_xlsx(tmp_path)
+    converter = XlsxConverterWithOCR()
+    with open(xlsx_path, "rb") as f:
+        md = converter.convert(
+            f, StreamInfo(extension=".xlsx"), ocr_service=svc
+        ).text_content
+    assert md == "## Data\n\n| hello | world |\n| --- | --- |"
+
+
+def test_xlsx_legacy_show_zeroes_sheetview_no_ocr_service(tmp_path: Path) -> None:
+    xlsx_path = _write_legacy_show_zeroes_xlsx(tmp_path)
+    converter = XlsxConverterWithOCR()
+    with open(xlsx_path, "rb") as f:
+        md = converter.convert(f, StreamInfo(extension=".xlsx")).text_content
+    assert md == "## Data\n| hello | world |\n| --- | --- |"


### PR DESCRIPTION
Fixes #2400.

`XlsxConverterWithOCR` calls `load_workbook()` and `pandas.read_excel()` directly, so it never gets the `showZeroes` -> `showZeros` worksheet repair that #2064 added to the core XLSX converter. Workbooks that still carry the legacy attribute raise `TypeError: SheetView.__init__() got an unexpected keyword argument 'showZeroes'` as soon as the OCR plugin is enabled, even though plain MarkItDown converts them fine.

This reuses the core repair helpers instead of duplicating them: the standard path now goes through `_read_xlsx_sheets`, and the OCR path loads the workbook through a small `_load_xlsx_workbook` helper that repairs and retries on that specific error, returning the repaired stream so the per-sheet `read_excel()` calls read it too.

One packaging note: those helpers landed in #2064, after the last version bump, so the first markitdown that has them is `0.1.8b1`. `markitdown-ocr` declared `markitdown>=0.1.0`, which would give an `ImportError` at plugin import time against a released markitdown, so the floor is raised here. Happy to change the pin if you would rather sequence the releases differently.

Tests: two regression tests in `packages/markitdown-ocr/tests/test_xlsx_converter.py` build a copy of `xlsx_image_start.xlsx` with the legacy attribute, covering the OCR path and the no-OCR path. They fail before the fix and pass after, and the OCR one asserts the output matches the untouched workbook, so the repair keeps the embedded images.