### PR TITLE
Add opt-in PDF page boundary markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Or use `-o` to specify the output file:
 markitdown path-to-file.pdf -o document.md
 ```
 
+To preserve PDF page boundaries as one-based HTML comments, use
+`--pdf-page-markers`:
+
+```bash
+markitdown --pdf-page-markers path-to-file.pdf
+```
+
+This emits `<!-- page 1 -->` before the first page and a corresponding marker
+before every subsequent page, including empty pages.
+
 You can also pipe content:
 
 ```bash
@@ -268,6 +278,16 @@ from markitdown import MarkItDown
 
 md = MarkItDown(enable_plugins=False) # Set to True to enable plugins
 result = md.convert("test.xlsx")
+print(result.markdown)
+```
+
+PDF page-boundary preservation is opt-in:
+
+```python
+from markitdown import MarkItDown
+
+md = MarkItDown()
+result = md.convert("test.pdf", pdf_page_markers=True)
 print(result.markdown)
 ```
 

--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -32,6 +32,13 @@ pip install -e 'packages/markitdown[all]'
 markitdown path-to-file.pdf > document.md
 ```
 
+Use `--pdf-page-markers` to emit a one-based HTML comment before every PDF
+page, including empty pages:
+
+```bash
+markitdown --pdf-page-markers path-to-file.pdf
+```
+
 ### Python API
 
 ```python
@@ -40,6 +47,12 @@ from markitdown import MarkItDown
 md = MarkItDown()
 result = md.convert("test.xlsx")
 print(result.markdown)
+```
+
+For opt-in PDF page-boundary preservation:
+
+```python
+result = md.convert("test.pdf", pdf_page_markers=True)
 ```
 
 ### More Information

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -142,6 +142,12 @@ def main():
         help="Keep data URIs (like base64-encoded images) in the output. By default, data URIs are truncated.",
     )
 
+    parser.add_argument(
+        "--pdf-page-markers",
+        action="store_true",
+        help="Add one-based HTML comment markers before every PDF page.",
+    )
+
     parser.add_argument("filename", nargs="?")
     args = parser.parse_args()
 
@@ -254,10 +260,14 @@ def main():
             io.BytesIO(sys.stdin.buffer.read()),
             stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
+            pdf_page_markers=args.pdf_page_markers,
         )
     else:
         result = markitdown.convert(
-            args.filename, stream_info=stream_info, keep_data_uris=args.keep_data_uris
+            args.filename,
+            stream_info=stream_info,
+            keep_data_uris=args.keep_data_uris,
+            pdf_page_markers=args.pdf_page_markers,
         )
 
     _handle_output(args, result)

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -254,20 +254,24 @@ def main():
     else:
         markitdown = MarkItDown(enable_plugins=args.use_plugins)
 
+    conversion_kwargs: Dict[str, Any] = {
+        "keep_data_uris": args.keep_data_uris,
+    }
+    if args.pdf_page_markers:
+        conversion_kwargs["pdf_page_markers"] = True
+
     if args.filename is None:
         # Windows pipe-backed stdin can report seekable() even though it cannot rewind.
         result = markitdown.convert_stream(
             io.BytesIO(sys.stdin.buffer.read()),
             stream_info=stream_info,
-            keep_data_uris=args.keep_data_uris,
-            pdf_page_markers=args.pdf_page_markers,
+            **conversion_kwargs,
         )
     else:
         result = markitdown.convert(
             args.filename,
             stream_info=stream_info,
-            keep_data_uris=args.keep_data_uris,
-            pdf_page_markers=args.pdf_page_markers,
+            **conversion_kwargs,
         )
 
     _handle_output(args, result)

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -62,6 +62,7 @@ _dependency_exc_info = None
 try:
     import pdfminer
     import pdfminer.high_level
+    import pdfminer.pdfpage
     import pdfplumber
 except ImportError:
     _dependency_exc_info = sys.exc_info()
@@ -73,6 +74,33 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ]
 
 ACCEPTED_FILE_EXTENSIONS = [".pdf"]
