### PR TITLE
Fix pipe characters in HTML table cells

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -143,6 +143,20 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
 
         return "![%s](%s%s)" % (alt, src, title_part)
 
+    @staticmethod
+    def _escape_table_cell_pipes(text: str) -> str:
+        return re.sub(r"(?<!\\)\|", r"\|", text)
+
+    def convert_td(self, el: Any, text: str, parent_tags: Any) -> str:
+        return super().convert_td(
+            el, self._escape_table_cell_pipes(text), parent_tags
+        )
+
+    def convert_th(self, el: Any, text: str, parent_tags: Any) -> str:
+        return super().convert_th(
+            el, self._escape_table_cell_pipes(text), parent_tags
+        )
+
     def convert_input(
         self,
         el: Any,

--- a/packages/markitdown/tests/test_html_converter.py
+++ b/packages/markitdown/tests/test_html_converter.py
@@ -122,3 +122,14 @@ def test_img_keeps_embedded_data_uri_over_data_src_when_keeping_data_uris() -> N
 
     assert f"![A photo]({embedded})" in markdown
     assert other_src not in markdown
+
+
+def test_html_table_escapes_pipe_characters_in_cells() -> None:
+    html = (
+        "<table><thead><tr><th>Name</th><th>Note</th></tr></thead>"
+        "<tbody><tr><td>Alice</td><td>Has a | pipe</td></tr></tbody></table>"
+    )
+
+    markdown = _convert_html(html)
+
+    assert "| Alice | Has a \\| pipe |" in markdown


### PR DESCRIPTION
## Summary

- escape literal pipe characters in HTML table cell content
- preserve table separators and colspan handling through markdownify
- add regression coverage for issue #2438

## Validation

- python -m pytest packages/markitdown/tests/test_html_converter.py -q (12 passed)
- python -m pytest packages/markitdown/tests -q (641 passed, 6 unrelated environment/platform or external-fixture failures)

Fixes #2438