### PR TITLE
Preserve all CSV columns by matching the widest row

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -90,6 +90,11 @@ class CsvConverter(DocumentConverter):
         if not rows:
             return DocumentConverterResult(markdown="")
 
+        # Pad all rows, including the header, to preserve the widest row.
+        num_columns = max(len(row) for row in rows)
+        for row in rows:
+            row.extend([""] * (num_columns - len(row)))
+
         # Create markdown table
         markdown_table = []
 
@@ -98,15 +103,10 @@ class CsvConverter(DocumentConverter):
         markdown_table.append("| " + " | ".join(header) + " |")
 
         # Add separator row
-        markdown_table.append("| " + " | ".join(["---"] * len(rows[0])) + " |")
+        markdown_table.append("| " + " | ".join(["---"] * num_columns) + " |")
 
         # Add data rows
         for row in rows[1:]:
-            # Make sure row has the same number of columns as header
-            while len(row) < len(rows[0]):
-                row.append("")
-            # Truncate if row has more columns than header
-            row = row[: len(rows[0])]
             markdown_table.append(
                 "| " + " | ".join(_escape_table_cell(cell) for cell in row) + " |"
             )

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1543,6 +1543,36 @@ def test_csv_all_blank_input_returns_empty_markdown() -> None:
     assert result == ""
 
 
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (
+            b"banner\nname,age,city\nAlice,30,Seattle\n",
+            "| banner |  |  |\n| --- | --- | --- |\n"
+            "| name | age | city |\n| Alice | 30 | Seattle |",
+        ),
+        (
+            b"name,age\nAlice\n\nBob,40,Seattle\nCarol,25\n",
+            "| name | age |  |\n| --- | --- | --- |\n"
+            "| Alice |  |  |\n|  |  |  |\n"
+            "| Bob | 40 | Seattle |\n| Carol | 25 |  |",
+        ),
+        (
+            b"name\nAlice,,\n",
+            "| name |  |  |\n| --- | --- | --- |\n| Alice |  |  |",
+        ),
+        (
+            b"name,age,city\nAlice,30\nBob\n",
+            "| name | age | city |\n| --- | --- | --- |\n"
+            "| Alice | 30 |  |\n| Bob |  |  |",
+        ),
+    ],
+    ids=["preamble", "widest-row-late", "trailing-empty-fields", "widest-header"],
+)
+def test_csv_table_matches_widest_row(data: bytes, expected: str) -> None:
+    assert _convert_csv(data) == expected
+
+
 def test_csv_pipe_in_cell_is_escaped() -> None:
     result = _convert_csv(b'name,description\nWidget,"cheap | fast"\n')
 


### PR DESCRIPTION
Size CSV tables to the widest row and pad shorter rows, including the header, with empty cells. This prevents extra fields from being silently truncated.

Includes regression tests; all 18 CSV tests pass.

Fixes #2390.