### PR TITLE
fix(epub): forward conversion options to the HTML converter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_epub_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_epub_converter.py
@@ -112,6 +112,7 @@ class EpubConverter(HtmlConverter):
                                 extension=extension,
                                 filename=filename,
                             ),
+                            **kwargs,
                         )
                         markdown_content.append(converted_content.markdown.strip())
 

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1470,6 +1470,77 @@ def test_epub_metadata_nodevalue():
     assert missing is None
 
 
+_EPUB_CONTAINER = (
+    '<?xml version="1.0"?>'
+    '<container version="1.0" '
+    'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+    '<rootfiles><rootfile full-path="OEBPS/content.opf" '
+    'media-type="application/oebps-package+xml"/></rootfiles></container>'
+)
+
+_EPUB_OPF = (
+    '<?xml version="1.0"?>'
+    '<package xmlns="http://www.idpf.org/2007/opf" version="2.0" '
+    'unique-identifier="id">'
+    '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+    "<dc:title>Example book</dc:title></metadata>"
+    '<manifest><item id="c1" href="ch1.xhtml" '
+    'media-type="application/xhtml+xml"/></manifest>'
+    '<spine><itemref idref="c1"/></spine></package>'
+)
+
+_EPUB_CHAPTER = (
+    '<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+    "<p>Chapter text.</p>"
+    '<img alt="diagram" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="/>'
+    "</body></html>"
+)
+
+
+def _build_epub() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr("META-INF/container.xml", _EPUB_CONTAINER)
+        zf.writestr("OEBPS/content.opf", _EPUB_OPF)
+        zf.writestr("OEBPS/ch1.xhtml", _EPUB_CHAPTER)
+    return buf.getvalue()
+
+
+def test_epub_honors_keep_data_uris() -> None:
+    """EPUB chapters must be converted with the options the caller passed."""
+    result = MarkItDown().convert_stream(
+        io.BytesIO(_build_epub()),
+        stream_info=StreamInfo(extension=".epub"),
+        keep_data_uris=True,
+    )
+
+    assert (
+        "![diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)" in result.markdown
+    )
+
+
+def test_epub_truncates_data_uris_by_default() -> None:
+    """Without the option, the default truncation must still apply."""
+    result = MarkItDown().convert_stream(
+        io.BytesIO(_build_epub()), stream_info=StreamInfo(extension=".epub")
+    )
+
+    assert "![diagram](data:image/png;base64...)" in result.markdown
+    assert "iVBORw0KGgo" not in result.markdown
+
+
+def test_epub_metadata_and_text_are_unchanged() -> None:
+    """The rest of the conversion must not move."""
+    result = MarkItDown().convert_stream(
+        io.BytesIO(_build_epub()), stream_info=StreamInfo(extension=".epub")
+    )
+
+    assert result.title == "Example book"
+    assert "**Title:** Example book" in result.markdown
+    assert "Chapter text." in result.markdown
+
+
 def test_json_with_late_non_ascii_character(tmp_path) -> None:
     payload = {
         "record": {


### PR DESCRIPTION
## What this changes

Conversion options are ignored for EPUB. `keep_data_uris=True` keeps the image source for
HTML, DOCX, XLSX and PPTX, but not for the same image inside an EPUB chapter:

```
.html  ->  ![diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)
.epub  ->  ![diagram](data:image/png;base64...)
```

## Why

`EpubConverter.convert` accepts `**kwargs` and then calls the HTML converter without them:

```python
converted_content = self._html_converter.convert(
    f,
    StreamInfo(
        mimetype=mimetype,
        extension=extension,
        filename=filename,
    ),
)
```

Every other converter that renders through `HtmlConverter` passes the bag along:

```python
# _docx_converter.py
return self._html_converter.convert_string(html_result, **kwargs)

# _xlsx_converter.py
self._html_converter.convert_string(html_content, **kwargs)

# _pptx_converter.py
self._html_converter.convert_string(html_table, **kwargs).markdown.strip()
```

`keep_data_uris` is the option with a visible effect today -- it is a CLI flag
(`--keep-data-uris`) and reaches the converter through `convert_stream`/`convert` -- but the
gap covers everything the caller passes, including the markdownify options
(`heading_style`, `bullets`, ...) and `strict`.

## Fix

Forward `**kwargs`, exactly as the sibling converters do. One line.

## Tests

Added to `packages/markitdown/tests/test_module_misc.py`, over a minimal in-memory EPUB whose
one chapter carries a data-URI image:

- `keep_data_uris=True` keeps the full data URI
- pinned: without the option the URI is still truncated to `data:image/png;base64...`, and
  the payload does not appear
- pinned: metadata, title and chapter text are unchanged

Against unmodified `main`:

```
E  AssertionError: assert '![diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)' in
   '**Title:** Example book\n\nChapter text.\n\n![diagram](data:image/png;base64...)'
1 failed, 3 passed, 65 deselected
```

With the fix:

```
4 passed, 65 deselected
```

## How I tested

Windows 11, Python 3.12, editable install of `packages/markitdown[all]`.

```
pytest tests/test_module_misc.py -k epub   ->  1 failed, 3 passed  (before)
pytest tests/test_module_misc.py -k epub   ->  4 passed            (after)
pytest tests/                              ->  18 failed, 429 passed, 4 skipped
```

Those 18 are unchanged by this PR: `main` gives `18 failed, 426 passed, 4 skipped` on this
machine before any edit, and the 3 added tests account for the difference. They are the CLI
stdout-encoding, Windows file-URI and speech-transcription tests that need a UTF-8 console, a
case-sensitive path and network/ffmpeg.

`black --check` clean on both files.
