### PR TITLE
Make optional converters opt-in for MarkItDown MCP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,8 +84,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Keep this environment free of optional converters to exercise the base install.
       - name: Install packages
-        run: pip install "./packages/markitdown[all]" ./packages/markitdown-mcp pytest
+        run: pip install ./packages/markitdown ./packages/markitdown-mcp pytest
 
       - name: Run tests
         working-directory: packages/markitdown-mcp

--- a/packages/markitdown-mcp/Dockerfile
+++ b/packages/markitdown-mcp/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 
 COPY . /app
 
-RUN pip install --no-cache-dir /app
+RUN pip install --no-cache-dir "/app[all]"
 
 WORKDIR /workdir
 

--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -14,11 +14,37 @@ It exposes one tool: `convert_to_markdown(uri)`, where uri can be any `http:`, `
 
 ## Installation
 
-To install the package, use pip:
+The base installation includes the MCP server and MarkItDown's core converters,
+such as text and HTML. Optional document and media converters are installed
+separately. This avoids requiring platform-specific dependencies for formats
+you do not use.
+
+To install the base package, use pip:
 
 ```bash
 pip install markitdown-mcp
 ```
+
+To install every optional converter (the previous default), use:
+
+```bash
+pip install "markitdown-mcp[all]"
+```
+
+For selected formats, install the corresponding MarkItDown extras alongside the
+server. For example, to add PDF support:
+
+```bash
+pip install markitdown-mcp "markitdown[pdf]"
+```
+
+With `uvx`, select the extra explicitly when full converter support is needed:
+
+```bash
+uvx --from "markitdown-mcp[all]" markitdown-mcp
+```
+
+The provided Docker image continues to include all optional converters.
 
 ## Usage
 

--- a/packages/markitdown-mcp/pyproject.toml
+++ b/packages/markitdown-mcp/pyproject.toml
@@ -25,9 +25,12 @@ classifiers = [
 ]
 dependencies = [
   "mcp>=2.1.1,<3.0.0",
-  "markitdown[all]>=0.1.1,<0.2.0",
+  "markitdown>=0.1.1,<0.2.0",
   "requests>=2.0.0,<3.0.0",
 ]
+
+[project.optional-dependencies]
+all = ["markitdown[all]>=0.1.1,<0.2.0"]
 
 [project.urls]
 Documentation = "https://github.com/microsoft/markitdown#readme"

--- a/packages/markitdown-mcp/tests/test_dependencies.py
+++ b/packages/markitdown-mcp/tests/test_dependencies.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import asyncio
+from importlib.metadata import requires
+
+from packaging.requirements import Requirement
+
+
+def markitdown_requirements():
+    return [
+        requirement
+        for value in requires("markitdown-mcp") or []
+        if (requirement := Requirement(value)).name == "markitdown"
+    ]
+
+
+def test_base_install_does_not_require_optional_converters():
+    requirements = [
+        requirement
+        for requirement in markitdown_requirements()
+        if requirement.marker is None or requirement.marker.evaluate({"extra": ""})
+    ]
+    assert len(requirements) == 1
+    assert requirements[0].extras == set()
+
+
+def test_all_extra_enables_converters_with_the_same_version_range():
+    requirements = markitdown_requirements()
+    base = next(
+        requirement for requirement in requirements if requirement.marker is None
+    )
+    optional = [
+        requirement
+        for requirement in requirements
+        if requirement.marker is not None
+        and requirement.marker.evaluate({"extra": "all"})
+    ]
+    assert len(optional) == 1
+    assert optional[0].extras == {"all"}
+    assert optional[0].specifier == base.specifier
+
+
+def test_mcp_tool_converts_html_without_optional_converters():
+    from markitdown_mcp.__main__ import convert_to_markdown
+
+    result = asyncio.run(convert_to_markdown("data:text/html,%3Ch1%3EHello%3C%2Fh1%3E"))
+    assert result.strip() == "# Hello"


### PR DESCRIPTION
Fixes #2440.

Depend on base MarkItDown instead of requiring every optional converter. `markitdown-mcp[all]` provides the previous full converter set, and the Dockerfile explicitly installs that extra to preserve its behavior. Document base, selective, and full installations.

Adds dependency-metadata and HTML-tool regressions, with a clean base-install CI job across Python 3.10 through 3.13. The MCP SDK constraint is unchanged; #2363 remains independent.

Validation:
- Both metadata regressions fail before the change.
- Built wheel; all three tests pass with Python 3.10 and 3.12, including base and full-converter environments on 3.12.
- Installed-wheel STDIO initialization, tool discovery, and HTML conversion pass.
- Python 3.14 / Windows ARM64 binary-only dependency resolution succeeds without the optional PDF/Office stack.
- Black and `git diff --check` pass.

Native Windows ARM64 execution and a Docker image build were not tested locally.