+
+
+def _format_page_with_marker(page_idx: int, content: str | None) -> str:
+    marker = f"<!-- page {page_idx + 1} -->"
+    if content and content.strip():
+        return f"{marker}\n\n{_merge_partial_numbering_lines(content.strip())}"
+    return marker
+
+
+def _extract_pdfminer_page(pdf_bytes: io.BytesIO, page_idx: int) -> str:
+    pdf_bytes.seek(0)
+    return pdfminer.high_level.extract_text(pdf_bytes, page_numbers=[page_idx])
+
+
+def _extract_marked_pages_with_pdfminer(pdf_bytes: io.BytesIO) -> str:
+    pdf_bytes.seek(0)
+    page_count = sum(1 for _ in pdfminer.pdfpage.PDFPage.get_pages(pdf_bytes))
+    if page_count == 0:
+        raise ValueError("PDF contains no pages")
+
+    return "\n\n".join(
+        _format_page_with_marker(
+            page_idx,
+            _extract_pdfminer_page(pdf_bytes, page_idx),
+        )
+        for page_idx in range(page_count)
+    )
 
 
 def _to_markdown_table(table: list[list[str]], include_separator: bool = True) -> str:
@@ -538,6 +566,35 @@ class PdfConverter(DocumentConverter):
 
         # Read file stream into BytesIO for compatibility with pdfplumber
         pdf_bytes = io.BytesIO(file_stream.read())
+
+        if kwargs.get("pdf_page_markers", False):
+            try:
+                pdf = pdfplumber.open(pdf_bytes)
+            except Exception:
+                return DocumentConverterResult(
+                    markdown=_extract_marked_pages_with_pdfminer(pdf_bytes)
+                )
+
+            markdown_chunks: list[str] = []
+            with pdf:
+                for page_idx, page in enumerate(pdf.pages):
+                    try:
+                        page_content = _extract_form_content_from_words(page)
+                        if page_content is None:
+                            page_content = page.extract_text()
+                    except Exception:
+                        page_content = _extract_pdfminer_page(pdf_bytes, page_idx)
+                    finally:
+                        page.close()
+
+                    markdown_chunks.append(
+                        _format_page_with_marker(page_idx, page_content)
+                    )
+
+            if not markdown_chunks:
+                raise ValueError("PDF contains no pages")
+
+            return DocumentConverterResult(markdown="\n\n".join(markdown_chunks))
 
         try:
             # Single pass: check every page for form-style content.

--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -3,8 +3,10 @@ import io
 import subprocess
 import sys
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from markitdown import __version__
+from markitdown import DocumentConverterResult
 from markitdown.__main__ import main
 
 # This file contains CLI tests that are not directly tested by the FileTestVectors.
@@ -53,6 +55,26 @@ def test_windows_pipe_input_is_buffered_before_conversion(monkeypatch, capsys) -
 
     captured = capsys.readouterr()
     assert captured.out.strip() == "# Test HTML"
+
+
+def test_pdf_page_markers_flag_is_forwarded(monkeypatch, capsys) -> None:
+    convert = MagicMock(return_value=DocumentConverterResult(markdown="result"))
+    monkeypatch.setattr("markitdown.__main__.MarkItDown.convert", convert)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["markitdown", "--pdf-page-markers", "document.pdf"],
+    )
+
+    main()
+
+    convert.assert_called_once_with(
+        "document.pdf",
+        stream_info=None,
+        keep_data_uris=False,
+        pdf_page_markers=True,
+    )
+    assert capsys.readouterr().out.strip() == "result"
 
 
 if __name__ == "__main__":

