### PR TITLE
Fix ipynb title extraction from string cell sources

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -64,7 +64,7 @@ class IpynbConverter(DocumentConverter):
 
             for cell in notebook_content.get("cells", []):
                 cell_type = cell.get("cell_type", "")
-                source_lines = cell.get("source", [])
+                source_lines = self._get_source_lines(cell.get("source", []))
 
                 if cell_type == "markdown":
                     md_output.append("".join(source_lines))
@@ -96,3 +96,10 @@ class IpynbConverter(DocumentConverter):
             raise FileConversionException(
                 f"Error converting .ipynb file: {str(e)}"
             ) from e
+
+    def _get_source_lines(self, source: Any) -> list[str]:
+        if isinstance(source, str):
+            return source.splitlines(keepends=True)
+        if isinstance(source, list):
+            return source
+        return []

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1412,6 +1412,27 @@ def test_ipynb_heading_title_preserves_leading_hash() -> None:
     assert result.title == "#hashtag campaign results"
 
 
+def test_ipynb_title_from_string_source() -> None:
+    """Cell source may be either a string or a list of strings."""
+    from markitdown.converters._ipynb_converter import IpynbConverter
+
+    notebook = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": "# My Report\n\nContent",
+                "metadata": {},
+            }
+        ],
+    }
+    result = IpynbConverter()._convert(notebook)
+    assert result.title == "My Report"
+    assert result.markdown == "# My Report\n\nContent"
+
+
 def test_ipynb_accepts_non_ascii() -> None:
     """IpynbConverter.accepts() must not raise on non-ASCII binary content."""
     from markitdown.converters._ipynb_converter import IpynbConverter


### PR DESCRIPTION
## Summary
- normalize notebook cell `source` values before rendering and title extraction
- preserve existing list-of-lines behavior while supporting string sources
- add a regression test for markdown cells whose source is a single string

Fixes #2115

## Testing
- `uv run --python /usr/local/bin/python3.12 --directory packages/markitdown --with pytest python -m pytest tests/test_module_misc.py -k ipynb`
- `uv run --python /usr/local/bin/python3.12 --with black black --check packages/markitdown/src/markitdown/converters/_ipynb_converter.py packages/markitdown/tests/test_module_misc.py`
- `git diff --check`
