### PR TITLE
Fix CSV parsing for CR-only line endings

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -83,7 +83,7 @@ class CsvConverter(DocumentConverter):
         content = content.lstrip("\ufeff")
 
         # Parse CSV content
-        reader = csv.reader(io.StringIO(content))
+        reader = csv.reader(io.StringIO(content, newline=""))
         rows = list(reader)
         _trim_outer_blank_rows(rows)
 

--- a/packages/markitdown/tests/test_csv_line_endings.py
+++ b/packages/markitdown/tests/test_csv_line_endings.py
@@ -1,0 +1,53 @@
+"""Regression tests for CR-only CSV record separators (issue #2411)."""
+
+import io
+
+import pytest
+
+from markitdown import MarkItDown, StreamInfo
+
+
+@pytest.fixture(scope="module")
+def converter() -> MarkItDown:
+    return MarkItDown(enable_plugins=False)
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"], ids=["LF", "CRLF", "CR"])
+@pytest.mark.parametrize("final_newline", [False, True])
+def test_csv_record_separators_produce_a_table(
+    converter: MarkItDown, newline: str, final_newline: bool
+) -> None:
+    content = newline.join(["name,age", "Alice,30"])
+    if final_newline:
+        content += newline
+
+    result = converter.convert_stream(
+        io.BytesIO(content.encode("utf-8")),
+        stream_info=StreamInfo(extension=".csv", charset="utf-8"),
+    )
+
+    assert result.markdown == "| name | age |\n| --- | --- |\n| Alice | 30 |"
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"], ids=["LF", "CRLF", "CR"])
+@pytest.mark.parametrize(
+    "cell_newline", ["\n", "\r\n", "\r"], ids=["cell-LF", "cell-CRLF", "cell-CR"]
+)
+def test_csv_quoted_line_break_stays_inside_its_cell(
+    converter: MarkItDown, newline: str, cell_newline: str
+) -> None:
+    content = newline.join(
+        ["name,notes", f'Alice,"first{cell_newline}second"', "Bob,plain"]
+    )
+
+    result = converter.convert_stream(
+        io.BytesIO(content.encode("utf-8")),
+        stream_info=StreamInfo(extension=".csv", charset="utf-8"),
+    )
+
+    assert result.markdown == (
+        "| name | notes |\n"
+        "| --- | --- |\n"
+        "| Alice | first second |\n"
+        "| Bob | plain |"
+    )


### PR DESCRIPTION
## Summary

Fixes #2411.

CSV input with CR-only (`\r`) record separators currently raises `_csv.Error` in `CsvConverter`. Through the public `MarkItDown.convert_stream()` API, conversion then falls back to plain text instead of producing a Markdown table.

Initialize the in-memory text stream with `io.StringIO(content, newline="")` so the CSV reader can handle LF, CRLF, and CR record separators without translating line endings inside quoted fields. The existing cell normalization and Markdown escaping are unchanged.

## Regression coverage

Add 15 parameterized cases through the public conversion API:

- LF, CRLF, and CR record separators, with and without a final newline (6 cases).
- Each record separator combined with LF, CRLF, or CR inside a quoted cell (9 cases).

Before the fix, the five CR-record-separator cases fail and the other ten pass. With the fix, all 15 pass.

## Validation

Environment: Windows, Python 3.12.14.

- New regression tests plus existing CSV tests: **29 passed, 52 deselected** (`python -m pytest packages/markitdown/tests/test_csv_line_endings.py packages/markitdown/tests/test_module_misc.py -k csv -q`, using the local source tree).
- `pre-commit run --all-files`: **passed** (Black).
- `git diff --check` and `git diff --cached --check`: **passed**.
- Full core suite (`hatch test -py 3.12` from `packages/markitdown`, with `GITHUB_ACTIONS=true` and no OpenAI API key): **425 passed, 34 skipped, 4 failed**.

All four full-suite failures also reproduce after restoring the CSV converter to the unchanged base revision (`b6e8bbdce628d564c6af031b5f26cda6e818ea10`):

- `test_output_to_stdout[test_vector6]` and `test_input_from_stdin_without_hints[test_vector6]`: Japanese CSV text cannot be represented faithfully by the local Windows default output encoding.
- `test_file_uris` and `test_convert_case_insensitive_uri_schemes`: tests expect POSIX paths, but Windows returns Windows-style paths.

These existing failures are outside this PR's scope. The local run also reported pytest cache permission warnings. Linux and other Python versions have not been verified locally.

## AI assistance

AI assistance was used to investigate the issue, prepare the fix and tests, and run validation.
