### PR TITLE
fix(pptx): do not emit a Notes heading for a slide with no notes

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -209,11 +209,14 @@ class PptxConverter(DocumentConverter):
             md_content = md_content.strip()
 
             if slide.has_notes_slide:
-                md_content += "\n\n### Notes:\n"
+                # PowerPoint attaches a notes slide to a slide whose notes pane
+                # has merely been opened, so having one says nothing about there
+                # being notes to read. Only head a section that has content.
                 notes_frame = slide.notes_slide.notes_text_frame
-                if notes_frame is not None:
-                    md_content += notes_frame.text or ""
-                md_content = md_content.strip()
+                notes_text = (notes_frame.text or "") if notes_frame is not None else ""
+                if notes_text.strip():
+                    md_content += "\n\n### Notes:\n" + notes_text
+                    md_content = md_content.strip()
 
         return DocumentConverterResult(markdown=md_content.strip())
 

--- a/packages/markitdown/tests/test_pptx_notes.py
+++ b/packages/markitdown/tests/test_pptx_notes.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3 -m pytest
+"""A slide whose notes slide carries no text must not get a "Notes:" heading."""
+
+import io
+
+import pptx
+
+from markitdown import MarkItDown, StreamInfo
+
+
+def _build_pptx(notes: str | None) -> io.BytesIO:
+    """Build a one-slide deck in memory, optionally attaching a notes slide."""
+    prs = pptx.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    slide.shapes.title.text = "Slide title"
+    if notes is not None:
+        # Touching notes_slide creates the part, which is what PowerPoint does
+        # for a deck whose notes pane has been opened.
+        slide.notes_slide.notes_text_frame.text = notes
+    buf = io.BytesIO()
+    prs.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def _convert(notes: str | None) -> str:
+    return (
+        MarkItDown()
+        .convert_stream(_build_pptx(notes), stream_info=StreamInfo(extension=".pptx"))
+        .markdown
+    )
+
+
+def test_empty_notes_slide_produces_no_notes_heading() -> None:
+    markdown = _convert("")
+
+    assert "Slide title" in markdown
+    assert "### Notes:" not in markdown
+
+
+def test_whitespace_only_notes_produce_no_notes_heading() -> None:
+    markdown = _convert("   \n\n  ")
+
+    assert "Slide title" in markdown
+    assert "### Notes:" not in markdown
+
+
+def test_slide_without_a_notes_slide_produces_no_notes_heading() -> None:
+    markdown = _convert(None)
+
+    assert "Slide title" in markdown
+    assert "### Notes:" not in markdown
+
+
+def test_notes_with_text_are_still_emitted() -> None:
+    markdown = _convert("Remember to mention the budget.")
+
+    assert "### Notes:\nRemember to mention the budget." in markdown


### PR DESCRIPTION
## What this changes

A slide gets a `### Notes:` heading with nothing under it whenever the deck has a notes slide
that carries no text:

```
<!-- Slide number: 1 -->
# Slide title

### Notes:
```

The heading announces a section that does not exist. Downstream that reads as a slide whose
speaker notes were dropped, rather than a slide that never had any.

## Why

The converter treats "has a notes slide" as "has notes":

```python
if slide.has_notes_slide:
    md_content += "\n\n### Notes:\n"
    notes_frame = slide.notes_slide.notes_text_frame
    if notes_frame is not None:
        md_content += notes_frame.text or ""
    md_content = md_content.strip()
```

Those are different things. PowerPoint writes a `notesSlide` part for a slide whose notes pane
has merely been opened, and a deck saved from a template can carry one for every slide, so
`has_notes_slide` is true for a great many slides with empty notes. The heading is emitted
before the text is read, so an empty (or whitespace-only) notes frame still gets one. The
trailing `.strip()` removes the newline after the heading but not the heading itself.

## Fix

Read the notes first and only emit the heading when there is something to head. This is the
same shape as the fix in #1990, where `WikipediaConverter` stopped rendering a `# None`
heading for a page with no title.

## Tests

New file `packages/markitdown/tests/test_pptx_notes.py`, over one-slide decks built in memory:

- a notes slide whose text is `""` produces no heading
- a notes slide whose text is whitespace produces no heading
- pinned: a slide with no notes slide at all is unaffected
- pinned: real notes are still emitted, heading and all

Against unmodified `main`:

```
E  AssertionError: assert '### Notes:' not in '<!-- Slide number: 1 -->\n# Slide title\n\n### Notes:'
E  AssertionError: assert '### Notes:' not in '<!-- Slide number: 1 -->\n# Slide title\n\n### Notes:'
2 failed, 2 passed
```

With the fix:

```
4 passed
```

The `test.pptx` fixture emits no `### Notes:` before or after this change, so the existing
vectors are untouched.

## How I tested

Windows 11, Python 3.12, editable install of `packages/markitdown[all]`.

```
pytest tests/test_pptx_notes.py   ->  2 failed, 2 passed  (before)
pytest tests/test_pptx_notes.py   ->  4 passed            (after)
pytest tests/                     ->  18 failed, 430 passed, 4 skipped
```

Those 18 are unchanged by this PR: `main` gives `18 failed, 426 passed, 4 skipped` on this
machine before any edit, and the 4 added tests account for the difference. They are the CLI
stdout-encoding, Windows file-URI and speech-transcription tests that need a UTF-8 console, a
case-sensitive path and network/ffmpeg.

`black --check` clean on both files.
