### PR TITLE
fix(ipynb): strip the UTF-8 BOM so a notebook is not emitted as raw JSON

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -54,6 +54,11 @@ class IpynbConverter(DocumentConverter):
         # Parse and convert the notebook
         encoding = stream_info.charset or "utf-8"
         notebook_content = file_stream.read().decode(encoding=encoding)
+
+        # Editors and Windows tooling prepend a UTF-8 BOM, which json rejects
+        # outright; strip it so the notebook is read as a notebook.
+        notebook_content = notebook_content.lstrip("\ufeff")
+
         return self._convert(json.loads(notebook_content))
 
     def _convert(self, notebook_content: dict) -> DocumentConverterResult:

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1412,6 +1412,72 @@ def test_ipynb_heading_title_preserves_leading_hash() -> None:
     assert result.title == "#hashtag campaign results"
 
 
+_UTF8_BOM = b"\xef\xbb\xbf"
+
+_BOM_NOTEBOOK = {
+    "nbformat": 4,
+    "nbformat_minor": 5,
+    "metadata": {},
+    "cells": [
+        {"cell_type": "markdown", "source": ["# Quarterly notes\n"], "metadata": {}},
+        {"cell_type": "code", "source": ["print('hello')\n"], "metadata": {}},
+    ],
+}
+
+
+def test_ipynb_with_a_utf8_bom_is_still_converted() -> None:
+    """A leading BOM must not stop the notebook from being parsed."""
+    from markitdown.converters._ipynb_converter import IpynbConverter
+
+    data = _UTF8_BOM + json.dumps(_BOM_NOTEBOOK).encode("utf-8")
+
+    result = IpynbConverter().convert(
+        io.BytesIO(data), StreamInfo(extension=".ipynb", charset="utf-8")
+    )
+
+    assert "# Quarterly notes" in result.markdown
+    assert "```python\nprint('hello')" in result.markdown
+    assert result.title == "Quarterly notes"
+
+
+def test_ipynb_with_a_utf8_bom_is_not_emitted_as_raw_json() -> None:
+    """The whole stack must not fall through to the plain-text converter."""
+    data = _UTF8_BOM + json.dumps(_BOM_NOTEBOOK).encode("utf-8")
+
+    result = MarkItDown().convert_stream(
+        io.BytesIO(data), stream_info=StreamInfo(extension=".ipynb")
+    )
+
+    assert result.markdown.startswith("# Quarterly notes")
+    assert "nbformat" not in result.markdown
+
+
+def test_ipynb_without_a_bom_is_unchanged() -> None:
+    """The case that already worked must produce exactly the same markdown."""
+    from markitdown.converters._ipynb_converter import IpynbConverter
+
+    data = json.dumps(_BOM_NOTEBOOK).encode("utf-8")
+
+    result = IpynbConverter().convert(
+        io.BytesIO(data), StreamInfo(extension=".ipynb", charset="utf-8")
+    )
+
+    assert result.markdown == "# Quarterly notes\n\n\n```python\nprint('hello')\n\n```"
+
+
+def test_ipynb_utf8_sig_charset_still_works() -> None:
+    """A charset that already consumes the BOM must not be double-stripped."""
+    from markitdown.converters._ipynb_converter import IpynbConverter
+
+    data = _UTF8_BOM + json.dumps(_BOM_NOTEBOOK).encode("utf-8")
+
+    result = IpynbConverter().convert(
+        io.BytesIO(data), StreamInfo(extension=".ipynb", charset="utf-8-sig")
+    )
+
+    assert "# Quarterly notes" in result.markdown
+
+
 def test_ipynb_accepts_non_ascii() -> None:
     """IpynbConverter.accepts() must not raise on non-ASCII binary content."""
     from markitdown.converters._ipynb_converter import IpynbConverter


### PR DESCRIPTION
## What this changes

A `.ipynb` saved with a UTF-8 BOM is not converted as a notebook. It comes back as its own
raw JSON:

```
﻿{"nbformat": 4, "nbformat_minor": 5, "metadata": {}, "cells": [{"cell_type": "markdown",
"source": ["# Quarterly notes\n"], "metadata": {}}, {"cell_type": "code", "source":
["print('hello')\n"], "metadata": {}}]}
```

instead of:

````
# Quarterly notes

```python
print('hello')
```
````

## Why

`IpynbConverter.convert` hands the decoded text straight to `json.loads`:

```python
encoding = stream_info.charset or "utf-8"
notebook_content = file_stream.read().decode(encoding=encoding)
return self._convert(json.loads(notebook_content))
```

`json.loads` refuses a leading `U+FEFF` by design:

```
json.decoder.JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)
```

The failure is not visible to the caller. `_convert` in `_markitdown.py` records the exception
as a failed attempt and keeps walking the converter list, and `PlainTextConverter` -- which
accepts anything textual -- succeeds. So the notebook is silently emitted as JSON source, and
a caller that only looks at the markdown has no way to tell.

A BOM on a `.ipynb` is not exotic: Windows PowerShell's `Out-File`/`>` and several editors
write UTF-8 with a signature, and nbformat itself tolerates the file on the way back in.

## Fix

Strip the BOM before parsing, which is what `_csv_converter` already does with the same
one-liner for the same reason:

```python
# _csv_converter.py
content = content.lstrip("﻿")
```

Nothing else moves. `lstrip` on a string with no BOM is a no-op, so a notebook without one is
byte-identical; a caller that declares `charset="utf-8-sig"` has already consumed the BOM at
decode time and is likewise unaffected.

## Tests

Added to `packages/markitdown/tests/test_module_misc.py`:

- a BOM-prefixed notebook converts, keeping its heading, code fence and title
- the same notebook through `MarkItDown().convert_stream` does not come back as raw JSON
- pinned: a notebook with no BOM produces exactly the same markdown as before, asserted
  against the full string
- pinned: `charset="utf-8-sig"` still works and is not double-stripped

Against unmodified `main`:

```
E  json.decoder.JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)
E  assert False
E   +  where False = '﻿{"nbformat": 4, "nbformat_minor": 5, ...}'.startswith('# Quarterly notes')
2 failed, 4 passed, 64 deselected
```

With the fix:

```
6 passed, 64 deselected
```

## How I tested

Windows 11, Python 3.12, editable install of `packages/markitdown[all]`.

```
pytest tests/test_module_misc.py -k ipynb   ->  2 failed, 4 passed  (before)
pytest tests/test_module_misc.py -k ipynb   ->  6 passed            (after)
pytest tests/                               ->  18 failed, 430 passed, 4 skipped
```

Those 18 are unchanged by this PR: `main` gives `18 failed, 426 passed, 4 skipped` on this
machine before any edit, and the 4 added tests account for the difference. They are the CLI
stdout-encoding, Windows file-URI and speech-transcription tests that need a UTF-8 console, a
case-sensitive path and network/ffmpeg.

`black --check` clean on both files.
