### PR TITLE
Add opt-in filtering for hidden XLSX worksheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,13 @@ result = md.convert("test.xlsx")
 print(result.markdown)
 ```
 
+The built-in XLSX converter includes all worksheets by default. To exclude
+worksheets marked `hidden` or `veryHidden`, pass `include_hidden_sheets=False`:
+
+```python
+result = md.convert("test.xlsx", include_hidden_sheets=False)
+```
+
 Document Intelligence conversion in Python:
 
 ```python

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -56,7 +56,7 @@ def _read_xlsx_sheets(
                 for sheet in workbook.book.worksheets
                 if sheet.sheet_state == "visible"
             ]
-            # Select before parsing, so hidden cell data is never loaded.
+            # Select before parsing, so only visible sheets become DataFrames.
             return pd.read_excel(workbook, sheet_name=visible_sheets)
 
     start_pos = file_stream.tell()

--- a/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -43,16 +43,31 @@ _SHEET_VIEW_START_TAG = re.compile(rb"<sheetView(?=[\s/>])[^>]*>")
 _SHOW_ZEROES_ATTRIBUTE = re.compile(rb"(?<=[\s])showZeroes(\s*=)")
 
 
-def _read_xlsx_sheets(file_stream: BinaryIO) -> dict[str, Any]:
+def _read_xlsx_sheets(
+    file_stream: BinaryIO, *, include_hidden_sheets: bool = True
+) -> dict[str, Any]:
+    def read_sheets(stream: BinaryIO) -> dict[str, Any]:
+        if include_hidden_sheets:
+            return pd.read_excel(stream, sheet_name=None, engine="openpyxl")
+
+        with pd.ExcelFile(stream, engine="openpyxl") as workbook:
+            visible_sheets = [
+                sheet.title
+                for sheet in workbook.book.worksheets
+                if sheet.sheet_state == "visible"
+            ]
+            # Select before parsing, so hidden cell data is never loaded.
+            return pd.read_excel(workbook, sheet_name=visible_sheets)
+
     start_pos = file_stream.tell()
     try:
-        return pd.read_excel(file_stream, sheet_name=None, engine="openpyxl")
+        return read_sheets(file_stream)
     except TypeError as exc:
         if "showZeroes" not in str(exc):
             raise
 
         repaired_stream = _repair_sheetview_show_zeroes(file_stream, start_pos)
-        return pd.read_excel(repaired_stream, sheet_name=None, engine="openpyxl")
+        return read_sheets(repaired_stream)
 
 
 def _rename_show_zeroes_attribute(data: bytes) -> bytes:
@@ -87,6 +102,9 @@ def _repair_sheetview_show_zeroes(
 class XlsxConverter(DocumentConverter):
     """
     Converts XLSX files to Markdown, with each sheet presented as a separate Markdown table.
+
+    Pass ``include_hidden_sheets=False`` to convert only visible worksheets.
+    Hidden and veryHidden worksheets are included by default.
     """
 
     def __init__(self):
@@ -131,7 +149,10 @@ class XlsxConverter(DocumentConverter):
                 _xlsx_dependency_exc_info[2]
             )
 
-        sheets = _read_xlsx_sheets(file_stream)
+        sheets = _read_xlsx_sheets(
+            file_stream,
+            include_hidden_sheets=kwargs.get("include_hidden_sheets", True),
+        )
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"

