### PR TITLE
Fix PPTX shape sorting treating top-zero as missing

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -189,8 +189,8 @@ class PptxConverter(DocumentConverter):
                     sorted_shapes = sorted(
                         shape.shapes,
                         key=lambda x: (
-                            float("-inf") if not x.top else x.top,
-                            float("-inf") if not x.left else x.left,
+                            float("-inf") if x.top is None else x.top,
+                            float("-inf") if x.left is None else x.left,
                         ),
                     )
                     for subshape in sorted_shapes:
@@ -199,8 +199,8 @@ class PptxConverter(DocumentConverter):
             sorted_shapes = sorted(
                 slide.shapes,
                 key=lambda x: (
-                    float("-inf") if not x.top else x.top,
-                    float("-inf") if not x.left else x.left,
+                    float("-inf") if x.top is None else x.top,
+                    float("-inf") if x.left is None else x.left,
                 ),
             )
             for shape in sorted_shapes:


### PR DESCRIPTION
`_pptx_converter.py` used if not `x.top / x.left` for sort keys, so shapes at position `0` were treated as missing and sorted as `-inf`, corrupting slide reading order.
This change checks `is None` instead to preserve correct order for zero-positioned shapes.