--- a/packages/markitdown/tests/test_pdf_page_markers.py
+++ b/packages/markitdown/tests/test_pdf_page_markers.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3 -m pytest
+import io
+from unittest.mock import ANY, MagicMock, call, patch
+
+import pytest
+
+from markitdown import MarkItDown, StreamInfo
+from markitdown.converters import PdfConverter
+
+
+def _make_page(text: str | None) -> MagicMock:
+    page = MagicMock()
+    page.extract_text.return_value = text
+    return page
+
+
+def _mock_pdfplumber_open(pages: list[MagicMock]):
+    def mock_open(stream):
+        pdf = MagicMock()
+        pdf.pages = pages
+        pdf.__enter__.return_value = pdf
+        pdf.__exit__.return_value = False
+        return pdf
+
+    return mock_open
+
+
+def _convert_with_markers(pages: list[MagicMock]):
+    with patch(
+        "markitdown.converters._pdf_converter.pdfplumber.open",
+        side_effect=_mock_pdfplumber_open(pages),
+    ), patch(
+        "markitdown.converters._pdf_converter._extract_form_content_from_words",
+        return_value=None,
+    ):
+        return MarkItDown().convert_stream(
+            io.BytesIO(b"pdf"),
+            stream_info=StreamInfo(extension=".pdf"),
+            pdf_page_markers=True,
+        )
+
+
+def test_default_pdf_output_remains_unmarked() -> None:
+    pages = [_make_page("pdfplumber text")]
+    with patch(
+        "markitdown.converters._pdf_converter.pdfplumber.open",
+        side_effect=_mock_pdfplumber_open(pages),
+    ), patch(
+        "markitdown.converters._pdf_converter._extract_form_content_from_words",
+        return_value=None,
+    ), patch(
+        "markitdown.converters._pdf_converter.pdfminer.high_level.extract_text",
+        return_value="default output",
+    ):
+        result = MarkItDown().convert_stream(
+            io.BytesIO(b"pdf"),
+            stream_info=StreamInfo(extension=".pdf"),
+        )
+
+    assert result.markdown == "default output"
+    assert "<!-- page" not in result.markdown
+
+
+def test_plain_text_pages_have_one_based_markers_in_order() -> None:
+    result = _convert_with_markers(
+        [_make_page("first"), _make_page("second"), _make_page("third")]
+    )
+
+    assert result.markdown == (
+        "<!-- page 1 -->\n\nfirst\n\n"
+        "<!-- page 2 -->\n\nsecond\n\n"
+        "<!-- page 3 -->\n\nthird"
+    )
+
+
+def test_empty_pages_keep_their_page_index() -> None:
+    result = _convert_with_markers(
+        [_make_page("first"), _make_page(None), _make_page("third")]
+    )
+
+    assert result.markdown == (
+        "<!-- page 1 -->\n\nfirst\n\n"
+        "<!-- page 2 -->\n\n"
+        "<!-- page 3 -->\n\nthird"
+    )
+
+
+def test_table_and_plain_text_pages_preserve_boundaries() -> None:
+    pages = [_make_page(None), _make_page("plain text")]
+    with patch(
+        "markitdown.converters._pdf_converter.pdfplumber.open",
+        side_effect=_mock_pdfplumber_open(pages),
+    ), patch(
+        "markitdown.converters._pdf_converter._extract_form_content_from_words",
+        side_effect=["| Name | Value |\n| --- | --- |\n| A | 1 |", None],
+    ):
+        result = MarkItDown().convert_stream(
+            io.BytesIO(b"pdf"),
+            stream_info=StreamInfo(extension=".pdf"),
+            pdf_page_markers=True,
+        )
+
+    assert result.markdown == (
+        "<!-- page 1 -->\n\n"
+        "| Name | Value |\n| --- | --- |\n| A | 1 |\n\n"
+        "<!-- page 2 -->\n\nplain text"
+    )
+
+
+def test_page_extraction_failure_falls_back_only_for_that_page() -> None:
+    pages = [_make_page("unused"), _make_page("second")]
+    with patch(
+        "markitdown.converters._pdf_converter.pdfplumber.open",
+        side_effect=_mock_pdfplumber_open(pages),
+    ), patch(
+        "markitdown.converters._pdf_converter._extract_form_content_from_words",
+        side_effect=[RuntimeError("page failure"), None],
+    ), patch(
+        "markitdown.converters._pdf_converter.pdfminer.high_level.extract_text",
+        return_value="fallback first",
+    ) as extract_text:
+        result = MarkItDown().convert_stream(
+            io.BytesIO(b"pdf"),
+            stream_info=StreamInfo(extension=".pdf"),
+            pdf_page_markers=True,
+        )
+
+    assert result.markdown == (
+        "<!-- page 1 -->\n\nfallback first\n\n"
+        "<!-- page 2 -->\n\nsecond"
+    )
+    extract_text.assert_called_once()
+    assert extract_text.call_args.kwargs["page_numbers"] == [0]
+
+
+def test_pdfplumber_failure_falls_back_page_by_page() -> None:
+    with patch(
+        "markitdown.converters._pdf_converter.pdfplumber.open",
+        side_effect=RuntimeError("open failure"),
+    ), patch(
+        "markitdown.converters._pdf_converter.pdfminer.pdfpage.PDFPage.get_pages",
+        return_value=iter([object(), object(), object()]),
+    ), patch(
+        "markitdown.converters._pdf_converter.pdfminer.high_level.extract_text",
+        side_effect=["first", "", "third"],
+    ) as extract_text:
+        result = PdfConverter().convert(
+            io.BytesIO(b"pdf"),
+            StreamInfo(extension=".pdf"),
+            pdf_page_markers=True,
+        )
+
+    assert result.markdown == (
+        "<!-- page 1 -->\n\nfirst\n\n"
+        "<!-- page 2 -->\n\n"
+        "<!-- page 3 -->\n\nthird"
+    )
+    assert extract_text.call_args_list == [
+        call(ANY, page_numbers=[0]),
+        call(ANY, page_numbers=[1]),
+        call(ANY, page_numbers=[2]),
+    ]
+
+
+def test_page_fallback_failure_is_not_replaced_by_whole_document_output() -> None:
+    page = _make_page("unused")
+    with patch(
+        "markitdown.converters._pdf_converter.pdfplumber.open",
+        side_effect=_mock_pdfplumber_open([page]),
+    ), patch(
+        "markitdown.converters._pdf_converter._extract_form_content_from_words",
+        side_effect=RuntimeError("page failure"),
+    ), patch(
+        "markitdown.converters._pdf_converter.pdfminer.high_level.extract_text",
+        side_effect=RuntimeError("fallback failure"),
+    ) as extract_text:
+        with pytest.raises(RuntimeError, match="fallback failure"):
+            PdfConverter().convert(
+                io.BytesIO(b"pdf"),
+                StreamInfo(extension=".pdf"),
+                pdf_page_markers=True,
+            )
+
+    extract_text.assert_called_once()
+    page.close.assert_called_once()