--- a/packages/markitdown/tests/test_xlsx_hidden_sheets.py
+++ b/packages/markitdown/tests/test_xlsx_hidden_sheets.py
@@ -1,0 +1,86 @@
+import io
+import zipfile
+
+import pytest
+from openpyxl import Workbook
+
+from markitdown import MarkItDown
+
+
+def _workbook(*, legacy_sheet_view=False, invalid_hidden_cell=False):
+    workbook = Workbook()
+    workbook.remove(workbook.active)
+    for title, state, value in [
+        ("Summary", "visible", "public summary"),
+        ("Hidden", "hidden", "hidden details"),
+        ("VeryHidden", "veryHidden", "very hidden details"),
+        ("Appendix", "visible", "public appendix"),
+    ]:
+        sheet = workbook.create_sheet(title)
+        sheet.sheet_state = state
+        sheet.append(["Value"])
+        sheet.append([value])
+
+    original = io.BytesIO()
+    workbook.save(original)
+    workbook.close()
+    result = io.BytesIO()
+    with zipfile.ZipFile(original) as source:
+        with zipfile.ZipFile(result, "w") as target:
+            for item in source.infolist():
+                data = source.read(item.filename)
+                if legacy_sheet_view and item.filename == "xl/worksheets/sheet1.xml":
+                    assert b"<sheetView " in data
+                    data = data.replace(
+                        b"<sheetView ", b'<sheetView showZeroes="0" ', 1
+                    )
+                if invalid_hidden_cell and item.filename == "xl/worksheets/sheet2.xml":
+                    original_cell = (
+                        b'<c r="A2" t="inlineStr"><is><t>hidden details</t></is></c>'
+                    )
+                    assert original_cell in data
+                    data = data.replace(
+                        original_cell, b'<c r="A2" t="n"><v>not-a-number</v></c>'
+                    )
+                target.writestr(item, data)
+    result.seek(0)
+    return result
+
+
+@pytest.mark.parametrize("legacy_sheet_view", [False, True])
+def test_exclude_hidden_sheets_preserves_visible_sheet_order(legacy_sheet_view):
+    stream = _workbook(legacy_sheet_view=legacy_sheet_view)
+    result = MarkItDown().convert_stream(
+        stream, file_extension=".xlsx", include_hidden_sheets=False
+    )
+
+    assert "hidden details" not in result.markdown
+    assert "## Hidden" not in result.markdown
+    assert "## VeryHidden" not in result.markdown
+    assert "public summary" in result.markdown
+    assert "public appendix" in result.markdown
+    assert result.markdown.index("## Summary") < result.markdown.index("## Appendix")
+    assert not stream.closed
+
+
+@pytest.mark.parametrize("options", [{}, {"include_hidden_sheets": True}])
+def test_hidden_sheets_are_included_by_default(options):
+    result = MarkItDown().convert_stream(_workbook(), file_extension=".xlsx", **options)
+
+    headings = ["## Summary", "## Hidden", "## VeryHidden", "## Appendix"]
+    positions = [result.markdown.index(heading) for heading in headings]
+    assert positions == sorted(positions)
+    assert "hidden details" in result.markdown
+    assert "very hidden details" in result.markdown
+
+
+def test_excluded_hidden_cells_are_not_parsed():
+    result = MarkItDown().convert_stream(
+        _workbook(invalid_hidden_cell=True),
+        file_extension=".xlsx",
+        include_hidden_sheets=False,
+    )
+
+    assert "public summary" in result.markdown
+    assert "public appendix" in result.markdown
+    assert "hidden details" not in result.markdown


### PR DESCRIPTION
Related to #1073.

XLSX conversion currently includes worksheets marked `hidden` or `veryHidden`, so content intended to stay out of the visible workbook also appears in Markdown sent to an LLM. The built-in XLSX converter now accepts `include_hidden_sheets=False` through the public conversion API:

```python
result = md.convert("test.xlsx", include_hidden_sheets=False)
```

The default still includes every worksheet for compatibility with existing callers. This implements the issue's requested filtering option; changing the default can be considered separately.

Visible worksheets retain their workbook order. Filtering happens before cell parsing, so excluded sheets do not need to be read into DataFrames. The existing repair for legacy `showZeroes` sheet views preserves the filtering option when retrying. No new dependencies are added.

Validation:
- Five new in-memory workbook regressions: **3 failed / 2 passed before**, **5 passed after**. They cover both hidden states, visible-sheet order, explicit/default inclusion, the legacy repair path, and an invalid numeric cell in an excluded sheet.
- Existing XLSX regression tests: **2 passed**.
- XLSX/XLS API and CLI conversion vectors: **18 passed**.
- HTML converter tests: **11 passed**.
- `pre-commit run --all-files` and `git diff --check`: passed.

Developed and tested with OpenAI Codex assistance.
