### PR TITLE
fix(docx): an equation without its properties child drops every equation

### DIFF
--- a/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
+++ b/packages/markitdown/src/markitdown/converter_utils/docx/math/omml.py
@@ -172,6 +172,18 @@ class Pr(Tag2Method):
     }
 
 
+# Every element's properties child is optional: <m:f> without <m:fPr> is a
+# fraction with default properties. Word always writes the child, because it
+# carries the control run's formatting, but nothing else has to.
+ABSENT_PR = Pr(ET.fromstring("<properties/>"))
+
+
+def get_pr(c_dict, tag_name):
+    """Read an element's properties child, which may legitimately be absent."""
+    pr = c_dict.get(tag_name)
+    return ABSENT_PR if pr is None else pr
+
+
 class oMath2Latex(Tag2Method):
     """
     Convert oMath element of omml to latex
@@ -208,7 +220,9 @@ class oMath2Latex(Tag2Method):
         """
         c_dict = self.process_children_dict(elm)
         latex_s = get_val(
-            c_dict["accPr"].chr, default=CHR_DEFAULT.get("ACC_VAL"), store=CHR
+            get_pr(c_dict, "accPr").chr,
+            default=CHR_DEFAULT.get("ACC_VAL"),
+            store=CHR,
         )
         return latex_s.format(c_dict["e"])
 
@@ -217,7 +231,7 @@ class oMath2Latex(Tag2Method):
         the bar function
         """
         c_dict = self.process_children_dict(elm)
-        pr = c_dict["barPr"]
+        pr = get_pr(c_dict, "barPr")
         latex_s = get_val(pr.pos, default=POS_DEFAULT.get("BAR_VAL"), store=POS)
         return pr.text + latex_s.format(c_dict["e"])
 
@@ -226,7 +240,7 @@ class oMath2Latex(Tag2Method):
         the delimiter object
         """
         c_dict = self.process_children_dict(elm)
-        pr = c_dict["dPr"]
+        pr = get_pr(c_dict, "dPr")
         null = D_DEFAULT.get("null")
         s_val = get_char(pr.begChr, default=D_DEFAULT.get("left"), store=T)
         e_val = get_char(pr.endChr, default=D_DEFAULT.get("right"), store=T)
@@ -255,7 +269,7 @@ class oMath2Latex(Tag2Method):
         the fraction object
         """
         c_dict = self.process_children_dict(elm)
-        pr = c_dict["fPr"]
+        pr = get_pr(c_dict, "fPr")
         latex_s = get_val(pr.type, default=F_DEFAULT, store=F)
         return pr.text + latex_s.format(num=c_dict.get("num"), den=c_dict.get("den"))
 
@@ -298,7 +312,7 @@ class oMath2Latex(Tag2Method):
         the Group-Character object
         """
         c_dict = self.process_children_dict(elm)
-        pr = c_dict["groupChrPr"]
+        pr = get_pr(c_dict, "groupChrPr")
         latex_s = get_val(pr.chr, default=CHR_DEFAULT.get("GROUP_CHR_VAL"), store=CHR)
         return pr.text + latex_s.format(c_dict["e"])
 