--- a/packages/markitdown/tests/test_pdf_page_markers.py
+++ b/packages/markitdown/tests/test_pdf_page_markers.py
@@ -79,9 +79,7 @@ def test_empty_pages_keep_their_page_index() -> None:
     )
 
     assert result.markdown == (
-        "<!-- page 1 -->\n\nfirst\n\n"
-        "<!-- page 2 -->\n\n"
-        "<!-- page 3 -->\n\nthird"
+        "<!-- page 1 -->\n\nfirst\n\n" "<!-- page 2 -->\n\n" "<!-- page 3 -->\n\nthird"
     )
 
 
@@ -126,8 +124,7 @@ def test_page_extraction_failure_falls_back_only_for_that_page() -> None:
         )
 
     assert result.markdown == (
-        "<!-- page 1 -->\n\nfallback first\n\n"
-        "<!-- page 2 -->\n\nsecond"
+        "<!-- page 1 -->\n\nfallback first\n\n" "<!-- page 2 -->\n\nsecond"
     )
     extract_text.assert_called_once()
     assert extract_text.call_args.kwargs["page_numbers"] == [0]
@@ -151,9 +148,7 @@ def test_pdfplumber_failure_falls_back_page_by_page() -> None:
         )
 
     assert result.markdown == (
-        "<!-- page 1 -->\n\nfirst\n\n"
-        "<!-- page 2 -->\n\n"
-        "<!-- page 3 -->\n\nthird"
+        "<!-- page 1 -->\n\nfirst\n\n" "<!-- page 2 -->\n\n" "<!-- page 3 -->\n\nthird"
     )
     assert extract_text.call_args_list == [
         call(ANY, page_numbers=[0]),


### PR DESCRIPTION
## Summary

Add opt-in preservation of PDF page boundaries.

- Add the `--pdf-page-markers` CLI option.
- Add the `pdf_page_markers=True` Python API option.
- Emit one-based `<!-- page N -->` markers before every PDF page.
- Preserve markers for empty pages so page indexes do not shift.
- Preserve boundaries across plain-text, table/form, and mixed-content PDFs.
- Use page-scoped extraction fallbacks when markers are enabled.
- Keep default PDF conversion behavior unchanged.
- Add no new dependencies.

Addresses microsoft/markitdown#1317

## Example

```text
<!-- page 1 -->

First page content

<!-- page 2 -->

Second page content
```

## Testing

- pre-commit run --all-files 
- PDF-marker, CLI, Content Understanding, PDF memory, PDF table, and MasterFormat tests: 173 passed, 2 skipped
- Full local Windows run: 649 passed, 5 skipped; remaining failures were related to Windows console encoding, Windows file-URI expectations, and unavailable FFmpeg