### PR TITLE
fix(ipynb): keep the title when a cell's source is a single string

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_ipynb_converter.py
@@ -65,6 +65,11 @@ class IpynbConverter(DocumentConverter):
             for cell in notebook_content.get("cells", []):
                 cell_type = cell.get("cell_type", "")
                 source_lines = cell.get("source", [])
+                # nbformat allows `source` to be a single string as well as a
+                # list of lines. Iterating a string walks it character by
+                # character, so the title scan below never sees a whole line.
+                if isinstance(source_lines, str):
+                    source_lines = source_lines.splitlines(keepends=True)
 
                 if cell_type == "markdown":
                     md_output.append("".join(source_lines))

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1412,6 +1412,33 @@ def test_ipynb_heading_title_preserves_leading_hash() -> None:
     assert result.title == "#hashtag campaign results"
 
 
+def test_ipynb_string_source_keeps_title() -> None:
+    """A cell whose `source` is one string must yield the same title as a list.
+
+    nbformat permits either form. The body already survived the string form,
+    because joining a string rebuilds it, so the loss was confined to the title
+    and easy to miss.
+
+    Regression for https://github.com/microsoft/markitdown/issues/2115
+    """
+    from markitdown.converters._ipynb_converter import IpynbConverter
+
+    def notebook(source):
+        return {
+            "nbformat": 4,
+            "nbformat_minor": 5,
+            "metadata": {},
+            "cells": [{"cell_type": "markdown", "source": source, "metadata": {}}],
+        }
+
+    as_list = IpynbConverter()._convert(notebook(["# My Report\n", "\n", "Content"]))
+    as_string = IpynbConverter()._convert(notebook("# My Report\n\nContent"))
+
+    assert as_list.title == "My Report"
+    assert as_string.title == "My Report"
+    assert as_string.markdown == as_list.markdown
+
+
 def test_ipynb_accepts_non_ascii() -> None:
     """IpynbConverter.accepts() must not raise on non-ASCII binary content."""
     from markitdown.converters._ipynb_converter import IpynbConverter
@@ -1679,6 +1706,7 @@ if __name__ == "__main__":
         test_markitdown_llm,
         test_pptx_chart_no_title_text_frame,
         test_pptx_chart_with_title_text_frame,
+        test_ipynb_string_source_keeps_title,
         test_ipynb_accepts_non_ascii,
         test_epub_metadata_nodevalue,
         test_exiftool_metadata_with_nonexistent_binary,


### PR DESCRIPTION
Fixes #2115.

## The bug

The [nbformat spec](https://nbformat.readthedocs.io/en/latest/format_description.html) allows a cell's `source` to be either a list of lines or a single string. `IpynbConverter._convert` iterates the value directly when looking for the first `# ` heading:

```python
source_lines = cell.get("source", [])
...
for line in source_lines:
    if line.startswith("# "):
```

When `source` is a string, that loop walks it one character at a time, so `startswith("# ")` never matches and `result.title` comes back `None`.

What makes it easy to miss: the **body** is fine either way, because `"".join(source_lines)` over a string simply rebuilds the string. Same value, two consumers, and only the title scan cared about the difference. So the converter looked correct on every notebook that happened to use the list form, and lost the title silently on the ones that didn't.

## The change

Normalise a string `source` into lines with `splitlines(keepends=True)` before the scan. Five lines including the comment. The list form is untouched.

## Verification

From `packages/markitdown`, in a fresh venv with `.[all]`:

- New regression test `test_ipynb_string_source_keeps_title`, placed next to the existing `test_ipynb_heading_title_preserves_leading_hash` and registered in the same runner list. It converts one notebook both ways and asserts the two titles match **and** the two bodies match, so it also pins the fact that the body path was never the problem.
- Reverting only the converter change and keeping the test fails it with `AssertionError: assert None == 'My Report'`.
- Full suite: 392 passed, 4 skipped, 3 failed. All three failures reproduce on unmodified `main` on this machine and are unrelated to notebooks: `test_file_uris` and `test_convert_case_insensitive_uri_schemes` are Windows drive-letter path handling, `test_speech_transcription` needs a network service.
- `black --check` clean on both files.

## Relationship to #2113

That PR, open since June, contains the same one-line idea for this bug but bundles it with an unrelated PDF numbering fix, and it has had no maintainer review in three months. Credit to @Sahilalgo8 for spotting it first. This is the notebook half on its own with a regression test, so it can be reviewed as one thing; if #2113 is preferred instead, happy to close this.

---

AI help was taken for this change.
