### PR TITLE
Workaround for ARM CI tests.

### DIFF
--- a/.github/constraints.txt
+++ b/.github/constraints.txt
@@ -1,0 +1,3 @@
+# Temporary CI workaround until Windows ARM64 wheels return.
+# https://github.com/pyca/cryptography/pull/15350
+cryptography==46.0.3; sys_platform == "win32" and platform_machine == "ARM64"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ permissions:
 env:
   # Preserve Unicode in captured CLI output on Windows.
   PYTHONUTF8: "1"
+  PIP_CONSTRAINT: ${{ github.workspace }}/.github/constraints.txt
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/constraints.txt
 
 jobs:
   tests:


### PR DESCRIPTION
Pin cryptography to 46.0.3 (in the CI, only) to temporarily enable ARM tests of the rest of the suite