### PR TITLE
fix(rss): support namespace-prefixed Atom feeds

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -29,6 +29,7 @@ CANDIDATE_FILE_EXTENSIONS = [
     ".xml",
 ]
 
+ATOM_NAMESPACE = "http://www.w3.org/2005/Atom"
 XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml"
 
 
@@ -109,9 +110,9 @@ class RssConverter(DocumentConverter):
     def _feed_type(self, doc: Any) -> str | None:
         if doc.getElementsByTagName("rss"):
             return "rss"
-        elif doc.getElementsByTagName("feed"):
-            root = doc.getElementsByTagName("feed")[0]
-            if root.getElementsByTagName("entry"):
+        root = doc.documentElement
+        if root.localName == "feed" and root.namespaceURI in (None, ATOM_NAMESPACE):
+            if root.getElementsByTagNameNS(root.namespaceURI, "entry"):
                 # An Atom feed must have a root element of <feed> and at least one <entry>
                 return "atom"
         return None
@@ -143,10 +144,10 @@ class RssConverter(DocumentConverter):
 
         Returns None if the feed type is not recognized or something goes wrong.
         """
-        root = doc.getElementsByTagName("feed")[0]
+        root = doc.documentElement
         title = self._get_data_by_tag_name(root, "title")
         subtitle = self._get_data_by_tag_name(root, "subtitle")
-        entries = root.getElementsByTagName("entry")
+        entries = root.getElementsByTagNameNS(root.namespaceURI, "entry")
         md_text = f"# {title}\n"
         if subtitle:
             md_text += f"{subtitle}\n"
@@ -182,7 +183,7 @@ class RssConverter(DocumentConverter):
         Values flagged as markup are converted by ``_parse_content``; plain text
         is returned verbatim for the caller to emit as-is.
         """
-        nodes = entry.getElementsByTagName(tag_name)
+        nodes = entry.getElementsByTagNameNS(entry.namespaceURI, tag_name)
         if not nodes:
             return None, True
 
@@ -311,7 +312,10 @@ class RssConverter(DocumentConverter):
         """Get data from first child element with the given tag name.
         Returns None when no such element is found.
         """
-        nodes = element.getElementsByTagName(tag_name)
+        if element.namespaceURI == ATOM_NAMESPACE:
+            nodes = element.getElementsByTagNameNS(ATOM_NAMESPACE, tag_name)
+        else:
+            nodes = element.getElementsByTagName(tag_name)
         if not nodes:
             return None
         fc = nodes[0].firstChild

--- a/packages/markitdown/tests/test_rss_converter.py
+++ b/packages/markitdown/tests/test_rss_converter.py
@@ -1,7 +1,97 @@
 import io
 
-from markitdown import StreamInfo
+import pytest
+
+from markitdown import MarkItDown, StreamInfo
 from markitdown.converters import RssConverter
