### PR TITLE
fix(cli): allow Document Intelligence conversion from stdin

### DIFF
--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -210,8 +210,6 @@ def main():
                 "Document Intelligence Endpoint is required when using Document Intelligence. "
                 "Pass -e/--endpoint or set MARKITDOWN_DOCINTEL_ENDPOINT."
             )
-        elif args.filename is None:
-            _exit_with_error("Filename is required when using Document Intelligence.")
 
         markitdown = MarkItDown(
             enable_plugins=args.use_plugins, docintel_endpoint=args.endpoint

--- a/packages/markitdown/tests/test_cli_docintel.py
+++ b/packages/markitdown/tests/test_cli_docintel.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3 -m pytest
+"""--use-docintel must keep the CLI's filename-optional stdin mode."""
+
+import io
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from markitdown.__main__ import main
+
+DOC_INTEL = "markitdown.converters._doc_intel_converter"
+
+
+def test_use_docintel_reads_from_stdin(monkeypatch, capsys) -> None:
+    pdf_bytes = b"%PDF-1.4 fake pdf"
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(pdf_bytes)))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["markitdown", "--use-docintel", "-e", "https://fake-di", "-x", "pdf"],
+    )
+    monkeypatch.delenv("AZURE_API_KEY", raising=False)
+
+    client = MagicMock()
+    client.begin_analyze_document.return_value.result.return_value.content = (
+        "# Converted by Document Intelligence"
+    )
+    request = MagicMock()
+
+    with patch(f"{DOC_INTEL}._dependency_exc_info", None), patch(
+        f"{DOC_INTEL}.DocumentIntelligenceClient", return_value=client
+    ), patch(f"{DOC_INTEL}.DefaultAzureCredential"), patch(
+        f"{DOC_INTEL}.DocumentAnalysisFeature"
+    ), patch(
+        f"{DOC_INTEL}.AnalyzeDocumentRequest", request
+    ):
+        main()
+
+    # The bytes read from stdin are what gets sent to Document Intelligence
+    request.assert_called_once_with(bytes_source=pdf_bytes)
+    assert capsys.readouterr().out.strip() == "# Converted by Document Intelligence"


### PR DESCRIPTION
While reading #2318, which let `--use-cu` read its input from stdin, I noticed the `--use-docintel` branch just above it still stops with "Filename is required when using Document Intelligence." whenever no filename is given. `markitdown -d -e <endpoint> doc.pdf` works, `markitdown --use-cu --cu-endpoint <endpoint> < doc.pdf` works, but `markitdown -d -e <endpoint> < doc.pdf` exits with status 1 before converting anything.

Nothing in `DocumentIntelligenceConverter` needs a path. `convert()` reads `file_stream` and sends the bytes as `bytes_source`, and `accepts()` only looks at the extension and MIME type, which stdin mode already gets from `-x`/`-m` or from magika. So I removed the check the same way #2318 did for Content Understanding.

The new `tests/test_cli_docintel.py` runs `main()` with a PDF on stdin and the Azure client mocked. It checks that the stdin bytes are what reaches `AnalyzeDocumentRequest` and that the markdown returned by the service is printed. On main it fails with `SystemExit: 1` and the "Filename is required" message. With the change it passes. I also ran the real CLI against an unreachable endpoint: before the change stdin exits on the filename check, after it `DocumentIntelligenceConverter.convert` is called with extension `.pdf` and the output is identical to passing the same file by path.

The full suite passes locally (761 passed, 14 skipped, Linux, Python 3.12), and black 23.7.0 leaves both files unchanged.

AI tools used
