### PR TITLE
Improve efficiency of escaping pipes in CSVs

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_csv_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_csv_converter.py
@@ -15,7 +15,8 @@ ACCEPTED_FILE_EXTENSIONS = [".csv"]
 
 # Matches a pipe together with the (possibly empty) run of backslashes in front
 # of it, so that run can be doubled before the pipe is escaped.
-_PIPE_ESCAPE_RE = re.compile(r"(\\*)\|")
+# The lookbehind avoids retrying from each position inside a backslash run.
+_PIPE_ESCAPE_RE = re.compile(r"(?<!\\)(\\*)\|")
 
 
 def _escape_table_cell(value: str) -> str:

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -1800,6 +1800,20 @@ def test_csv_backslash_without_a_pipe_is_left_alone() -> None:
     assert r"| Widget | C:\temp\file.txt |" in result
 
 
+@pytest.mark.parametrize(
+    "suffix,escaped_suffix",
+    [("", ""), ("|", r"\|"), ("x|", r"x\|")],
+)
+def test_csv_long_backslash_runs(suffix: str, escaped_suffix: str) -> None:
+    backslashes = "\\" * 65_536
+    value = backslashes + suffix
+    expected = backslashes * (2 if suffix == "|" else 1) + escaped_suffix
+
+    result = _convert_csv(f"{value}\n{value}\n".encode("utf-8"), charset="utf-8")
+
+    assert result == f"| {expected} |\n| --- |\n| {expected} |"
+
+
 # ---------------------------------------------------------------------------
 # Regression test for issue #1960:
 # exiftool_path pointing to a nonexistent binary used to leak a raw


### PR DESCRIPTION
## Problem

CSV pipe escaping introduced quadratic processing time for long runs of backslashes not immediately followed by a pipe.

The regex  `r"(\\*)\|"`  consumes the backslash run, backtracks looking for a pipe, then repeats from each subsequent position. A valid CSV containing a single 64 KiB backslash-only field took approximately 9 seconds to convert. The same slowdown occurs when a pipe appears later, separated from the backslashes by another character.

## Fix

Add a negative lookbehind so matching cannot restart inside a backslash run:

```
_PIPE_ESCAPE_RE = re.compile(r"(?<!\\)(\\*)\|")
```

This makes processing linear rather than quadratic, reducing the reproduced 64 KiB case to milliseconds.

Output remains unchanged: pipes are escaped, backslashes immediately preceding pipes are doubled, unrelated backslashes are preserved, and newline handling is untouched. Regression coverage includes long backslash runs in both header and data cells, with no following pipe, an adjacent pipe, and a pipe separated by ordinary text.