### PR TITLE
fix(rss): convert Atom feeds without entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ MarkItDown currently supports the conversion from:
 - ZIP files (iterates over contents)
 - YouTube URLs
 - EPubs
+- RSS and Atom feeds (including Atom feeds without entries)
 - ... and more!
 
 ## Why Markdown?

--- a/packages/markitdown/src/markitdown/converters/_rss_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_rss_converter.py
@@ -133,8 +133,9 @@ class RssConverter(DocumentConverter):
         if root.tagName == "rss":
             return "rss"
         if root.localName == "feed" and root.namespaceURI in (None, ATOM_NAMESPACE):
-            if self._get_children(root, "entry"):
-                # An Atom feed must have a root element of <feed> and at least one <entry>
+            # RFC 4287 permits zero entries. Keep the entry heuristic only for
+            # legacy feeds that do not declare the Atom namespace.
+            if root.namespaceURI == ATOM_NAMESPACE or self._get_children(root, "entry"):
                 return "atom"
         return None
 

--- a/packages/markitdown/tests/test_rss_converter.py
+++ b/packages/markitdown/tests/test_rss_converter.py
@@ -7,6 +7,54 @@ from markitdown import MarkItDown, StreamInfo
 from markitdown.converters import RssConverter
 
 
+@pytest.mark.parametrize("prefix", ["", "a:"])
+@pytest.mark.parametrize(
+    "stream_info",
+    [
+        StreamInfo(extension=".xml"),
+        StreamInfo(extension=".atom"),
+        StreamInfo(mimetype="application/xml"),
+        StreamInfo(mimetype="application/atom+xml"),
+    ],
+)
+def test_atom_without_entries(prefix: str, stream_info: StreamInfo) -> None:
+    namespace = "xmlns:a" if prefix else "xmlns"
+    feed = f"""<{prefix}feed {namespace}="http://www.w3.org/2005/Atom">
+  <{prefix}title>Release updates</{prefix}title>
+  <{prefix}subtitle>No releases yet.</{prefix}subtitle>
+  <{prefix}id>urn:example:releases</{prefix}id>
+  <{prefix}updated>2026-09-13T00:00:00Z</{prefix}updated>
+  <{prefix}author><{prefix}name>Example project</{prefix}name></{prefix}author>
+</{prefix}feed>""".encode(
+        "utf-8"
+    )
+    converter = RssConverter()
+    stream = io.BytesIO(feed)
+
+    assert converter.accepts(stream, stream_info)
+    assert stream.tell() == 0
+    result = converter.convert(stream, stream_info)
+    assert result.title == "Release updates"
+    assert result.markdown == "# Release updates\nNo releases yet.\n"
+
+    converted = MarkItDown().convert_stream(io.BytesIO(feed), stream_info=stream_info)
+    assert converted.title == result.title
+    assert converted.markdown == result.markdown
+
+
+@pytest.mark.parametrize("namespace", ["", "urn:example:other"])
+def test_non_atom_feed_without_entries_is_not_accepted(namespace: str) -> None:
+    feed = f'<feed xmlns="{namespace}"><title>Other feed</title></feed>'.encode()
+    converter = RssConverter()
+    stream_info = StreamInfo(extension=".xml")
+    stream = io.BytesIO(feed)
+
+    assert not converter.accepts(stream, stream_info)
+    assert stream.tell() == 0
+    with pytest.raises(ValueError, match="Unknown feed type"):
+        converter.convert(stream, stream_info)
+
+
 @pytest.mark.parametrize(
     "root_prefix, child_prefix",
     [("", ""), ("a:", "a:"), ("a:", "b:"), ("a:", ""), ("", "a:")],


### PR DESCRIPTION
A namespace-qualified Atom feed with no entries currently fails `RssConverter.convert()` with `ValueError: Unknown feed type`. Through `MarkItDown.convert_stream()`, it falls back to raw XML instead of rendering the feed title and subtitle. [RFC 4287 section 4.1.1](https://www.rfc-editor.org/rfc/rfc4287.html#section-4.1.1) permits zero entry elements.

The detection code incorrectly requires an entry even when the root declares the Atom namespace. Accept that namespace-qualified root without entries, while preserving the existing entry heuristic for unqualified feeds. For example, an empty release feed now produces `# Release updates` and its subtitle, `No releases yet.`

Regression tests cover default and explicit namespace prefixes, extension and MIME detection, stream-position preservation, direct conversion, and the public API. Negative cases retain rejection of entryless unqualified or unrelated-namespace XML. The README notes support for Atom feeds without entries. No related issue was found in the issue and PR searches.

Validation on macOS / Python 3.12.13:

- Before the fix: all eight empty-Atom regression cases failed; both unrelated-XML controls passed.
- RSS/Atom tests: 173 passed (`pytest tests/test_rss_converter.py tests/test_rss_titles.py -q`).
- Full package suite: 873 passed, 43 skipped (`hatch test --python 3.12`, with `GITHUB_ACTIONS=true` and `OPENAI_API_KEY` unset to use the existing remote/LLM skip conditions).
- `pre-commit run --all-files`: passed.
- `hatch build -t wheel`: passed.
- `git diff --check`: passed.

The patch and tests were prepared with assistance from OpenAI Codex.