+
+
+@pytest.mark.parametrize(
+    "root_prefix, child_prefix",
+    [("", ""), ("a:", "a:"), ("a:", "b:"), ("a:", ""), ("", "a:")],
+)
+def test_atom_namespace_prefixes(root_prefix: str, child_prefix: str) -> None:
+    # Fully prefixed feeds do not need a default namespace declaration.
+    default_namespace = (
+        "" if root_prefix and child_prefix else "http://www.w3.org/2005/Atom"
+    )
+    feed = f"""<?xml version="1.0" encoding="utf-8"?>
+<{root_prefix}feed xmlns="{default_namespace}"
+    xmlns:a="http://www.w3.org/2005/Atom"
+    xmlns:b="http://www.w3.org/2005/Atom">
+  <{child_prefix}title>Example feed</{child_prefix}title>
+  <{child_prefix}subtitle>Feed subtitle</{child_prefix}subtitle>
+  <{child_prefix}id>urn:example:feed</{child_prefix}id>
+  <{child_prefix}updated>2026-01-01T00:00:00Z</{child_prefix}updated>
+  <{child_prefix}author><{child_prefix}name>Example author</{child_prefix}name></{child_prefix}author>
+  <{child_prefix}entry>
+    <{child_prefix}title>Example entry</{child_prefix}title>
+    <{child_prefix}id>urn:example:entry</{child_prefix}id>
+    <{child_prefix}updated>2026-01-02T00:00:00Z</{child_prefix}updated>
+    <{child_prefix}summary type="html">&lt;p&gt;An &lt;em&gt;entry summary&lt;/em&gt;.&lt;/p&gt;</{child_prefix}summary>
+    <{child_prefix}content type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>Read the <strong>important details</strong>.</p>
+      </div>
+    </{child_prefix}content>
+  </{child_prefix}entry>
+</{root_prefix}feed>
+""".encode(
+        "utf-8"
+    )
+    stream_info = StreamInfo(mimetype="application/xml", extension=".xml")
+    converter = RssConverter()
+    stream = io.BytesIO(feed)
+
+    assert converter.accepts(stream, stream_info)
+    assert stream.tell() == 0
+    result = converter.convert(stream, stream_info)
+
+    assert result.title == "Example feed"
+    assert result.markdown.startswith("# Example feed\nFeed subtitle\n")
+    assert "## Example entry\nUpdated on: 2026-01-02T00:00:00Z" in result.markdown
+    assert "An *entry summary*." in result.markdown
+    assert "Read the **important details**." in result.markdown
+
+    # The public API must recognize the feed instead of falling back to raw XML.
+    converted = MarkItDown().convert_stream(io.BytesIO(feed), stream_info=stream_info)
+    assert converted.title == result.title
+    assert converted.markdown == result.markdown.strip()
+
+
+def test_atom_without_namespace_is_still_supported() -> None:
+    feed = b"""<feed>
+  <title>Example feed</title>
+  <entry><title>Example entry</title><content>Entry content.</content></entry>
+</feed>"""
+    converter = RssConverter()
+    stream_info = StreamInfo(extension=".xml")
+
+    assert converter.accepts(io.BytesIO(feed), stream_info)
+    result = converter.convert(io.BytesIO(feed), stream_info)
+
+    assert result.title == "Example feed"
+    assert "## Example entry" in result.markdown
+    assert "Entry content." in result.markdown
+
+
+def test_atom_ignores_elements_from_other_namespaces() -> None:
+    feed = b"""<a:feed xmlns:a="http://www.w3.org/2005/Atom" xmlns="urn:example:other">
+  <title>Unrelated title</title>
+  <a:title>Example feed</a:title>
+  <entry><title>Unrelated entry</title><content>Unrelated content.</content></entry>
+  <a:entry>
+    <a:title>Example entry</a:title>
+    <content>Unrelated content.</content>
+    <a:content>Entry content.</a:content>
+  </a:entry>
+</a:feed>"""
+    result = RssConverter().convert(io.BytesIO(feed), StreamInfo(extension=".atom"))
+
+    assert result.title == "Example feed"
+    assert "## Example entry" in result.markdown
+    assert "Entry content." in result.markdown
+    assert "Unrelated" not in result.markdown
 
 
 def test_atom_xhtml_content_is_preserved() -> None:


### PR DESCRIPTION
Atom feeds that use an explicit prefix, such as `<atom:feed>`, currently fail feed detection and can fall back to raw XML in `MarkItDown.convert_stream()`. Prefixes are arbitrary under [RFC 4287 section 1.3](https://www.rfc-editor.org/rfc/rfc4287.html#section-1.3), so these feeds should convert the same way as feeds using the default Atom namespace.

Match Atom elements by namespace URI and local name during detection and conversion. This covers feed metadata, entries, summaries, and content, while preserving support for unqualified feeds. The regression tests exercise fully prefixed and mixed-prefix feeds through both `RssConverter` and the public API, and check that elements from other namespaces are ignored.

Validation on Windows / Python 3.11.16:

- The initial regression test failed for all four prefixed variants before the fix; the default-namespace control passed.
- RSS/Atom tests: **20 passed** (`pytest tests/test_rss_converter.py tests/test_module_misc.py -k 'atom or rss'`).
- `hatch test --python 3.11`: **419 passed, 34 skipped, 2 failed**. Both failures (`test_file_uris` and `test_convert_case_insensitive_uri_schemes`) expect Unix paths on Windows and also fail in a clean worktree at the unchanged base commit `b6e8bbd`. Remote/LLM tests were disabled using the existing CI skip conditions.
- `pre-commit run --all-files`: **passed**.

Prepared by OpenAI Codex on behalf of Elysium-Seeker, including reproduction, implementation, and local checks.
