### PR TITLE
fix(rss): read an element's whole text, not only its first node

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -310,12 +310,21 @@ class RssConverter(DocumentConverter):
     ) -> Union[str, None]:
         """Get data from first child element with the given tag name.
         Returns None when no such element is found.
+
+        An element's text is not necessarily a single node: a value written as
+        ``<description>\\n  <![CDATA[...]]>\\n</description>`` reaches the parser
+        as whitespace, then the CDATA section, then more whitespace. Reading
+        only the first of those returns the layout and drops the value, so all
+        of the element's own text and CDATA children are joined.
         """
         nodes = element.getElementsByTagName(tag_name)
         if not nodes:
             return None
-        fc = nodes[0].firstChild
-        if fc:
-            if hasattr(fc, "data"):
-                return fc.data
-        return None
+        parts = [
+            child.data
+            for child in nodes[0].childNodes
+            if child.nodeType in (Node.TEXT_NODE, Node.CDATA_SECTION_NODE)
+        ]
+        if not parts:
+            return None
+        return "".join(parts)

--- a/packages/markitdown/tests/test_rss_converter.py
+++ b/packages/markitdown/tests/test_rss_converter.py
@@ -248,3 +248,97 @@ def test_atom_plain_text_layout_whitespace_is_removed() -> None:
         "",
         "Then check status.",
     ]
+
+
+def test_rss_description_survives_a_cdata_section_on_its_own_line() -> None:
+    """A pretty-printed CDATA payload is a later child, not the first one."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel>
+  <title>Example feed</title>
+  <description>Example feed description</description>
+  <item>
+    <title>Example item</title>
+    <description>
+      <![CDATA[<p>The <strong>body</strong> of the item.</p>]]>
+    </description>
+  </item>
+</channel></rss>
+"""
+
+    result = RssConverter().convert(io.BytesIO(feed), StreamInfo(extension=".rss"))
+
+    assert "The **body** of the item." in result.markdown
+
+
+def test_rss_title_survives_a_cdata_section_in_the_middle() -> None:
+    """Text either side of a CDATA section belongs to the same value."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel>
+  <title>Example feed</title>
+  <description>Example feed description</description>
+  <item>
+    <title>Quarterly <![CDATA[R&D]]> report</title>
+    <description>Body.</description>
+  </item>
+</channel></rss>
+"""
+
+    result = RssConverter().convert(io.BytesIO(feed), StreamInfo(extension=".rss"))
+
+    assert "## Quarterly R&D report" in result.markdown
+
+
+def test_atom_summary_survives_a_cdata_section_on_its_own_line() -> None:
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example feed</title>
+  <entry>
+    <title>Example entry</title>
+    <summary type="html">
+      <![CDATA[<p>A <em>structured</em> summary.</p>]]>
+    </summary>
+  </entry>
+</feed>
+"""
+
+    result = RssConverter().convert(
+        io.BytesIO(feed), StreamInfo(mimetype="application/atom+xml")
+    )
+
+    assert "A *structured* summary." in result.markdown
+
+
+def test_rss_cdata_only_description_is_unchanged() -> None:
+    """The case that already worked must keep working."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel>
+  <title>Example feed</title>
+  <description>Example feed description</description>
+  <item>
+    <title>Example item</title>
+    <description><![CDATA[<p>Only a CDATA section.</p>]]></description>
+  </item>
+</channel></rss>
+"""
+
+    result = RssConverter().convert(io.BytesIO(feed), StreamInfo(extension=".rss"))
+
+    assert "Only a CDATA section." in result.markdown
+
+
+def test_rss_item_without_a_description_is_still_converted() -> None:
+    """An absent element must stay absent, not become an empty string."""
+    feed = b"""<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel>
+  <title>Example feed</title>
+  <description>Example feed description</description>
+  <item>
+    <title>Example item</title>
+  </item>
+</channel></rss>
+"""
+
+    result = RssConverter().convert(io.BytesIO(feed), StreamInfo(extension=".rss"))
+
+    assert result.title == "Example feed"
+    assert "## Example item" in result.markdown


### PR DESCRIPTION
## What this changes

An RSS item body written as a pretty-printed CDATA section is dropped. The item keeps its
heading; the content underneath it disappears.

```xml
<item>
  <title>Example item</title>
  <description>
    <![CDATA[<p>The <strong>body</strong> of the item.</p>]]>
  </description>
</item>
```

```
# Example feed
Example feed description

## Example item
```

That layout is ordinary in hand-written and CMS-generated feeds, and it is what WordPress
emits for `content:encoded`.

## Why

`_get_data_by_tag_name` reads one node:

```python
fc = nodes[0].firstChild
if fc:
    if hasattr(fc, "data"):
        return fc.data
return None
```

An element's text is not necessarily one node. The example above reaches the parser as three
children -- a text node holding `"\n    "`, the CDATA section, then another text node -- so
`firstChild` is the indentation and the value is never read. The same happens whenever a
CDATA section sits next to text:

```xml
<title>Quarterly <![CDATA[R&D]]> report</title>   ->  ## Quarterly
```

`_get_data_by_tag_name` backs `title`, `description`, `pubDate` and `content:encoded` on the
RSS side and `title`, `updated`, `summary` and `content` on the Atom side, so every one of
them truncates at the first CDATA boundary.

## Fix

Join the element's own text and CDATA children instead of reading only the first one. This is
what `_collect_node_text` in `_epub_converter` already does for the same minidom shape.

The join is deliberately not recursive: only the element's direct text and CDATA children are
read, which is exactly the set `firstChild` was sampling from. Element children keep behaving
as before -- `<summary type="xhtml">` is still handled by `_get_atom_content` before this
function is reached, and an element whose first child is markup still returns `None`.

## Tests

Added to `packages/markitdown/tests/test_rss_converter.py`:

- an RSS `<description>` whose CDATA sits on its own line
- an RSS `<title>` with a CDATA section in the middle of the text
- an Atom `<summary type="html">` whose CDATA sits on its own line
- pinned: a `<description>` that is nothing but a CDATA section, which already worked
- pinned: an item with no `<description>` at all, which must stay absent rather than become
  an empty string

Against unmodified `main`:

```
E  AssertionError: assert 'The **body** of the item.' in '# Example feed\nExample feed description\n\n## Example item\n'
E  AssertionError: assert '## Quarterly R&D report' in '# Example feed\nExample feed description\n\n## Quarterly \nBody.'
E  AssertionError: assert 'A *structured* summary.' in '# Example feed\n\n## Example entry\n'
3 failed, 14 passed
```

With the fix:

```
17 passed
```

## How I tested

Windows 11, Python 3.12, editable install of `packages/markitdown[all]`.

```
pytest tests/test_rss_converter.py   ->  3 failed, 14 passed  (before)
pytest tests/test_rss_converter.py   ->  17 passed            (after)
pytest tests/                        ->  18 failed, 431 passed, 4 skipped
```

Those 18 are unchanged by this PR: `main` gives `18 failed, 426 passed, 4 skipped` on this
machine before any edit, and the 5 added tests account for the difference. They are the CLI
stdout-encoding, Windows file-URI and speech-transcription tests that need a UTF-8 console,
a case-sensitive path and network/ffmpeg.

`black --check` clean on both files.
