### PR TITLE
fix(ipynb): label code fences with the notebook's own language

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -11,6 +11,34 @@ CANDIDATE_MIME_TYPE_PREFIXES = [
 
 ACCEPTED_FILE_EXTENSIONS = [".ipynb"]
 
+# A notebook that declares no language at all is overwhelmingly a Python one,
+# and Python is the label this converter has always written.
+DEFAULT_CODE_LANGUAGE = "python"
+
+
+def _code_language(notebook_content: dict) -> str:
+    """The language the notebook's code cells are written in.
+
+    nbformat records it in ``metadata.language_info.name``, which is what
+    nbconvert reads; ``metadata.kernelspec.language`` is the kernel's own
+    declaration, and is all some producers write.
+    """
+    metadata = notebook_content.get("metadata")
+    if not isinstance(metadata, dict):
+        return DEFAULT_CODE_LANGUAGE
+
+    for section, key in (("language_info", "name"), ("kernelspec", "language")):
+        declaration = metadata.get(section)
+        if not isinstance(declaration, dict):
+            continue
+        language = declaration.get(key)
+        # A fence's info string ends at the first whitespace, so only the
+        # first word of the declaration can label the block.
+        if isinstance(language, str) and language.split():
+            return language.split()[0]
+
+    return DEFAULT_CODE_LANGUAGE
+
 
 class IpynbConverter(DocumentConverter):
     """Converts Jupyter Notebook (.ipynb) files to Markdown."""
@@ -66,6 +94,7 @@ class IpynbConverter(DocumentConverter):
         try:
             md_output = []
             title = None
+            language = _code_language(notebook_content)
 
             for cell in notebook_content.get("cells", []):
                 cell_type = cell.get("cell_type", "")
@@ -83,7 +112,7 @@ class IpynbConverter(DocumentConverter):
 
                 elif cell_type == "code":
                     # Code cells are wrapped in Markdown code blocks
-                    md_output.append(f"```python\n{''.join(source_lines)}\n```")
+                    md_output.append(f"```{language}\n{''.join(source_lines)}\n```")
                 elif cell_type == "raw":
                     md_output.append(f"```\n{''.join(source_lines)}\n```")
 

--- a/packages/markitdown/tests/test_ipynb_code_language.py
+++ b/packages/markitdown/tests/test_ipynb_code_language.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3 -m pytest
+"""Code cells must be fenced with the language the notebook is written in."""
+
+import io
+import json
+from typing import Any, Dict
+
+from markitdown import MarkItDown, StreamInfo
+
+SOURCE = "plot(cars)\n"
+
+
+def _notebook(metadata: Dict[str, Any]) -> io.BytesIO:
+    """A one-code-cell notebook carrying the given ``metadata``."""
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "outputs": [],
+                "source": [SOURCE],
+            }
+        ],
+        "metadata": metadata,
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    return io.BytesIO(json.dumps(notebook).encode("utf-8"))
+
+
+def _convert(metadata: Dict[str, Any]) -> str:
+    return (
+        MarkItDown()
+        .convert_stream(_notebook(metadata), stream_info=StreamInfo(extension=".ipynb"))
+        .markdown
+    )
+
+
+def test_language_info_names_the_fence() -> None:
+    """nbformat records the notebook's language in metadata.language_info."""
+    markdown = _convert(
+        {
+            "kernelspec": {"display_name": "R", "language": "R", "name": "ir"},
+            "language_info": {"name": "R", "file_extension": ".r"},
+        }
+    )
+
+    assert "```R\n" + SOURCE in markdown
+    assert "```python" not in markdown
+
+
+def test_kernelspec_language_is_used_when_language_info_is_absent() -> None:
+    """Some producers write only the kernel's own declaration."""
+    markdown = _convert(
+        {"kernelspec": {"display_name": "Julia 1.10", "language": "julia"}}
+    )
+
+    assert "```julia\n" + SOURCE in markdown
+    assert "```python" not in markdown
+
+
+def test_python_notebooks_are_still_labelled_python() -> None:
+    markdown = _convert(
+        {
+            "kernelspec": {"display_name": "Python 3", "language": "python"},
+            "language_info": {"name": "python"},
+        }
+    )
+
+    assert "```python\n" + SOURCE in markdown
+
+
+def test_notebook_without_language_metadata_falls_back_to_python() -> None:
+    markdown = _convert({})
+
+    assert "```python\n" + SOURCE in markdown


### PR DESCRIPTION
Converting an R notebook produces

````
```R
plot(cars)
```
````

as

````
```python
plot(cars)
```
````

The same happens to Julia, Scala, C#, Bash and every other kernel: `IpynbConverter._convert` writes the fence with a hard-coded `python` info string, whatever the notebook says it is. The output then tells a reader — and any downstream renderer or model — that the code is Python.

nbformat records the notebook's language in `metadata.language_info.name`, which is the field nbconvert reads; `metadata.kernelspec.language` is the kernel's own declaration and is all some producers write. This reads the first, falls back to the second, and falls back to `python` when a notebook declares neither, which is what the converter has always emitted.

Only the first word of the declaration is used, since a fence's info string ends at the first whitespace.

## Reproduction

New test file, on unmodified `main` (`packages/markitdown`):

```
$ python -m pytest tests/test_ipynb_code_language.py -q
FAILED tests/test_ipynb_code_language.py::test_language_info_names_the_fence
FAILED tests/test_ipynb_code_language.py::test_kernelspec_language_is_used_when_language_info_is_absent
2 failed, 2 passed in 2.61s
```

with the failure showing the wrong label:

```
>       assert "```R\n" + SOURCE in markdown
E       AssertionError: assert ('```R\n' + 'plot(cars)\n') in '```python\nplot(cars)\n\n```'
```

The two tests that pass before and after are the ones that pin the existing behaviour: a notebook declaring `python`, and a notebook declaring no language at all, both still get `python`.

With the fix:

```
$ python -m pytest tests/test_ipynb_code_language.py -q
4 passed in 2.22s
```

## Verification

`tests/test_module_vectors.py` includes the end-to-end `test_notebook.ipynb` vector, which requires `` ```python `` — that notebook declares `language_info.name: "python"`, so it keeps its label.

```
$ python -m pytest tests/test_module_vectors.py tests/test_module_misc.py -q \
    -k "not file_uris and not case_insensitive and not speech"
183 passed, 2 skipped, 3 deselected in 63.85s   # origin/main
183 passed, 2 skipped, 3 deselected in 61.26s   # this branch
```

(The three deselected tests fail on `main` on this Windows machine for reasons unrelated to notebooks: console encoding, file-URI paths, and a missing `ffmpeg`.)

`black` reports both touched files unchanged.
