### PR TITLE
fix(wikipedia): drop the site suffix from italicised titles

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_wikipedia_converter.py
@@ -64,7 +64,12 @@ class WikipediaConverter(DocumentConverter):
 
         # Print only the main content
         body_elm = soup.find("div", {"id": "mw-content-text"})
-        title_elm = soup.find("span", {"class": "mw-page-title-main"})
+        # Wikipedia only wraps the title in mw-page-title-main when it is plain
+        # text. Titles that carry markup -- italicised species, film, album and
+        # journal names -- are written straight into the first heading instead.
+        title_elm = soup.find("span", {"class": "mw-page-title-main"}) or soup.find(
+            "h1", {"id": "firstHeading"}
+        )
 
         webpage_text = ""
         main_title = None if soup.title is None else soup.title.string
@@ -72,7 +77,10 @@ class WikipediaConverter(DocumentConverter):
         if body_elm:
             # What's the title
             if title_elm and isinstance(title_elm, bs4.Tag):
-                main_title = title_elm.string
+                # .string is None as soon as the element holds more than one
+                # child, which is what a title mixing markup with plain text
+                # looks like, so gather the descendant text instead.
+                main_title = title_elm.get_text()
 
             # Treat whitespace-only titles as if they were absent
             if main_title:

--- a/packages/markitdown/tests/test_wikipedia_titles.py
+++ b/packages/markitdown/tests/test_wikipedia_titles.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3 -m pytest
+"""Article titles that carry markup must survive conversion."""
+
+import io
+
+from markitdown import StreamInfo
+from markitdown.converters import WikipediaConverter
+
+STREAM_INFO = StreamInfo(
+    url="https://en.wikipedia.org/wiki/Example",
+    mimetype="text/html",
+    extension=".html",
+)
+
+
+def _page(heading: str, document_title: str) -> io.BytesIO:
+    """Build a page shaped like the article HTML Wikipedia actually serves."""
+    return io.BytesIO(
+        f"""<html><head><title>{document_title} - Wikipedia</title></head><body>
+<h1 id="firstHeading" class="firstHeading mw-first-heading">{heading}</h1>
+<div id="mw-content-text"><p>Body text.</p></div>
+</body></html>""".encode()
+    )
+
+
+def test_plain_title_is_read_from_the_title_span() -> None:
+    """A plain title keeps being read from mw-page-title-main."""
+    page = _page(
+        '<span lang="en" dir="ltr"><span class="mw-page-title-main">Paris</span></span>',
+        "Paris",
+    )
+
+    result = WikipediaConverter().convert(page, STREAM_INFO)
+
+    assert result.title == "Paris"
+    assert result.markdown.lstrip().startswith("# Paris")
+
+
+def test_fully_italicised_title_keeps_its_text() -> None:
+    """Wikipedia drops the title span for italicised titles, e.g. species names."""
+    page = _page("<i>Escherichia coli</i>", "Escherichia coli")
+
+    result = WikipediaConverter().convert(page, STREAM_INFO)
+
+    # Without the first-heading fallback this became "Escherichia coli - Wikipedia".
+    assert result.title == "Escherichia coli"
+    assert result.markdown.lstrip().startswith("# Escherichia coli")
+
+
+def test_title_mixing_markup_and_plain_text_keeps_both_parts() -> None:
+    """A disambiguated italic title spans several children, so .string is None."""
+    page = _page("<i>Titanic</i> (1997 film)", "Titanic (1997 film)")
+
+    result = WikipediaConverter().convert(page, STREAM_INFO)
+
+    assert result.title == "Titanic (1997 film)"
+    assert result.markdown.lstrip().startswith("# Titanic (1997 film)")


### PR DESCRIPTION
### Summary

`WikipediaConverter` looks for the article title in a `span.mw-page-title-main`. Wikipedia only emits that span when the title is **plain text** — titles rendered with markup (italicised species, film, album and journal names) are written straight into `h1#firstHeading` instead.

With the span absent, the converter silently fell back to the document `<title>`, which carries the site suffix. Both the returned `title` and the `#` heading then read `… - Wikipedia`.

| Article | Before | After |
|---|---|---|
| [Paris](https://en.wikipedia.org/wiki/Paris) | `Paris` | `Paris` (unchanged) |
| [Escherichia coli](https://en.wikipedia.org/wiki/Escherichia_coli) | `Escherichia coli - Wikipedia` | `Escherichia coli` |
| [Titanic (1997 film)](https://en.wikipedia.org/wiki/Titanic_(1997_film)) | `Titanic (1997 film) - Wikipedia` | `Titanic (1997 film)` |

### Cause

Two things had to line up:

1. Wikipedia omits `mw-page-title-main` for titles containing markup, so `title_elm` was `None` and the `<title>` fallback won.
2. `Tag.string` returns `None` as soon as an element has more than one child — the exact shape of `<i>Titanic</i> (1997 film)` — so even when the element is found, a mixed markup/plain-text title yields nothing.

### Fix

Fall back to `h1#firstHeading` when the span is absent, and read `get_text()` rather than `.string` so titles that mix markup with plain text survive. Plain titles keep taking the existing path and are unaffected.

### Verification

Checked against HTML fetched live from the three articles above.

Added `packages/markitdown/tests/test_wikipedia_titles.py` with three cases: a fully italicised title, a title mixing markup with plain text, and a plain title as a regression guard. Reverting only the converter change fails the first two and leaves the third passing, confirming the tests pin the bug and the plain-title path is unchanged.

Full suite: 648 passed (the one unrelated failure locally is `test_speech_transcription`, which needs `ffprobe` on PATH). `black` 23.7.0 clean.