--- a/packages/markitdown/tests/test_docx_math_optional_properties.py
+++ b/packages/markitdown/tests/test_docx_math_optional_properties.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Every OMML element's properties child is optional.
+
+``<m:f>`` without ``<m:fPr>`` is a fraction with default properties, and the
+same goes for ``<m:d>``, ``<m:acc>``, ``<m:bar>`` and ``<m:groupChr>``. Word
+always writes the child, because it carries the control run's formatting, but
+other producers have no reason to. The handlers indexed it directly, so an
+equation that omits it raised ``KeyError``. ``_pre_process_math`` runs over the
+whole of ``word/document.xml`` inside a blanket ``except Exception``, so the
+crash discards the OMML rewrite for the entire part and every equation in the
+document is lost.
+"""
+
+import io
+import os
+import re
+import zipfile
+
+import pytest
+from xml.etree import ElementTree as ET
+
+from markitdown import MarkItDown, StreamInfo
+from markitdown.converter_utils.docx.math.omml import OMML_NS, oMath2Latex
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+EQUATIONS_DOCX = os.path.join(TEST_FILES_DIR, "equations.docx")
+
+MATH_NS_DECL = f'xmlns:m="{OMML_NS[1:-1]}"'
+
+
+def _latex(xml_fragment: str) -> str:
+    element = ET.fromstring(f"<m:oMath {MATH_NS_DECL}>{xml_fragment}</m:oMath>")
+    return oMath2Latex(element).latex
+
+
+FRACTION = "<m:f>{pr}<m:num><m:r><m:t>1</m:t></m:r></m:num><m:den><m:r><m:t>2</m:t></m:r></m:den></m:f>"
+DELIMITER = "<m:d>{pr}<m:e><m:r><m:t>x</m:t></m:r></m:e></m:d>"
+ACCENT = "<m:acc>{pr}<m:e><m:r><m:t>x</m:t></m:r></m:e></m:acc>"
+BAR = "<m:bar>{pr}<m:e><m:r><m:t>x</m:t></m:r></m:e></m:bar>"
+GROUP_CHAR = "<m:groupChr>{pr}<m:e><m:r><m:t>x</m:t></m:r></m:e></m:groupChr>"
+
+
+@pytest.mark.parametrize(
+    "template, properties",
+    [
+        (FRACTION, "<m:fPr><m:ctrlPr/></m:fPr>"),
+        (DELIMITER, "<m:dPr><m:ctrlPr/></m:dPr>"),
+        (ACCENT, "<m:accPr><m:ctrlPr/></m:accPr>"),
+        (BAR, "<m:barPr><m:ctrlPr/></m:barPr>"),
+        (GROUP_CHAR, "<m:groupChrPr><m:ctrlPr/></m:groupChrPr>"),
+    ],
+    ids=["f", "d", "acc", "bar", "groupChr"],
+)
+def test_omitted_properties_convert_like_default_properties(
+    template: str, properties: str
+) -> None:
+    """Omitting the child must read the same as a child that sets nothing."""
+    assert _latex(template.format(pr="")) == _latex(template.format(pr=properties))
+
+
+def test_fraction_without_properties_still_converts() -> None:
+    assert _latex(FRACTION.format(pr="")) == r"\frac{1}{2}"
+
+
+def test_delimiter_without_properties_uses_the_default_parentheses() -> None:
+    assert _latex(DELIMITER.format(pr="")) == r"\left(x\right)"
+
+
+def test_explicit_properties_are_still_honored() -> None:
+    """A property that is set must still win over the default."""
+    latex = _latex(
+        DELIMITER.format(pr='<m:dPr><m:begChr m:val="["/><m:endChr m:val="]"/></m:dPr>')
+    )
+
+    assert latex == r"\left[x\right]"
+
+
+def _docx_without(element_name: str) -> io.BytesIO:
+    """Rebuild the equations fixture with every ``<m:NAME>`` element removed."""
+    pattern = re.compile(
+        f"<m:{element_name}>.*?</m:{element_name}>".encode("utf-8"), re.S
+    )
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(EQUATIONS_DOCX) as source:
+        with zipfile.ZipFile(buffer, "w") as target:
+            for item in source.infolist():
+                data = source.read(item.filename)
+                if item.filename == "word/document.xml":
+                    data, removed = pattern.subn(b"", data)
+                    assert removed > 0, f"fixture has no <m:{element_name}> to remove"
+                target.writestr(item, data)
+    buffer.seek(0)
+    return buffer
+
+
+def _latex_line_count(stream) -> int:
+    markdown = (
+        MarkItDown()
+        .convert_stream(stream, stream_info=StreamInfo(extension=".docx"))
+        .markdown
+    )
+    return len([line for line in markdown.splitlines() if "$" in line])
+
+
+@pytest.mark.parametrize("element_name", ["fPr", "dPr"])
+def test_document_keeps_its_equations_without_the_properties_child(
+    element_name: str,
+) -> None:
+    """The damage is not local: one such equation loses all of them."""
+    with open(EQUATIONS_DOCX, "rb") as fixture:
+        expected = _latex_line_count(fixture)
+    assert expected > 0
+
+    assert _latex_line_count(_docx_without(element_name)) == expected


### PR DESCRIPTION
Converting a .docx whose equations were written by something other than Word produces the document's prose with every equation missing — no error, no warning, just no math (issue #1512).

Every OMML element's properties child is optional. `<m:f>` without `<m:fPr>` is a fraction with default properties, and the same goes for `<m:d>`, `<m:acc>`, `<m:bar>` and `<m:groupChr>`. Word always writes the child, because it carries the control run's formatting — in `tests/test_files/equations.docx` every `<m:fPr>` holds nothing but a `<m:ctrlPr>` — but nothing else has to.

`do_f`, `do_d`, `do_acc`, `do_bar` and `do_groupchr` indexed the child directly (`c_dict["fPr"]`), so an equation that omits it raises `KeyError`. The five already carry the spec's defaults; they just crash before reaching them.

The damage is not local. `_pre_process_math` runs over all of `word/document.xml` inside a blanket `except Exception`, so one such equation discards the OMML rewrite for the whole part, and Mammoth cannot render raw OMML. Taking the existing fixture and dropping the element a non-Word producer would not have written:

```
equations.docx                 : 4 lines containing LaTeX
equations.docx without <m:fPr>: 0 lines containing LaTeX
equations.docx without <m:dPr>: 0 lines containing LaTeX
```

After the fix, 4 and 4 and 4.

This is the same failure class as #2368, which gives `do_nary` the spec default for an omitted `m:chr`; these five crash a step earlier, on the properties element itself. The fix reads the child through a helper that substitutes an empty one, so every property falls through to the default it already has.

## Reproduction

New test file, on unmodified `main` (`packages/markitdown`):

```
$ python -m pytest tests/test_docx_math_optional_properties.py -q
FAILED tests/test_docx_math_optional_properties.py::test_omitted_properties_convert_like_default_properties[f]
FAILED tests/test_docx_math_optional_properties.py::test_omitted_properties_convert_like_default_properties[d]
FAILED tests/test_docx_math_optional_properties.py::test_omitted_properties_convert_like_default_properties[acc]
FAILED tests/test_docx_math_optional_properties.py::test_omitted_properties_convert_like_default_properties[bar]
FAILED tests/test_docx_math_optional_properties.py::test_omitted_properties_convert_like_default_properties[groupChr]
FAILED tests/test_docx_math_optional_properties.py::test_fraction_without_properties_still_converts
FAILED tests/test_docx_math_optional_properties.py::test_delimiter_without_properties_uses_the_default_parentheses
FAILED tests/test_docx_math_optional_properties.py::test_document_keeps_its_equations_without_the_properties_child[fPr]
FAILED tests/test_docx_math_optional_properties.py::test_document_keeps_its_equations_without_the_properties_child[dPr]
9 failed, 1 passed in 2.86s
```

The unit failures are `KeyError: 'fPr'` and friends; the end-to-end one is the whole document going dark:

```
>       assert _latex_line_count(_docx_without(element_name)) == expected
E       AssertionError: assert 0 == 4
```

The one test that passes before and after is the pin: `<m:dPr>` with an explicit `begChr`/`endChr` still converts to `\left[x\right]` rather than the default parentheses.

With the fix:

```
$ python -m pytest tests/test_docx_math_optional_properties.py -q
10 passed in 4.10s
```

## Verification

No fixture is modified: the end-to-end test rebuilds `equations.docx` in memory.

```
$ python -m pytest tests/test_docx_math.py tests/test_docx_math_accents.py \
    tests/test_docx_math_symbols.py tests/test_docx_omml.py \
    tests/test_module_vectors.py -q
125 passed in 45.09s   # origin/main
125 passed in 38.38s   # this branch
```

`black` reports both touched files unchanged.
