### PR TITLE
fix(zip): preserve content of entries with duplicate filenames

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -106,9 +106,10 @@ class ZipConverter(DocumentConverter):
         }
 
         with zipfile.ZipFile(file_stream, "r") as zipObj:
-            for name in zipObj.namelist():
+            for entry in zipObj.infolist():
+                name = entry.filename
                 try:
-                    z_file_stream = io.BytesIO(zipObj.read(name))
+                    z_file_stream = io.BytesIO(zipObj.read(entry))
                     z_file_stream_info = StreamInfo(
                         extension=os.path.splitext(name)[1],
                         filename=os.path.basename(name),

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1371,6 +1371,26 @@ def test_youtube_converter_missing_title_metadata() -> None:
         assert "# YouTube" in result_title_tag.markdown
 
 
+def test_zip_duplicate_filenames_preserve_each_entry() -> None:
+    """Same-named ZIP entries must retain their own content and archive order."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("notes.txt", "First archived entry.")
+        with pytest.warns(UserWarning, match="Duplicate name"):
+            archive.writestr("notes.txt", "Second archived entry.")
+    buf.seek(0)
+
+    result = MarkItDown().convert_stream(
+        buf, stream_info=StreamInfo(extension=".zip", filename="duplicate.zip")
+    )
+
+    assert result.markdown == (
+        "Content from the zip file `duplicate.zip`:\n\n"
+        "## File: notes.txt\n\nFirst archived entry.\n\n"
+        "## File: notes.txt\n\nSecond archived entry."
+    )
+
+
 def test_zip_stream_no_filename_header() -> None:
     """Regression test: ZipConverter must not render the literal string 'None'
     in the output header when the stream has no associated URL, local path, or
@@ -1836,6 +1856,7 @@ if __name__ == "__main__":
         test_docx_comments,
         test_docx_zip_filename_casing_mismatch,
         test_docx_zip_filename_non_casing_mismatch_still_rejected,
+        test_zip_duplicate_filenames_preserve_each_entry,
         test_input_as_strings,
         test_markitdown_remote,
         test_speech_transcription,


### PR DESCRIPTION
# fix(zip): preserve content of entries with duplicate filenames

ZIP archives can contain multiple entries with the same filename. ZipConverter iterated over names and passed each name to ZipFile.read(), so a duplicate name repeatedly selected the last matching entry. An archive containing notes.txt with content A followed by notes.txt with content B therefore produced B twice and silently lost A.

Iterate over ZipInfo entries and pass each entry to read() so every member retains its own content and archive order. Keep the existing filename-based headings and member conversion metadata.

Add an in-memory regression test through MarkItDown.convert_stream() that verifies the complete Markdown output for two same-named members. No new dependency or binary fixture is required.

## Validation

- Regression fails before the fix on upstream main f9042b4: the first member's content is replaced by the second member's content.
- Regression, existing ZIP header test, and test_zip_kwargs.py: 7 passed.
- Existing ZIP conversion vector across format detection, local files, streams with/without hints, file URIs, and data URIs: 6 passed; HTTP test skipped using the repository's GITHUB_ACTIONS setting.
- Black 23.7.0 check on both changed files and git diff --check passed.
- Full repository test suite was not run.
