### PR TITLE
fix(html): keep links inside inline code as literal text

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -61,6 +61,9 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         **kwargs,
     ):
         """Same as usual converter, but removes JavaScript links and escapes URIs."""
+        if el.find_parent(["code", "kbd", "samp"]) is not None:
+            return text
+
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
         if not text:
             return ""

--- a/packages/markitdown/tests/test_html_code_links.py
+++ b/packages/markitdown/tests/test_html_code_links.py
@@ -1,0 +1,36 @@
+import pytest
+
+from markitdown.converters._html_converter import HtmlConverter
+
+
+@pytest.mark.parametrize("tag", ["code", "kbd", "samp"])
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ('<a href="Action.html">Action</a>', "Action"),
+        ('<span><a href="/Client">Client </a></span>value', "Client value"),
+    ],
+)
+def test_inline_code_links_remain_literal(
+    tag: str, content: str, expected: str
+) -> None:
+    result = HtmlConverter().convert_string(f"<p>Use <{tag}>{content}</{tag}>.</p>")
+
+    assert result.markdown == f"Use `{expected}`."
+
+
+@pytest.mark.parametrize(
+    "html, expected",
+    [
+        ('<a href="/Client">Client</a>', "[Client](/Client)"),
+        ('<a href="/Client"><code>Client</code></a>', "[`Client`](/Client)"),
+        (
+            'before<a href="/Client"> Client </a>after',
+            "before [Client](/Client) after",
+        ),
+    ],
+)
+def test_links_outside_code_remain_links(html: str, expected: str) -> None:
+    result = HtmlConverter().convert_string(html)
+
+    assert result.markdown == expected


### PR DESCRIPTION
hey, found a small issue with linked identifiers in API docs.
`<code><a href="Action.html">Action</a></code>` currently comes out as `[Action](Action.html)` instead of `Action`. The link syntax ends up inside the backticks, so it becomes part of the code. This markup also appears in OpenJDK’s JMenu docs. This adds an early return for anchors inside code, kbd, and samp, before trimming or link formatting. Regular links still work, including links wrapped around code spans. Kept this separate from #2396’s whitespace fix. These inline-code cases still fail with that PR applied, and pass with this change added. Added six regression cases and three controls: six fail before the fix, all nine pass after. Checked the real converter source locally on Python 3.13 with markdownify 1.2.2 using a source-subset import harness; I haven’t run the full Hatch suite yet. Prepared with ChatGPT assistance.

