### PR TITLE
Fix charset detection returning literal None string on empty input

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -76,7 +76,8 @@ class CsvConverter(DocumentConverter):
         if stream_info.charset:
             content = file_stream.read().decode(stream_info.charset)
         else:
-            content = str(from_bytes(file_stream.read()).best())
+            detected = from_bytes(file_stream.read()).best()
+            content = str(detected) if detected is not None else ""
 
         # Excel and other tools prepend a UTF-8 BOM to CSV exports; strip it so
         # it does not end up inside the first header cell.

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -55,6 +55,7 @@ class PlainTextConverter(DocumentConverter):
         if stream_info.charset:
             text_content = file_stream.read().decode(stream_info.charset)
         else:
-            text_content = str(from_bytes(file_stream.read()).best())
+            detected = from_bytes(file_stream.read()).best()
+            text_content = str(detected) if detected is not None else ""
 
         return DocumentConverterResult(markdown=text_content)


### PR DESCRIPTION
`PlainTextConverter` and `CsvConverter` did `str(from_bytes(...).best())` without a None check, so when detection failed it returned the literal string `"None"` as document content.
This change checks for `None` and falls back to `""` to avoid corrupting output.