### PR TITLE
docs(ocr): drop CLI flags that the markitdown CLI does not define

### DIFF
--- a/packages/markitdown-ocr/README.md
+++ b/packages/markitdown-ocr/README.md
@@ -29,8 +29,12 @@ pip install openai
 ### Command Line
 
 ```bash
-markitdown document.pdf --use-plugins --llm-client openai --llm-model gpt-4o
+markitdown document.pdf --use-plugins
 ```
+
+> [!NOTE]
+> The CLI has no `--llm-client` / `--llm-model` flags — the LLM-backed OCR
+> described below is configured through the Python API only.
 
 ### Python API
 


### PR DESCRIPTION
The `markitdown-ocr` README's command-line example used `--llm-client openai --llm-model gpt-4o` — neither flag exists in the CLI's argparse (`__main__.py`); pasting the command fails with "unrecognized arguments". The example now shows the working CLI invocation and notes that LLM-backed OCR is configured through the Python API (whose snippet below the change is correct).