### PR TITLE
docs(converters): fix copy-pasted comment in _rss_converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -85,7 +85,7 @@ class RssConverter(DocumentConverter):
             if mimetype.startswith(prefix):
                 return True
 
-        # Check for precise mimetypes and file extensions
+        # Check for candidate mimetypes and file extensions
         if extension in CANDIDATE_FILE_EXTENSIONS:
             return self._check_xml(file_stream)
 


### PR DESCRIPTION
`_rss_converter.py` had the identical comment "Check for precise mimetypes and file extensions" twice — the second block actually checks `CANDIDATE_FILE_EXTENSIONS` / `CANDIDATE_MIME_TYPE_PREFIXES` (candidates, not precise matches). The comment now says "candidate".