### PR TITLE
fix(pptx): do not emit a heading for a slide with an empty title

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -180,7 +180,12 @@ class PptxConverter(DocumentConverter):
                 elif shape.has_text_frame:
                     text = shape.text or ""
                     if shape == title:
-                        md_content += "# " + text.lstrip() + "\n"
+                        # A layout's title placeholder sits on the slide whether
+                        # or not anything was typed into it, so having one says
+                        # nothing about there being a title to read. Only emit a
+                        # heading that has text.
+                        if text.strip():
+                            md_content += "# " + text.lstrip() + "\n"
                     else:
                         md_content += text + "\n"
 

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -180,10 +180,6 @@ class PptxConverter(DocumentConverter):
                 elif shape.has_text_frame:
                     text = shape.text or ""
                     if shape == title:
-                        # A layout's title placeholder sits on the slide whether
-                        # or not anything was typed into it, so having one says
-                        # nothing about there being a title to read. Only emit a
-                        # heading that has text.
                         if text.strip():
                             md_content += "# " + text.lstrip() + "\n"
                     else:

--- a/packages/markitdown/tests/test_pptx_empty_title.py
+++ b/packages/markitdown/tests/test_pptx_empty_title.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3 -m pytest
+"""A slide whose title placeholder carries no text must not get a bare heading."""
+
+import io
+
+import pptx
+
+from markitdown import MarkItDown, StreamInfo
+
+BODY_TEXT = "Some body text on the slide."
+
+
+def _build_pptx(title: str | None) -> io.BytesIO:
+    """Build a one-slide "Title and Content" deck, optionally filling the title.
+
+    Passing None leaves the title placeholder as PowerPoint creates it: present
+    on the slide, showing "Click to add title", and carrying no text.
+    """
+    prs = pptx.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[1])
+    if title is not None:
+        slide.shapes.title.text = title
+    slide.placeholders[1].text = BODY_TEXT
+    buf = io.BytesIO()
+    prs.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def _convert(title: str | None) -> str:
+    return (
+        MarkItDown()
+        .convert_stream(_build_pptx(title), stream_info=StreamInfo(extension=".pptx"))
+        .markdown
+    )
+
+
+def _heading_lines(markdown: str) -> list[str]:
+    return [line for line in markdown.splitlines() if line.startswith("#")]
+
+
+def test_untouched_title_placeholder_produces_no_heading() -> None:
+    markdown = _convert(None)
+
+    assert BODY_TEXT in markdown
+    assert _heading_lines(markdown) == []
+
+
+def test_empty_title_produces_no_heading() -> None:
+    markdown = _convert("")
+
+    assert BODY_TEXT in markdown
+    assert _heading_lines(markdown) == []
+
+
+def test_whitespace_only_title_produces_no_heading() -> None:
+    markdown = _convert("   ")
+
+    assert BODY_TEXT in markdown
+    assert _heading_lines(markdown) == []
+
+
+def test_title_with_text_is_still_emitted() -> None:
+    markdown = _convert("Quarterly Results")
+
+    assert "# Quarterly Results" in markdown
+    assert BODY_TEXT in markdown


### PR DESCRIPTION
Converting a deck whose slide has an empty title placeholder produces a bare `#` line where the heading should be:

```
<!-- Slide number: 1 -->
#
Some body text on the slide.
```

expected the slide's text with no heading at all:

```
<!-- Slide number: 1 -->
Some body text on the slide.
```

A layout's title placeholder is on the slide whether or not anything was typed into it — PowerPoint shows it as "Click to add title" — so `slide.shapes.title` returning a shape says nothing about there being a title to read. `convert` emitted `"# " + text.lstrip()` unconditionally, so an untouched placeholder wrote `"# "`, and the trailing space is then removed by the output normalization, leaving `#` on a line of its own. Every slide built from a title layout but headed by a picture, a chart or a table carries one.

This is the same shape as the notes fix in #2427: a section header written before the thing it heads is known to exist.

The fix guards the heading on the title having text, matching how the notes heading is guarded a few lines below.

## Reproduction

New test file, on unmodified `main` (`packages/markitdown`):

```
$ python -m pytest tests/test_pptx_empty_title.py -q
FAILED tests/test_pptx_empty_title.py::test_untouched_title_placeholder_produces_no_heading
FAILED tests/test_pptx_empty_title.py::test_empty_title_produces_no_heading
FAILED tests/test_pptx_empty_title.py::test_whitespace_only_title_produces_no_heading
3 failed, 1 passed in 1.78s
```

with the failure being the heading that should not be there:

```
    def test_empty_title_produces_no_heading() -> None:
        markdown = _convert("")
        assert BODY_TEXT in markdown
>       assert _heading_lines(markdown) == []
E       AssertionError: assert ['#'] == []
```

The fourth test — a title that does have text still emitting `# Quarterly Results` — passes before and after.

With the fix:

```
$ python -m pytest tests/test_pptx_empty_title.py -q
4 passed in 1.39s
```

## Verification

The existing PPTX and end-to-end vector tests are unchanged, before and after:

```
$ python -m pytest tests/test_pptx_notes.py tests/test_pptx_none_text.py tests/test_pptx_svg.py tests/test_module_vectors.py -q
119 passed in 38.98s   # origin/main
119 passed in 42.53s   # this branch
```

`black` reports both touched files unchanged.
