### PR TITLE
Update Docker images to Debian trixie (Python 3.13-slim-trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-trixie
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EXIFTOOL_PATH=/usr/bin/exiftool
 ENV FFMPEG_PATH=/usr/bin/ffmpeg
+ENV ORT_DISABLE_TELEMETRY=1
 
 # Runtime dependency
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
-    exiftool
+    libimage-exiftool-perl
 
 ARG INSTALL_GIT=false
 RUN if [ "$INSTALL_GIT" = "true" ]; then \

--- a/packages/markitdown-mcp/Dockerfile
+++ b/packages/markitdown-mcp/Dockerfile
@@ -1,28 +1,27 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-trixie
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EXIFTOOL_PATH=/usr/bin/exiftool
 ENV FFMPEG_PATH=/usr/bin/ffmpeg
 ENV MARKITDOWN_ENABLE_PLUGINS=True
+ENV ORT_DISABLE_TELEMETRY=1
 
-# Runtime dependency
-# NOTE: Add any additional MarkItDown plugins here
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg \
-    exiftool
-
-# Cleanup
-RUN rm -rf /var/lib/apt/lists/*
+# Runtime dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libimage-exiftool-perl \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . /app
-RUN pip --no-cache-dir install /app
+
+RUN pip install --no-cache-dir /app
 
 WORKDIR /workdir
 
-# Default USERID and GROUPID
 ARG USERID=nobody
 ARG GROUPID=nogroup
 
-USER $USERID:$GROUPID
+USER ${USERID}:${GROUPID}
 
-ENTRYPOINT [ "markitdown-mcp" ]
+ENTRYPOINT ["markitdown-mcp"]

--- a/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
+++ b/packages/markitdown-mcp/src/markitdown_mcp/__main__.py
@@ -3,6 +3,7 @@ import sys
 import os
 from collections.abc import AsyncIterator
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.server import Settings
 from starlette.applications import Starlette
 from mcp.server.sse import SseServerTransport
 from starlette.requests import Request
@@ -12,6 +13,10 @@ from mcp.server import Server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from markitdown import MarkItDown
 import uvicorn
+
+# Resolve the forward reference in Settings.lifespan before the model is first
+# instantiated, otherwise pydantic-settings emits IncompleteFieldDefinitionWarning.
+Settings.model_rebuild()
 
 # Initialize FastMCP server for MarkItDown (SSE)
 mcp = FastMCP("markitdown")


### PR DESCRIPTION
Moves both Dockerfiles from `python:3.13-slim-bullseye` to `python:3.13-slim-trixie`, plus two small fixes surfaced by the upgrade.

Fixes: #2420 

### Changes

- **`Dockerfile`, `packages/markitdown-mcp/Dockerfile`**: base image to `python:3.13-slim-trixie`.
- **exiftool package name**: `exiftool` does not exist in trixie (`apt-cache policy exiftool` → `Candidate: (none)`), so the build fails at `apt-get install`. Switched to `libimage-exiftool-perl`, which provides `/usr/bin/exiftool` and matches the existing `EXIFTOOL_PATH`.
- **`ORT_DISABLE_TELEMETRY=1`**: onnxruntime (via magika) logs `Failed to persist telemetry device ID` on every run, because the images run as `nobody`, whose `$HOME` is `/nonexistent`. Setting this removes the noise — relevant for the MCP server, where stray stderr output clutters client logs.
- **`packages/markitdown-mcp/src/markitdown_mcp/__main__.py`**: call `Settings.model_rebuild()` before `FastMCP("markitdown")` is constructed, to silence `IncompleteFieldDefinitionWarning: Field 'lifespan' has an incomplete definition` from newer `pydantic-settings`. This resolves the forward reference rather than suppressing the warning: `Settings.model_fields['lifespan'].annotation` goes from an unresolved string to a real `Callable[[FastMCP], AbstractAsyncContextManager[LifespanResultT]] | None`. The call must precede first instantiation, since that is when the warning fires.

### Verification

Both images build and run:

- `exiftool 13.25` and `ffmpeg 7.1.5-0+deb13u1` resolve at the paths `EXIFTOOL_PATH` / `FFMPEG_PATH` point to.
- `markitdown` CLI converts HTML → Markdown correctly.
- `markitdown-mcp` completes a full stdio JSON-RPC handshake, `tools/list`, and a real `tools/call` conversion. stderr now contains only the normal MCP request log line, no warnings.